### PR TITLE
Use standard PS prompt for comment help.

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -480,7 +480,7 @@
             ".DESCRIPTION",
             "\tLong description",
             ".EXAMPLE",
-            "\tC:\\PS> <example usage>",
+            "\tPS C:\\> <example usage>",
             "\tExplanation of what the example does",
             ".INPUTS",
             "\tInputs (if any)",


### PR DESCRIPTION
Changed `C:\PS>` to `PS C:\>` which seems to be the standard prompt used in the examples in help for core PS commands.