### PR TITLE
Remove [System.Exception] from try snippets.

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -729,7 +729,7 @@
             "try {",
             "\t$0",
             "}",
-            "catch [${exception:System.Exception}] {",
+            "catch {",
             "\t",
             "}"
         ],
@@ -741,7 +741,7 @@
             "try {",
             "\t$0",
             "}",
-            "catch [${exception:System.Exception}] {",
+            "catch {",
             "\t",
             "}",
             "finally {",


### PR DESCRIPTION
After long discussion on PSMVP alias it seems that there's a bug with catch [System.Exception].  If there are two catch statements and the "general" case uses "catch [System.Exception" instead of "catch" the general case will run instead of the more specific exception!!  That's pretty mind blowing. Fix #296