### PR TITLE
Tweaks to PSake build script

### DIFF
--- a/examples/Build.ps1
+++ b/examples/Build.ps1
@@ -193,8 +193,6 @@ Task StoreKey -requiredVariables EncryptedApiKeyPath {
 }
 
 Task ShowKey -requiredVariables EncryptedApiKeyPath {
-    $OFS = ''
-
     if ($NuGetApiKey) {
         "The embedded (partial) NuGetApiKey is: $($NuGetApiKey[0..7])"
     }
@@ -225,6 +223,7 @@ Task ? -description 'Lists the available tasks' {
 # Helper functions
 ###############################################################################
 function PromptUserForNuGetApiKeyCredential {
+    [Diagnostics.CodeAnalysis.SuppressMessage("PSProvideDefaultParameterValue", '')]
     param(
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -243,6 +242,8 @@ function PromptUserForNuGetApiKeyCredential {
 }
 
 function EncryptAndSaveNuGetApiKey {
+    [Diagnostics.CodeAnalysis.SuppressMessage("PSAvoidUsingConvertToSecureStringWithPlainText", '')]
+    [Diagnostics.CodeAnalysis.SuppressMessage("PSProvideDefaultParameterValue", '')]
     param(
         [Parameter(Mandatory, ParameterSetName='SecureString')]
         [ValidateNotNull()]
@@ -275,6 +276,7 @@ function EncryptAndSaveNuGetApiKey {
 }
 
 function LoadAndUnencryptNuGetApiKey {
+    [Diagnostics.CodeAnalysis.SuppressMessage("PSProvideDefaultParameterValue", '')]
     param(
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]


### PR DESCRIPTION
Added some script analyzer rule suppressions and decomposed the single Get-NuGetApiKey function into several smaller functions.  

Was going to try to use rebase on this but I've got to get out of the habit of publishing my branch to my fork after the first commit.  Been reading that you do not want to rebase a published branch.