### PR TITLE
Move away from deprecated language configuration settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -57,19 +57,34 @@ export function activate(context: vscode.ExtensionContext): void {
                 ['(', ')'],
             ],
 
-            __electricCharacterSupport: {
-                docComment: { scope: 'comment.documentation', open: '/**', lineStart: ' * ', close: ' */' }
-            },
-
-            __characterPairSupport: {
-                autoClosingPairs: [
-                    { open: '{', close: '}' },
-                    { open: '[', close: ']' },
-                    { open: '(', close: ')' },
-                    { open: '"', close: '"', notIn: ['string'] },
-                    { open: '\'', close: '\'', notIn: ['string', 'comment'] }
-                ]
-            }
+			onEnterRules: [
+				{
+					// e.g. /** | */
+					beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+					afterText: /^\s*\*\/$/,
+					action: { indentAction: IndentAction.IndentOutdent, appendText: ' * ' }
+				},
+				{
+					// e.g. /** ...|
+					beforeText: /^\s*\/\*\*(?!\/)([^\*]|\*(?!\/))*$/,
+					action: { indentAction: IndentAction.None, appendText: ' * ' }
+				},
+				{
+					// e.g.  * ...|
+					beforeText: /^(\t|(\ \ ))*\ \*(\ ([^\*]|\*(?!\/))*)?$/,
+					action: { indentAction: IndentAction.None, appendText: '* ' }
+				},
+				{
+					// e.g.  */|
+					beforeText: /^(\t|(\ \ ))*\ \*\/\s*$/,
+					action: { indentAction: IndentAction.None, removeText: 1 }
+				},
+				{
+					// e.g.  *-----*/|
+					beforeText: /^(\t|(\ \ ))*\ \*[^/]*\*\/\s*$/,
+					action: { indentAction: IndentAction.None, removeText: 1 }
+				}
+			]
         });
 
     // The language server is only available on Windows


### PR DESCRIPTION
In the July release of VSCode we added new properties to the language configuration files so that the deprecated __characterPairSupport and __electricCharacterSupport APIs in vscode.d.ts are no longer necessary.
See https://github.com/Microsoft/vscode/issues/9281.

I've added the new bracket pairs already to the powershell language definition in the built-in powershell extension (see https://github.com/Microsoft/vscode/commit/fd674fa8e61a48ad374791230f594b97159b2678
 ). You can keep your current state a while if you want to be backward compatible to pre-July versions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/229)

<!-- Reviewable:end -->
