### PR TITLE
Consume Editor Services host as PowerShell module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ examples/Release/
 examples/Tests/foo*.txt
 out/
 node_modules/
+logs/
+modules/*
+!modules/README.md
 vscode-powershell.zip
 vscps-preview.zip
 *.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,5 @@ build/**
 bin/EditorServices.log
 bin/DebugAdapter.log
 bin/*.vshost.*
+logs/
+

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,0 +1,8 @@
+## `modules` folder README
+
+This folder contains modules that are bundled with the vscode-powershell extension.
+All subfolders are not included in our GitHub repository, they are added here just
+before the module is published to the Visual Studio Marketplace.
+
+This file serves as a placeholder so that the `modules` folder will be included
+in our Git repository.

--- a/package.json
+++ b/package.json
@@ -118,19 +118,8 @@
                         "powershell"
                     ]
                 },
-                "windows": {
-                    "program": "bin/Microsoft.PowerShell.EditorServices.Host.exe"
-                },
-                "winx86": {
-                    "program": "bin/Microsoft.PowerShell.EditorServices.Host.x86.exe"
-                },
-                "args": [
-                    "/debugAdapter",
-                    "/logLevel:Verbose",
-                    "/hostName:\"Visual Studio Code Host\"",
-                    "/hostProfileId:Microsoft.VSCode",
-                    "/hostVersion:0.6.1"
-                ],
+                "program": "./out/debugAdapter.js",
+                "runtime": "node",
                 "configurationAttributes": {
                     "launch": {
                         "required": [
@@ -165,68 +154,6 @@
                         "program": "${file}",
                         "args": [],
                         "cwd": "${file}"
-                    },
-                    {
-                        "name": "PowerShell x86",
-                        "type": "PowerShell x86",
-                        "request": "launch",
-                        "program": "${file}",
-                        "args": [],
-                        "cwd": "${file}"
-                    }
-                ]
-            },
-            {
-                "type": "PowerShell x86",
-                "enableBreakpointsFor": {
-                    "languageIds": [
-                        "powershell"
-                    ]
-                },
-                "windows": {
-                    "program": "bin/Microsoft.PowerShell.EditorServices.Host.x86.exe"
-                },
-                "args": [
-                    "/debugAdapter",
-                    "/logLevel:Verbose",
-                    "/hostName:\"Visual Studio Code Host\"",
-                    "/hostProfileId:Microsoft.VSCode",
-                    "/hostVersion:0.6.1"
-                ],
-                "configurationAttributes": {
-                    "launch": {
-                        "required": [
-                            "program"
-                        ],
-                        "properties": {
-                            "program": {
-                                "type": "string",
-                                "description": "Absolute path to the PowerShell script to launch under the debugger."
-                            },
-                            "args": {
-                                "type": "array",
-                                "description": "Command line arguments to pass to the PowerShell script.",
-                                "items": {
-                                    "type": "string"
-                                },
-                                "default": []
-                            },
-                            "cwd": {
-                                "type": "string",
-                                "description": "Absolute path to the working directory. Default is the current workspace.",
-                                "default": "."
-                            }
-                        }
-                    }
-                },
-                "initialConfigurations": [
-                    {
-                        "name": "PowerShell x86",
-                        "type": "PowerShell x86",
-                        "request": "launch",
-                        "program": "${file}",
-                        "args": [],
-                        "cwd": "${file}"
                     }
                 ]
             }
@@ -255,10 +182,10 @@
                     "default": "",
                     "description": "Specifies the path to a PowerShell Script Analyzer settings file. Use either an absolute path (to override the default settings for all projects) or use a path relative to your workspace."
                 },
-                "powershell.developer.editorServicesHostPath": {
+                "powershell.developer.bundledModulesPath": {
                     "type": "string",
-                    "default": "../bin/",
-                    "description": "Specifies the path to the folder containing the PowerShell Editor Services host executables."
+                    "default": "../modules/",
+                    "description": "Specifies the path to the folder containing modules that are bundled with the PowerShell extension (i.e. PowerShell Editor Services, PowerShell Script Analyzer, Plaster)"
                 },
                 "powershell.developer.editorServicesLogLevel": {
                     "type": "string",

--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -1,0 +1,67 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $EditorServicesVersion,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $HostName,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $HostProfileId,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $HostVersion,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $LanguageServicePipeName,
+
+    [Parameter(Mandatory=$true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $DebugServicePipeName,
+
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $BundledModulesPath,
+
+    [ValidateNotNullOrEmpty()]
+    $LogPath,
+
+    [ValidateSet("Normal", "Verbose", "Error")]
+    $LogLevel,
+
+    [switch]
+    $WaitForCompletion,
+
+    [switch]
+    $WaitForDebugger
+)
+
+# Add BundledModulesPath to $env:PSModulePath
+if ($BundledModulesPath) {
+    $env:PSModulePath = $BundledModulesPath + ";" + $env:PSModulePath
+}
+
+$parsedVersion = [System.Version]::new($EditorServicesVersion)
+Import-Module PowerShellEditorServices -RequiredVersion $parsedVersion -ErrorAction Stop
+
+Start-EditorServicesHost `
+    -HostName $HostName `
+    -HostProfileId $HostProfileId `
+    -HostVersion $HostVersion `
+    -LogPath $LogPath `
+    -LogLevel $LogLevel `
+    -LanguageServicePipeName $LanguageServicePipeName `
+    -DebugServicePipeName $DebugServicePipeName `
+    -BundledModulesPath $BundledModulesPath `
+    -WaitForCompletion:$WaitForCompletion.IsPresent `
+    -WaitForDebugger:$WaitForDebugger.IsPresent

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,0 +1,53 @@
+import fs = require('fs');
+import path = require('path');
+import net = require('net');
+import logging = require('./logging');
+
+// NOTE: The purpose of this file is to serve as a bridge between
+// VS Code's debug adapter client (which communicates via stdio) and
+// PowerShell Editor Services' debug service (which communicates via
+// named pipes or a network protocol).  It is purely a naive data
+// relay between the two transports.
+
+var logBasePath = path.resolve(__dirname, "../logs");
+logging.ensurePathExists(logBasePath);
+
+var debugAdapterLogWriter =
+    fs.createWriteStream(
+        path.resolve(
+            logBasePath,
+            logging.getLogName("DebugAdapterClient")));
+
+// Pause the stdin buffer until we're connected to the
+// debug server
+process.stdin.pause();
+
+// Establish connection before setting up the session
+let pipeName = "\\\\.\\pipe\\PSES-VSCode-DebugService-" + process.env.VSCODE_PID;
+debugAdapterLogWriter.write("Connecting to named pipe: " + pipeName + "\r\n");
+let debugServiceSocket = net.connect(pipeName);
+
+// Write any errors to the log file
+debugServiceSocket.on(
+    'error',
+    (e) => debugAdapterLogWriter.write("Named pipe ERROR: " + e + "\r\n"));
+
+// Route any output from the socket through stdout
+debugServiceSocket.on(
+    'data',
+    (data: Buffer) => process.stdout.write(data));
+
+// Wait for the connection to complete
+debugServiceSocket.on(
+    'connect',
+    () => {
+        debugAdapterLogWriter.write("Connected to named pipe: " + pipeName + "\r\n");
+
+        // When data comes on stdin, route it through the socket
+        process.stdin.on(
+            'data',
+            (data: Buffer) => debugServiceSocket.write(data));
+
+        // Resume the stdin stream
+        process.stdin.resume();
+    });

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,19 @@
+import fs = require('fs');
+
+export function ensurePathExists(targetPath: string) {
+    // Ensure that the path exists
+    try {
+        fs.mkdirSync(targetPath);
+    }
+    catch (e) {
+        // If the exception isn't to indicate that the folder
+        // exists already, rethrow it.
+        if (e.code != 'EEXIST') {
+            throw e;
+        }
+    }
+}
+
+export function getLogName(baseName: string): string {
+    return Math.floor(Date.now() / 1000) + '-' +  baseName + '.log';
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,7 +12,8 @@ export interface IScriptAnalysisSettings {
 }
 
 export interface IDeveloperSettings {
-    editorServicesHostPath?: string;
+    powerShellExePath?: string;
+    bundledModulesPath?: string;
     editorServicesLogLevel?: string;
     editorServicesWaitForDebugger?: boolean;
 }
@@ -33,7 +34,8 @@ export function load(myPluginId: string): ISettings {
     };
 
     let defaultDeveloperSettings = {
-        editorServicesHostPath: "../bin/",
+        powerShellExePath: undefined,
+        bundledModulesPath: "../modules/",
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false
     }


### PR DESCRIPTION
This change refactors the existing PowerShell Editor Services host
management and editor client code to use the PSES host as a PowerShell
module rather than its previous executable form.  This involves launching
the powershell.exe process and loading up the PSES host as a module in
that process.  It also involves communicating with the PSES host via named
pipes instead of standard in/out as we did previously.

This change can be understood further by looking at the following pull
request at the PowerShellEditorServices repo:

https://github.com/PowerShell/PowerShellEditorServices/pull/256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/210)
<!-- Reviewable:end -->
