### PR TITLE
Release 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # vscode-powershell Release History
 
+## 0.7.1
+### Tuesday, August 23, 2016
+
+- "Auto" variable scope in debugger UI now expands by default
+- Fixed #244: Extension fails to load if username contains spaces
+- Fixed #246: Restore default PSScriptAnalyzer ruleset
+- Fixed #248: Extension fails to load on Windows 7 with PowerShell v3
+
 ## 0.7.0
 ### Thursday, August 18, 2016
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 
 This extension provides rich PowerShell language support for Visual Studio Code.
 Now you can write and debug PowerShell scripts using the excellent IDE-like interface
-that VS Code provides.
+that Visual Studio Code provides.
+
+## Platform support
+
+- **Windows 7 through 10** with PowerShell v3 and higher
+- **Linux** with PowerShell v6 (all PowerShell-supported distribtions)
+- **Mac OS X** with PowerShell v6
+
+Read the [installation instructions](https://github.com/PowerShell/PowerShell/blob/master/docs/learning-powershell/using-vscode.md)
+to get more details on how to use the extension on these platforms.
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "PowerShell",
     "displayName": "PowerShell",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "publisher": "ms-vscode",
     "description": "Develop PowerShell scripts in Visual Studio Code!",
     "engines": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import net = require('net');
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
-var requiredEditorServicesVersion = "0.7.0";
+var requiredEditorServicesVersion = "0.7.1";
 
 var powerShellProcess: cp.ChildProcess = undefined;
 var languageServerClient: LanguageClient = undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,7 +177,7 @@ function startPowerShell(powerShellExePath: string, bundledModulesPath: string, 
 
         // Add the Start-EditorServices.ps1 invocation arguments
         args.push('-Command')
-        args.push(startScriptPath + ' ' + startArgs)
+        args.push('& "' + startScriptPath + '" ' + startArgs)
 
         // Launch PowerShell as child process
         powerShellProcess = cp.spawn(powerShellExePath, args);


### PR DESCRIPTION
- "Auto" variable scope in debugger UI now expands by default
- Fixed #244: Extension fails to load if username contains spaces
- Fixed #246: Restore default PSScriptAnalyzer ruleset
- Fixed #248: Extension fails to load on Windows 7 with PowerShell v3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/vscode-powershell/258)
<!-- Reviewable:end -->
