### PR TITLE
Addresses issue #55 for 0.4.0 release to select debug host bitness.

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,36 @@
                         "program": "${file}"
                     }
                 ]
+            },
+            {
+                "type": "PowerShell x86",
+                "enableBreakpointsFor": {
+                    "languageIds": [
+                        "powershell"
+                    ]
+                },
+                "program": "bin/Microsoft.PowerShell.EditorServices.Host.DebugAdapter.x86.cmd",
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [
+                            "program"
+                        ],
+                        "properties": {
+                            "program": {
+                                "type": "string",
+                                "description": "Workspace relative path to the PowerShell script."
+                            }
+                        }
+                    }
+                },
+                "initialConfigurations": [
+                    {
+                        "name": "PowerShell x86",
+                        "type": "PowerShell x86",
+                        "request": "launch",
+                        "program": "${file}"
+                    }
+                ]
             }
         ],
         "configuration": {


### PR DESCRIPTION
This change adds a new debugger configuration to the package.json file.  The user can simply change the debug type from 'PowerShell' to 'PowerShell x86' in their launch.json file to do 32-bit debugging.  Also, when they open a folder that doesn't have a .vscode\launch.json file, when they go to create that file, they can pick between 'PowerShell' and 'PowerShell x86'.  Of course on 32-bit OSs the 'PowerShell x86' selection is redundant with 'PowerShell'.  Oh well.