### PR TITLE
Fix local examples path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ how to use them.
 This folder can be found at the following path:
 
 ```
-c:\Users\<yourusername>\.vscode\extensions\daviwil.PowerShell\examples
+c:\Users\<yourusername>\.vscode\extensions\ms-vscode.PowerShell\examples
 ```
 
 ## Contributing to the Code


### PR DESCRIPTION
Fixes the path to the local examples in the readme to the current path of the extension