### PR TITLE
Release 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # vscode-powershell Release History
 
+## 0.7.2
+### Friday, September 2, 2016
+
+- Fixed #243: Debug adapter process has terminated unexpectedly
+- Fixed #264: Add check for OpenSSL on OS X before starting the language service
+- Fixed #271: PSScriptAnalyzer settings path isn't being passed along
+- Fixed #273: Debugger crashes after multiple runs
+- Fixed #274: Extension crashes on Ctrl+Hover
+
 ## 0.7.1
 ### Tuesday, August 23, 2016
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,49 @@
+# Troubleshooting PowerShell Extension Issues
+
+This document contains troubleshooting steps for commonly reported issues when using the
+PowerShell extension for Visual Studio Code.
+
+## Mac OS X
+
+### 1. PowerShell IntelliSense does not work, can't debug scripts
+
+The most common problem when the PowerShell extension doesn't work on Mac OS X is that
+OpenSSL is not installed.  You can check for the installation of OpenSSL by looking for
+the following two files:
+
+```
+/usr/local/lib/libcrypto.1.0.0.dylib
+/usr/local/lib/libssl.1.0.0.dylib
+```
+
+The extension should check for these files and direct you to this documentation if you
+do not have OpenSSL isntalled.
+
+#### Installing OpenSSL via Homebrew
+
+You can use Homebrew to easily install OpenSSL.  First install Homebrew and then run the following command:
+
+```
+brew install openssl
+```
+
+Restart VS Code after completing the installation and verify that the extension is working correctly.
+
+#### Installing OpenSSL via MacPorts
+
+If you prefer to use [MacPorts](https://www.macports.org/), you can run the following command to install OpenSSL:
+
+```
+sudo port install openssl
+```
+
+You will need to take an additional step once installation completes:
+
+```
+sudo ln -s /opt/local/lib/libcrypto.1.0.0.dylib /usr/local/lib/
+sudo ln -s /opt/local/lib/libssl.1.0.0.dylib /usr/local/lib/
+```
+
+Thanks to [@MarlonRodriguez](https://github.com/MarlonRodriguez) for the tip!
+
+Restart VS Code after completing the installation and verify that the extension is working correctly.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "PowerShell",
     "displayName": "PowerShell",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "publisher": "ms-vscode",
     "description": "Develop PowerShell scripts in Visual Studio Code!",
     "engines": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,6 +112,26 @@ export function activate(context: vscode.ExtensionContext): void {
     }
     else if (os.platform() == "darwin") {
         powerShellExePath = "/usr/local/bin/powershell";
+
+        // Check for OpenSSL dependency on OS X
+        if (!utils.checkIfFileExists("/usr/local/lib/libcrypto.1.0.0.dylib") ||
+            !utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib")) {
+                var thenable =
+                    vscode.window.showWarningMessage(
+                        "The PowerShell extension will not work without OpenSSL on Mac OS X",
+                        "Show Documentation");
+
+                thenable.then(
+                    (s) => {
+                        if (s === "Show Documentation") {
+                            cp.exec("open https://github.com/PowerShell/vscode-powershell/blob/master/docs/troubleshooting.md#1-powershell-intellisense-does-not-work-cant-debug-scripts");
+                        }
+                    });
+
+                // Don't continue initializing since Editor Services will not load successfully
+                console.log("Cannot start PowerShell Editor Services due to missing OpenSSL dependency.");
+                return;
+            }
     }
     else {
         powerShellExePath = "/usr/bin/powershell";

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ import net = require('net');
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
-var requiredEditorServicesVersion = "0.7.1";
+var requiredEditorServicesVersion = "0.7.2";
 
 var powerShellProcess: cp.ChildProcess = undefined;
 var languageServerClient: LanguageClient = undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,3 +80,13 @@ export function readSessionFile(): EditorServicesSessionDetails {
 export function deleteSessionFile() {
     fs.unlinkSync(sessionFilePath);
 }
+
+export function checkIfFileExists(filePath: string): boolean {
+    try {
+        fs.accessSync(filePath, fs.R_OK)
+        return true;
+    }
+    catch (e) {
+        return false;
+    }
+}


### PR DESCRIPTION
- Fixed #243: Debug adapter process has terminated unexpectedly
- Fixed #264: Add check for OpenSSL on OS X before starting the language service
- Fixed #271: PSScriptAnalyzer settings path isn't being passed along
- Fixed #273: Debugger crashes after multiple runs
- Fixed #274: Extension crashes on Ctrl+Hover