### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vscode-powershell Release History
 
+## 0.6.2
+### Friday, August 12, 2016
+
+- Fixed #231: In VS Code 1.4.0, IntelliSense has stopped working
+- Fixed #193: Typing "n" breaks intellisense
+- Fixed #187: Language server sometimes crashes then $ErrorActionPreference = "Stop"
+
 ## 0.6.1
 ### Monday, May 16, 2016
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "PowerShell",
     "displayName": "PowerShell",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "publisher": "ms-vscode",
     "description": "Develop PowerShell scripts in Visual Studio Code!",
     "engines": {


### PR DESCRIPTION
- Fixed #231: In VS Code 1.4.0, IntelliSense has stopped working
- Fixed #193: Typing "n" breaks intellisense
- Fixed #187: Language server sometimes crashes then $ErrorActionPreference = "Stop"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/235)
<!-- Reviewable:end -->
