### PR TITLE
Open in PowerShell ISE

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
             ,
 			{
 				"command": "PowerShell.OpenInISE",
-				"key": "ctrl+shift+i",
+				"key": "ctrl+alt+i",
 				"when": "editorTextFocus && editorLangId == 'powershell'"
 			}
 		],

--- a/package.json
+++ b/package.json
@@ -55,6 +55,12 @@
 				"key": "f8",
 				"when": "editorTextFocus && editorLangId == 'powershell'"
 			}
+            ,
+			{
+				"command": "PowerShell.OpenInISE",
+				"key": "ctrl+shift+i",
+				"when": "editorTextFocus && editorLangId == 'powershell'"
+			}
 		],
 		"commands": [			
 			{
@@ -70,6 +76,11 @@
 			{
 				"command": "PowerShell.RunSelection",
 				"title": "Run selection",
+				"category": "PowerShell"	
+			},
+			{
+				"command": "PowerShell.OpenInISE",
+				"title": "Open current file in PowerShell ISE",
 				"category": "PowerShell"	
 			}
 		],

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -1,30 +1,37 @@
 import vscode = require('vscode'); 
 import Window = vscode.window;
-
-
-/** 
-function convertUriToPath(Uri) {
-  
-  window.showInformationMessage(Uri)
-  var result = Uri.replace("file://","")
-  var result = result.replace("/","\")
-  var driveletter = result.substring(0)
-  var result =   driveletter + ":" + result.substring(1,-1)
-  
-}
-*/
+import os = require('os'); 
 
 export function registerOpenInISECommand(): void {
     var disposable = vscode.commands.registerCommand('PowerShell.OpenInISE', () => {
 
 		var editor    = Window.activeTextEditor;
 		var document  = editor.document;		
+
+var uri = document.uri
+
+// For testing, to be removed
+Window.showInformationMessage(uri.fsPath);
+Window.showInformationMessage(uri.path);
+
+if (os.arch()== 'x64') {
+    
+    var ISEPath = 'C:\\Windows\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
+
+} else
+{
+
+    // Need to figure out how to check OS architecture os.arch returns process architecture
+    //var ISEPath = process.env.windir + '\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
+    var ISEPath = 'C:\\Windows\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
+
+}
+
+// For testing, to be removed
+Window.showInformationMessage(os.arch());
+Window.showInformationMessage(ISEPath);
         
-        //process = require('child_process');
-        //var filePath = convertUriToPath(editor.document.uri);
-        var filePath = 'C:\temp\Get-ProductKey.ps1'
-        //require("child_process").exec('powershell_ise.exe -NoProfile -File "C:\\temp\\Get-ProductKey.ps1"').unref();
-        require("child_process").exec(process.env.windir + '\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe -NoProfile -File "C:\\temp\\Get-ProductKey.ps1"').unref();
+        require("child_process").exec(ISEPath + ' -NoProfile -File ' + uri.fsPath).unref();
         
 
 			});

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -1,14 +1,18 @@
 import vscode = require('vscode'); 
 import Window = vscode.window;
 
+
+/** 
 function convertUriToPath(Uri) {
   
+  window.showInformationMessage(Uri)
   var result = Uri.replace("file://","")
   var result = result.replace("/","\")
   var driveletter = result.substring(0)
   var result =   driveletter + ":" + result.substring(1,-1)
   
 }
+*/
 
 export function registerOpenInISECommand(): void {
     var disposable = vscode.commands.registerCommand('PowerShell.OpenInISE', () => {
@@ -16,9 +20,10 @@ export function registerOpenInISECommand(): void {
 		var editor    = Window.activeTextEditor;
 		var document  = editor.document;		
         
-        process = require('child_process');
-        var filePath = convertUriToPath(editor.document.uri);
-        process.exec("powershell_ise.exe -NoProfile -File " + filePath);
+        //process = require('child_process');
+        //var filePath = convertUriToPath(editor.document.uri);
+        var filePath = 'C:\temp\Get-ProductKey.ps1'
+        require("child_process").exec("powershell_ise.exe -NoProfile -File " + filePath).unref();
 
 			});
 }

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -23,7 +23,9 @@ export function registerOpenInISECommand(): void {
         //process = require('child_process');
         //var filePath = convertUriToPath(editor.document.uri);
         var filePath = 'C:\temp\Get-ProductKey.ps1'
-        require("child_process").exec("powershell_ise.exe -NoProfile -File C:\temp\Get-ProductKey.ps1").unref();
+        //require("child_process").exec('powershell_ise.exe -NoProfile -File "C:\\temp\\Get-ProductKey.ps1"').unref();
+        require("child_process").exec(process.env.windir + '\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe -NoProfile -File "C:\\temp\\Get-ProductKey.ps1"').unref();
+        
 
 			});
 }

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -23,7 +23,7 @@ export function registerOpenInISECommand(): void {
         //process = require('child_process');
         //var filePath = convertUriToPath(editor.document.uri);
         var filePath = 'C:\temp\Get-ProductKey.ps1'
-        require("child_process").exec("powershell_ise.exe -NoProfile -File " + filePath).unref();
+        require("child_process").exec("powershell_ise.exe -NoProfile -File C:\temp\Get-ProductKey.ps1").unref();
 
 			});
 }

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -11,7 +11,7 @@ var uri = document.uri
 
 if (process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432')) {
     
-    var ISEPath = 'C:\\Windows\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
+    var ISEPath = process.env.windir + '\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
 
 } else
 {
@@ -20,7 +20,7 @@ if (process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432')) {
 
 }
        
-        require("child_process").exec(ISEPath + ' -NoProfile -File ' + uri.fsPath).unref();
+        require("child_process").exec(ISEPath + ' -File ' + uri.fsPath).unref();
         
 
 			});

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -1,0 +1,14 @@
+import vscode = require('vscode');
+import { LanguageClient } from 'vscode-languageclient';
+import { RequestType, NotificationType, ResponseError } from 'vscode-jsonrpc';
+import Window = vscode.window;
+
+
+export function registerOpenInISECommand(client: LanguageClient): void {
+    var disposable = vscode.commands.registerCommand('PowerShell.OpenInISE', () => {
+
+		var editor    = Window.activeTextEditor;
+		var document  = editor.document;		
+
+			});
+}

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -1,6 +1,5 @@
 import vscode = require('vscode'); 
 import Window = vscode.window;
-import os = require('os'); 
 
 export function registerOpenInISECommand(): void {
     var disposable = vscode.commands.registerCommand('PowerShell.OpenInISE', () => {
@@ -10,27 +9,17 @@ export function registerOpenInISECommand(): void {
 
 var uri = document.uri
 
-// For testing, to be removed
-Window.showInformationMessage(uri.fsPath);
-Window.showInformationMessage(uri.path);
-
-if (os.arch()== 'x64') {
+if (process.env.hasOwnProperty('PROCESSOR_ARCHITEW6432')) {
     
     var ISEPath = 'C:\\Windows\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
 
 } else
 {
 
-    // Need to figure out how to check OS architecture os.arch returns process architecture
-    //var ISEPath = process.env.windir + '\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
-    var ISEPath = 'C:\\Windows\\Sysnative\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
+    var ISEPath = process.env.windir + '\\System32\\WindowsPowerShell\\v1.0\\powershell_ise.exe';
 
 }
-
-// For testing, to be removed
-Window.showInformationMessage(os.arch());
-Window.showInformationMessage(ISEPath);
-        
+       
         require("child_process").exec(ISEPath + ' -NoProfile -File ' + uri.fsPath).unref();
         
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	registerExpandAliasCommand(languageServerClient);
 	registerShowHelpCommand(languageServerClient);
 	registerConsoleCommands(languageServerClient);
+	registerOpenInISECommand();    
 }
 
 export function deactivate(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { LanguageClient, LanguageClientOptions, Executable } from 'vscode-langua
 import { RequestType, NotificationType, ResponseError } from 'vscode-jsonrpc';
 import { registerExpandAliasCommand } from './features/ExpandAlias';
 import { registerShowHelpCommand } from './features/ShowOnlineHelp';
+import { registerOpenInISECommand } from './features/OpenInISE';
 import { registerConsoleCommands } from './features/Console';
 
 var languageServerClient : LanguageClient = undefined;
@@ -100,6 +101,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	// Register other features
 	registerExpandAliasCommand(languageServerClient);
 	registerShowHelpCommand(languageServerClient);
+    registerOpenInISECommand(languageServerClient);
 	registerConsoleCommands(languageServerClient);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -101,7 +101,6 @@ export function activate(context: vscode.ExtensionContext): void {
 	// Register other features
 	registerExpandAliasCommand(languageServerClient);
 	registerShowHelpCommand(languageServerClient);
-    registerOpenInISECommand(languageServerClient);
 	registerConsoleCommands(languageServerClient);
 }
 


### PR DESCRIPTION
Added a new extension for vscode-powershell called OpenInISE - a feature to open PowerShell-files in PowerShell ISE by using the keybinding Ctrl+Shift+I.