### PR TITLE
Replace program with script in launch.json.

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "PowerShell",
             "type": "PowerShell",
             "request": "launch",
-            "program": "${file}",
+            "script": "${file}",
             "args": [],
             "cwd": "${file}"
         }

--- a/package.json
+++ b/package.json
@@ -123,10 +123,14 @@
                 "configurationAttributes": {
                     "launch": {
                         "required": [
-                            "program"
+                            "script"
                         ],
                         "properties": {
                             "program": {
+                                "type": "string",
+                                "description": "Deprecated. Please use the 'script' property instead to specify the absolute path to the PowerShell script to launch under the debugger."
+                            },
+                            "script": {
                                 "type": "string",
                                 "description": "Absolute path to the PowerShell script to launch under the debugger."
                             },
@@ -151,7 +155,7 @@
                         "name": "PowerShell",
                         "type": "PowerShell",
                         "request": "launch",
-                        "program": "${file}",
+                        "script": "${file}",
                         "args": [],
                         "cwd": "${file}"
                     }


### PR DESCRIPTION
"program" is left in place with updated description indicating the user should use the  "script" property instead.  This will allow existing PowerShell projects to continue work with newer versions of PSES.

Any new launch.json files created with this updated extension will generate just "script". This means that if someone loads the project in an older version of the extension, it won't launch the debugger correctly.  The question is, given how *easy* it is to update PSES, do we think this will be a big problem?

I don't "think" so and I think the term "script" will make more sense to PowerShell users in the long run.  That said, I'm totally OK with rejecting this PR if other folks do not agree.  BTW there is a companion PR on PSES to implement the PSES side of this change.