### PR TITLE
Add support for debug configurationSnippets.

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -2,9 +2,9 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "PowerShell",
             "type": "PowerShell",
             "request": "launch",
+            "name": "PowerShell Launch (current file)",
             "script": "${file}",
             "args": [],
             "cwd": "${file}"

--- a/package.json
+++ b/package.json
@@ -120,6 +120,34 @@
                 },
                 "program": "./out/debugAdapter.js",
                 "runtime": "node",
+
+				"configurationSnippets": [
+					{
+						"label": "PowerShell: Launch Current File Configuration",
+						"description": "A new configuration for launching the current opened PowerShell script",
+						"body": {
+							"type": "PowerShell",
+							"request": "launch",
+							"name": "PowerShell Launch (current file)",
+							"script": "^\"\\${file}\"",
+                            "args": [],
+                            "cwd": "^\"\\${file}\""
+						}
+					},
+					{
+						"label": "PowerShell: Launch Configuration",
+						"description": "A new configuration for launching a PowerShell script",
+						"body": {
+							"type": "PowerShell",
+							"request": "launch",
+							"name": "PowerShell Launch (${Script})",
+							"script": "^\"\\${workspaceRoot}/${Script}\"",
+                            "args": [],
+                            "cwd": "^\"\\${workspaceRoot}\""
+						}
+					}
+				],
+
                 "configurationAttributes": {
                     "launch": {
                         "required": [
@@ -145,16 +173,16 @@
                             "cwd": {
                                 "type": "string",
                                 "description": "Absolute path to the working directory. Default is the current workspace.",
-                                "default": "."
+                                "default": "${workspaceRoot}"
                             }
                         }
                     }
                 },
                 "initialConfigurations": [
                     {
-                        "name": "PowerShell",
                         "type": "PowerShell",
                         "request": "launch",
+                        "name": "PowerShell Launch (current file)",
                         "script": "${file}",
                         "args": [],
                         "cwd": "${file}"

--- a/package.json
+++ b/package.json
@@ -121,32 +121,32 @@
                 "program": "./out/debugAdapter.js",
                 "runtime": "node",
 
-				"configurationSnippets": [
-					{
-						"label": "PowerShell: Launch Current File Configuration",
-						"description": "A new configuration for launching the current opened PowerShell script",
-						"body": {
-							"type": "PowerShell",
-							"request": "launch",
-							"name": "PowerShell Launch (current file)",
-							"script": "^\"\\${file}\"",
+                "configurationSnippets": [
+                    {
+                        "label": "PowerShell: Launch Current File Configuration",
+                        "description": "A new configuration for launching the current opened PowerShell script",
+                        "body": {
+                            "type": "PowerShell",
+                            "request": "launch",
+                            "name": "PowerShell Launch (current file)",
+                            "script": "^\"\\${file}\"",
                             "args": [],
                             "cwd": "^\"\\${file}\""
-						}
-					},
-					{
-						"label": "PowerShell: Launch Configuration",
-						"description": "A new configuration for launching a PowerShell script",
-						"body": {
-							"type": "PowerShell",
-							"request": "launch",
-							"name": "PowerShell Launch (${Script})",
-							"script": "^\"\\${workspaceRoot}/${Script}\"",
+                        }
+                    },
+                    {
+                        "label": "PowerShell: Launch Configuration",
+                        "description": "A new configuration for launching a PowerShell script",
+                        "body": {
+                            "type": "PowerShell",
+                            "request": "launch",
+                            "name": "PowerShell Launch (${Script})",
+                            "script": "^\"\\${workspaceRoot}/${Script}\"",
                             "args": [],
                             "cwd": "^\"\\${workspaceRoot}\""
-						}
-					}
-				],
+                        }
+                    }
+                ],
 
                 "configurationAttributes": {
                     "launch": {


### PR DESCRIPTION
Rename debug target from "PowerShell" to "PowerShell Launch (current file)" this makes room for an eventual "PowerShell Attach" debug target.

Fix #364.