### PR TITLE
Add support for loading host profile scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,10 @@
                 },
                 "args": [
                     "/debugAdapter",
-                    "/logLevel:Verbose"
+                    "/logLevel:Verbose",
+                    "/hostName:\"Visual Studio Code Host\"",
+                    "/hostProfileId:Microsoft.VSCode",
+                    "/hostVersion:0.5.0"
                 ],
                 "configurationAttributes": {
                     "launch": {
@@ -179,7 +182,11 @@
                     "program": "bin/Microsoft.PowerShell.EditorServices.Host.x86.exe"
                 },
                 "args": [
-                    "/debugAdapter"
+                    "/debugAdapter",
+                    "/logLevel:Verbose",
+                    "/hostName:\"Visual Studio Code Host\"",
+                    "/hostProfileId:Microsoft.VSCode",
+                    "/hostVersion:0.5.0"
                 ],
                 "configurationAttributes": {
                     "launch": {
@@ -227,6 +234,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "If true, causes the 32-bit language service to be used on 64-bit Windows.  On 32-bit Windows this setting has no effect.  This setting does not affect the debugger which has its own architecture configuration."
+                },
+                "powershell.enableProfileLoading": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, causes user and system wide profiles (profile.ps1 and Microsoft.VSCode_profile.ps1) to be loaded into the PowerShell session.  This affects IntelliSense and interactive script execution.  The debugger is not affected by this setting."
                 },
                 "powershell.scriptAnalysis.enable": {
                     "type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,20 @@ export function activate(context: vscode.ExtensionContext): void {
     // The language server is only available on Windows
     if (os.platform() == "win32")
     {
-        let args = [];
+        // Get the current version of this extension
+        var hostVersion =
+            vscode
+                .extensions
+                .getExtension("ms-vscode.PowerShell")
+                .packageJSON
+                .version;
+
+        let args = [
+            "/hostName:\"Visual Studio Code Host\"",
+            "/hostProfileId:\"Microsoft.VSCode\"",
+            "/hostVersion:" + hostVersion
+        ];
+
         if (settings.developer.editorServicesWaitForDebugger) {
             args.push('/waitForDebugger');
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ export interface IDeveloperSettings {
 
 export interface ISettings {
     useX86Host?: boolean,
+    enableProfileLoading?: boolean,
     scriptAnalysis?: IScriptAnalysisSettings,
     developer?: IDeveloperSettings,
 }
@@ -37,6 +38,7 @@ export function load(myPluginId: string): ISettings {
 
     return {
         useX86Host: configuration.get<boolean>("useX86Host", false),
+        enableProfileLoading: configuration.get<boolean>("enableProfileLoading", false),
         scriptAnalysis: configuration.get<IScriptAnalysisSettings>("scriptAnalysis", defaultScriptAnalysisSettings),
         developer: configuration.get<IDeveloperSettings>("developer", defaultDeveloperSettings)
     }


### PR DESCRIPTION
This change adds support for loading both host-specific and host-agnostic
profile scripts for both the current user and all users on the same
system.  For VS Code, the profile names are Microsoft.VSCode_profile.ps1
and profile.ps1.  The new 'enableProfileLoading' setting controls whether
profiles are loaded automatically when the language server starts up.  For
now this setting is turned off by default.

Resolves #124.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/130)
<!-- Reviewable:end -->
