### PR TITLE
Add PSMisleadingBacktick to PSSA settings file.

### DIFF
--- a/examples/PSScriptAnalyzerSettings.psd1
+++ b/examples/PSScriptAnalyzerSettings.psd1
@@ -10,6 +10,7 @@
     # Analyze **only** the following rules. Use IncludeRules when you want
     # to invoke only a small subset of the defualt rules.
     IncludeRules = @('PSAvoidDefaultValueSwitchParameter',
+                     'PSMisleadingBacktick',
                      'PSMissingModuleManifestField',
                      'PSReservedCmdletChar',
                      'PSReservedParams',


### PR DESCRIPTION
This is to keep the PSSA settings file in sync with the default rules enabled in PSES.  This helps the user know what the "defaults" are.