### PR TITLE
Various fixes for 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ that Visual Studio Code provides.
 
 - **Windows 7 through 10** with PowerShell v3 and higher
 - **Linux** with PowerShell v6 (all PowerShell-supported distribtions)
-- **Mac OS X** with PowerShell v6
+- **macOS and OS X** with PowerShell v6
 
 Read the [installation instructions](https://github.com/PowerShell/PowerShell/blob/master/docs/learning-powershell/using-vscode.md)
 to get more details on how to use the extension on these platforms.
@@ -67,7 +67,7 @@ Restart Visual Studio Code and try to reproduce the problem.  Once you are done 
 that, zip up the logs in the corresponding folder for your operating system:
 
 - **Windows**: `$HOME\.vscode\extensions\ms-vscode.PowerShell-<CURRENT VERSION>\logs`
-- **Linux and Mac OS X**: `~/.vscode/extensions/ms-vscode.PowerShell-<CURRENT VERSION>/logs`
+- **Linux and macOS**: `~/.vscode/extensions/ms-vscode.PowerShell-<CURRENT VERSION>/logs`
 
 You have two options for sending us the logs:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,6 +3,18 @@
 This document contains troubleshooting steps for commonly reported issues when using the
 PowerShell extension for Visual Studio Code.
 
+## Windows
+
+### 1. IntelliSense is extremely slow on PowerShell 5.0
+
+There is a known issue with PowerShell 5.0 which, for a small number of users, causes IntelliSense
+(code completions) to return after 5-15 seconds.  The following steps *might* resolve the issue for you:
+
+1. In a PowerShell console, run the following command: `Remove-Item -Force -Recurse $env:LOCALAPPDATA\Microsoft\Windows\PowerShell\CommandAnalysis`
+2. Restart Visual Studio Code and try getting IntelliSense again.
+
+This issue has been resolved in PowerShell 5.1.
+
 ## macOS (OS X)
 
 ### 1. PowerShell IntelliSense does not work, can't debug scripts

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -3,11 +3,11 @@
 This document contains troubleshooting steps for commonly reported issues when using the
 PowerShell extension for Visual Studio Code.
 
-## Mac OS X
+## macOS (OS X)
 
 ### 1. PowerShell IntelliSense does not work, can't debug scripts
 
-The most common problem when the PowerShell extension doesn't work on Mac OS X is that
+The most common problem when the PowerShell extension doesn't work on macOS is that
 OpenSSL is not installed.  You can check for the installation of OpenSSL by looking for
 the following files:
 
@@ -30,7 +30,7 @@ do not have OpenSSL installed.
 
 #### Installing OpenSSL via Homebrew
 
-We **highly recommend** that you use [Homebrew](http://brew.sh) to install OpenSSL.  The PowerShell distribution for OS X
+We **highly recommend** that you use [Homebrew](http://brew.sh) to install OpenSSL.  The PowerShell distribution for macOS
 has built-in support for Homebrew's OpenSSL library paths.  If you install with Homebrew, you will avoid
 [security concerns](https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl)
 around creating symbolic links in your `/usr/local/lib` path which are needed when using other means of installation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,7 +9,16 @@ PowerShell extension for Visual Studio Code.
 
 The most common problem when the PowerShell extension doesn't work on Mac OS X is that
 OpenSSL is not installed.  You can check for the installation of OpenSSL by looking for
-the following two files:
+the following files:
+
+If installed using Homebrew:
+
+```
+/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib
+/usr/local/opt/openssl/lib/libssl.1.0.0.dylib
+```
+
+If installed by some other means:
 
 ```
 /usr/local/lib/libcrypto.1.0.0.dylib
@@ -21,17 +30,15 @@ do not have OpenSSL installed.
 
 #### Installing OpenSSL via Homebrew
 
-You can use [Homebrew](http://brew.sh) to easily install OpenSSL.  First, install Homebrew and then run the following command:
+We **highly recommend** that you use [Homebrew](http://brew.sh) to install OpenSSL.  The PowerShell distribution for OS X
+has built-in support for Homebrew's OpenSSL library paths.  If you install with Homebrew, you will avoid
+[security concerns](https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#openssl)
+around creating symbolic links in your `/usr/local/lib` path which are needed when using other means of installation.
+
+First, install Homebrew and then run the following command:
 
 ```
 brew install openssl
-```
-
-After installation, the libraries of interest must be symlinked to `/usr/local/lib`; e.g. (note that /usr/local/lib may not already exist and may need to be created before symlinking):
-
-```
-ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/libcrypto.1.0.0.dylib
-ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/libssl.1.0.0.dylib
 ```
 
 Restart VS Code after completing the installation and verify that the extension is working correctly.
@@ -47,8 +54,8 @@ sudo port install openssl
 You will need to take an additional step once installation completes:
 
 ```
-sudo ln -s /opt/local/lib/libcrypto.1.0.0.dylib /usr/local/lib/
-sudo ln -s /opt/local/lib/libssl.1.0.0.dylib /usr/local/lib/
+sudo ln -s /opt/local/lib/libcrypto.1.0.0.dylib /usr/local/lib/libcrypto.1.0.0.dylib
+sudo ln -s /opt/local/lib/libssl.1.0.0.dylib /usr/local/lib/libssl.1.0.0.dylib
 ```
 
 Thanks to [@MarlonRodriguez](https://github.com/MarlonRodriguez) for the tip!

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -172,6 +172,9 @@ export class ConsoleFeature implements IFeature {
                 this.languageClient.sendRequest(EvaluateRequest.type, {
                     expression: editor.document.getText(selectionRange)
                 });
+
+                // Show the output window if it isn't already visible
+                this.consoleChannel.show(vscode.ViewColumn.Three);
             });
 
         this.consoleChannel = vscode.window.createOutputChannel("PowerShell Output");
@@ -189,14 +192,6 @@ export class ConsoleFeature implements IFeature {
             promptDetails => showInputPrompt(promptDetails, this.languageClient));
 
         this.languageClient.onNotification(OutputNotification.type, (output) => {
-            var outputEditorExist = vscode.window.visibleTextEditors.some((editor) => {
-                return editor.document.languageId == 'Log'
-            });
-
-            if (!outputEditorExist) {
-                this.consoleChannel.show(vscode.ViewColumn.Three);
-            }
-
             this.consoleChannel.append(output.output);
         });
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -454,7 +454,7 @@ export class SessionManager {
         else if (os.platform() == "darwin") {
             powerShellExePath = "/usr/local/bin/powershell";
 
-            // Check for OpenSSL dependency on OS X.  Look for the default Homebrew installation
+            // Check for OpenSSL dependency on macOS.  Look for the default Homebrew installation
             // path and if that fails check the system-wide library path.
             if (!(utils.checkIfFileExists("/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib") &&
                   utils.checkIfFileExists("/usr/local/opt/openssl/lib/libssl.1.0.0.dylib")) &&
@@ -462,7 +462,7 @@ export class SessionManager {
                   utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib"))) {
                     var thenable =
                         vscode.window.showWarningMessage(
-                            "The PowerShell extension will not work without OpenSSL on Mac OS X",
+                            "The PowerShell extension will not work without OpenSSL on macOS and OS X",
                             "Show Documentation");
 
                     thenable.then(

--- a/src/session.ts
+++ b/src/session.ts
@@ -454,9 +454,12 @@ export class SessionManager {
         else if (os.platform() == "darwin") {
             powerShellExePath = "/usr/local/bin/powershell";
 
-            // Check for OpenSSL dependency on OS X
-            if (!utils.checkIfFileExists("/usr/local/lib/libcrypto.1.0.0.dylib") ||
-                !utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib")) {
+            // Check for OpenSSL dependency on OS X.  Look for the default Homebrew installation
+            // path and if that fails check the system-wide library path.
+            if (!(utils.checkIfFileExists("/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib") &&
+                  utils.checkIfFileExists("/usr/local/opt/openssl/lib/libssl.1.0.0.dylib")) &&
+                !(utils.checkIfFileExists("/usr/local/lib/libcrypto.1.0.0.dylib") &&
+                  utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib"))) {
                     var thenable =
                         vscode.window.showWarningMessage(
                             "The PowerShell extension will not work without OpenSSL on Mac OS X",


### PR DESCRIPTION
- Output window should appear when F8 is pressed.
- Check for Homebrew's OpenSSL libraries correctly
- Update OS X nomenaclature to macOS
- Add troubleshooting note about IntelliSense slowness in PS 5.0