### PR TITLE
package.json: use ${workspaceRoot}

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 						"name": "PowerShell",
 						"type": "PowerShell",
 						"request": "launch",
-						"program": "SET_SCRIPT_FILE_PATH_HERE.ps1"
+						"program": "${workspaceRoot}/SET_SCRIPT_FILE_PATH_HERE.ps1"
 					}
 				]
 			}


### PR DESCRIPTION
At the moment we magically append the workspace root to some properties of the launch.json on the vscode side.
This will go away in the future since it is clunky. Thus we want to educate users to use the ${workspaceRoot} variable for all paths, since we will no longer support relative paths in the future.