### PR TITLE
Fix language id

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,38 +23,31 @@
 		"url": "https://github.com/PowerShell/vscode-powershell.git"
 	},	
 	"main": "./out/main",
-	"activationEvents": ["onLanguage:PowerShell"],
+	"activationEvents": ["onLanguage:powershell"],
 	"dependencies": {
 		"vscode-languageclient": "0.10.7"
 	},
 	"devDependencies": {
 		"vscode": "0.10.0"
 	},
+	"extensionDependencies": [
+        "vscode.powershell"
+    ],
     "scripts": {
 		"vscode:prepublish": "node ./node_modules/vscode/bin/compile",
 		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
     },
 	"contributes": {
-		"languages": [{
-			"id": "PowerShell",
-			"extensions": [ ".ps1", ".psm1", ".psd1", ".pssc", ".psrc" ],
-			"aliases": [ "PowerShell", "powershell", "ps", "ps1" ]
-		}],
-		"grammars": [{
-			"language": "PowerShell",
-			"scopeName": "source.powershell",
-			"path": "./syntaxes/PowerShell.tmLanguage"
-		}],
 		"snippets": [
 			{
-				"language": "PowerShell",
+				"language": "powershell",
 				"path": "./snippets/PowerShell.json"
 			}
 		],
 		"debuggers": [
 			{
 				"type": "PowerShell",
-				"enableBreakpointsFor": { "languageIds": ["PowerShell"] },
+				"enableBreakpointsFor": { "languageIds": ["powershell"] },
 				"program": "bin/Microsoft.PowerShell.EditorServices.Host.DebugAdapter.cmd"
 			}
 		],		


### PR DESCRIPTION
The VS code built-in powershell extension has a language contribution that looks like that
```json
		"languages": [{
			"id": "powershell",
			"extensions": [ ".ps1", ".psm1", ".psd1" ],
			"aliases": [ "PowerShell", "powershell", "ps", "ps1" ],
			"configuration": "./powershell.configuration.json"
		}],
```

The powershell extension however uses "id": "PowerShell"
This results in two 'Powershell' entries in the language selector drop down.

As long as we have the built-in powershell support, the powershell extension should use the same id, and ideally not contribute the language and grammar contribution but instead add a dependency on the built-in extension:
```json
 "extensionDependencies": [
        "vscode.powershell"
    ],
```
This will make sure the built-in extension is loaded.

Please file an issue for any changes you'd like us to do the built-in contributes section (such as adding more file extension) or the grammar. Of course a pull request would even be easier.