### PR TITLE
Change expand alias shorcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
             },
             {
                 "command": "PowerShell.ExpandAlias",
-                "key": "ctrl+f5",
+                "key": "ctrl+alt+e",
                 "when": "editorTextFocus && editorLangId == 'powershell'"
             },
             {


### PR DESCRIPTION
The current shortcut Ctrl+F5 has been subsumed by VSCode for use as "start without debugging".  The new shortcut is Ctrl+Alt+E.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/138)
<!-- Reviewable:end -->
