### PR TITLE
Add support for new project creation using Plaster

### DIFF
--- a/examples/PromptExamples.ps1
+++ b/examples/PromptExamples.ps1
@@ -1,0 +1,10 @@
+
+# Multi-choice prompt
+$choices = @(
+    New-Object "System.Management.Automation.Host.ChoiceDescription" "&Apple", "Apple"
+    New-Object "System.Management.Automation.Host.ChoiceDescription" "&Banana", "Banana"
+    New-Object "System.Management.Automation.Host.ChoiceDescription" "&Orange", "Orange"
+)
+
+$defaults = [int[]]@(0, 2)
+$host.UI.PromptForChoice("Choose a fruit", "You may choose more than one", $choices, $defaults)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     },
     "main": "./out/main",
     "activationEvents": [
-        "onLanguage:powershell"
+        "onLanguage:powershell",
+        "onCommand:PowerShell.NewProjectFromTemplate"
     ],
     "dependencies": {
         "vscode-languageclient": "1.3.1"
@@ -132,6 +133,11 @@
             {
                 "command": "PowerShell.ShowSessionOutput",
                 "title": "Show Session Output",
+                "category": "PowerShell"
+            },
+            {
+                "command": "PowerShell.NewProjectFromTemplate",
+                "title": "Create New Project from Plaster Template",
                 "category": "PowerShell"
             }
         ],

--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
                 "command": "PowerShell.SelectPSSARules",
                 "title": "Select PSScriptAnalyzer Rules",
                 "category": "PowerShell"
+            },
+            {
+                "command": "PowerShell.ShowSessionOutput",
+                "title": "Show Session Output",
+                "category": "PowerShell"
             }
         ],
         "snippets": [

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -144,12 +144,12 @@ function onInputEntered(responseText: string): ShowInputPromptResponseBody {
 }
 
 export class ConsoleFeature implements IFeature {
-    private command: vscode.Disposable;
+    private commands: vscode.Disposable[];
     private languageClient: LanguageClient;
     private consoleChannel: vscode.OutputChannel;
 
     constructor() {
-        this.command =
+        this.commands = [
             vscode.commands.registerCommand('PowerShell.RunSelection', () => {
                 if (this.languageClient === undefined) {
                     // TODO: Log error message
@@ -175,7 +175,13 @@ export class ConsoleFeature implements IFeature {
 
                 // Show the output window if it isn't already visible
                 this.consoleChannel.show(vscode.ViewColumn.Three);
-            });
+            }),
+
+            vscode.commands.registerCommand('PowerShell.ShowSessionOutput', () => {
+                // Show the output window if it isn't already visible
+                this.consoleChannel.show(vscode.ViewColumn.Three);
+            })
+        ];
 
         this.consoleChannel = vscode.window.createOutputChannel("PowerShell Output");
     }
@@ -197,7 +203,7 @@ export class ConsoleFeature implements IFeature {
     }
 
     public dispose() {
-        this.command.dispose();
+        this.commands.forEach(command => command.dispose());
         this.consoleChannel.dispose();
     }
 }

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -4,6 +4,7 @@
 
 import vscode = require('vscode');
 import { IFeature } from '../feature';
+import { showCheckboxQuickPick, CheckboxQuickPickItem } from '../checkboxQuickPick'
 import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
 
 export namespace EvaluateRequest {
@@ -46,14 +47,15 @@ interface ShowInputPromptRequestArgs {
 }
 
 interface ShowChoicePromptRequestArgs {
+    isMultiChoice: boolean;
     caption: string;
     message: string;
     choices: ChoiceDetails[];
-    defaultChoice: number;
+    defaultChoices: number[];
 }
 
 interface ShowChoicePromptResponseBody {
-    chosenItem: string;
+    responseText: string;
     promptCancelled: boolean;
 }
 
@@ -66,36 +68,62 @@ function showChoicePrompt(
     promptDetails: ShowChoicePromptRequestArgs,
     client: LanguageClient) : Thenable<ShowChoicePromptResponseBody> {
 
-    var quickPickItems =
-        promptDetails.choices.map<vscode.QuickPickItem>(choice => {
-            return {
-                label: choice.label,
-                description: choice.helpMessage
+    var resultThenable: Thenable<ShowChoicePromptResponseBody> = undefined;
+
+    if (!promptDetails.isMultiChoice) {
+        var quickPickItems =
+            promptDetails.choices.map<vscode.QuickPickItem>(choice => {
+                return {
+                    label: choice.label,
+                    description: choice.helpMessage
+                }
+            });
+
+        if (promptDetails.defaultChoices &&
+            promptDetails.defaultChoices.length > 0) {
+
+            // Shift the default items to the front of the
+            // array so that the user can select it easily
+            var defaultChoice = promptDetails.defaultChoices[0];
+            if (defaultChoice > -1 &&
+                defaultChoice < promptDetails.choices.length) {
+
+                var defaultChoiceItem = quickPickItems[defaultChoice];
+                quickPickItems.splice(defaultChoice, 1);
+
+                // Add the default choice to the head of the array
+                quickPickItems = [defaultChoiceItem].concat(quickPickItems);
             }
+        }
+
+        resultThenable =
+            vscode.window
+                .showQuickPick(
+                    quickPickItems,
+                    { placeHolder: promptDetails.caption + " - " + promptDetails.message })
+                .then(onItemSelected);
+    }
+    else {
+        var checkboxQuickPickItems =
+            promptDetails.choices.map<CheckboxQuickPickItem>(choice => {
+                return {
+                    label: choice.label,
+                    description: choice.helpMessage,
+                    isSelected: false
+                }
+            });
+
+        // Select the defaults
+        promptDetails.defaultChoices.forEach(choiceIndex => {
+            checkboxQuickPickItems[choiceIndex].isSelected = true
         });
 
-    // Shift the default item to the front of the
-    // array so that the user can select it easily
-    if (promptDetails.defaultChoice > -1 &&
-        promptDetails.defaultChoice < promptDetails.choices.length) {
-
-        var defaultChoiceItem = quickPickItems[promptDetails.defaultChoice];
-        quickPickItems.splice(promptDetails.defaultChoice, 1);
-
-        // Add the default choice to the head of the array
-        quickPickItems = [defaultChoiceItem].concat(quickPickItems);
+        resultThenable =
+            showCheckboxQuickPick(
+                    checkboxQuickPickItems,
+                    { confirmPlaceHolder: `${promptDetails.caption} - ${promptDetails.message}`})
+                .then(onItemsSelected);
     }
-
-    // For some bizarre reason, the quick pick dialog does not
-    // work if I return the Thenable immediately at this point.
-    // It only works if I save the thenable to a variable and
-    // return the variable instead...
-    var resultThenable =
-        vscode.window
-            .showQuickPick(
-                quickPickItems,
-                { placeHolder: promptDetails.caption + " - " + promptDetails.message })
-            .then(onItemSelected);
 
     return resultThenable;
 }
@@ -112,18 +140,34 @@ function showInputPrompt(
     return resultThenable;
 }
 
-function onItemSelected(chosenItem: vscode.QuickPickItem): ShowChoicePromptResponseBody {
-    if (chosenItem !== undefined) {
+function onItemsSelected(chosenItems: CheckboxQuickPickItem[]): ShowChoicePromptResponseBody {
+    if (chosenItems !== undefined) {
         return {
             promptCancelled: false,
-            chosenItem: chosenItem.label
+            responseText: chosenItems.filter(item => item.isSelected).map(item => item.label).join(", ")
         };
     }
     else {
         // User cancelled the prompt, send the cancellation
         return {
             promptCancelled: true,
-            chosenItem: undefined
+            responseText: undefined
+        };
+    }
+}
+
+function onItemSelected(chosenItem: vscode.QuickPickItem): ShowChoicePromptResponseBody {
+    if (chosenItem !== undefined) {
+        return {
+            promptCancelled: false,
+            responseText: chosenItem.label
+        };
+    }
+    else {
+        // User cancelled the prompt, send the cancellation
+        return {
+            promptCancelled: true,
+            responseText: undefined
         };
     }
 }

--- a/src/features/NewFileOrProject.ts
+++ b/src/features/NewFileOrProject.ts
@@ -1,0 +1,210 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import vscode = require('vscode');
+import { IFeature } from '../feature';
+import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
+
+export class NewFileOrProjectFeature implements IFeature {
+
+    private readonly loadIcon = "  $(sync)  ";
+    private command: vscode.Disposable;
+    private languageClient: LanguageClient;
+    private waitingForClientToken: vscode.CancellationTokenSource;
+
+    constructor() {
+        this.command =
+            vscode.commands.registerCommand('PowerShell.NewProjectFromTemplate', () => {
+
+                if (!this.languageClient && !this.waitingForClientToken) {
+
+                    // If PowerShell isn't finished loading yet, show a loading message
+                    // until the LanguageClient is passed on to us
+                    this.waitingForClientToken = new vscode.CancellationTokenSource();
+                    vscode.window
+                        .showQuickPick(
+                            ["Cancel"],
+                            { placeHolder: "New Project: Please wait, starting PowerShell..." },
+                            this.waitingForClientToken.token)
+                        .then(response => { if (response === "Cancel") { this.clearWaitingToken(); } });
+
+                    // Cancel the loading prompt after 60 seconds
+                    setTimeout(() => {
+                            if (this.waitingForClientToken) {
+                                this.clearWaitingToken();
+
+                                vscode.window.showErrorMessage(
+                                    "New Project: PowerShell session took too long to start.");
+                            }
+                        }, 60000);
+                }
+                else {
+                    this.showProjectTemplates();
+                }
+            });
+    }
+
+    public setLanguageClient(languageClient: LanguageClient) {
+        this.languageClient = languageClient;
+
+        if (this.waitingForClientToken) {
+            this.clearWaitingToken();
+            this.showProjectTemplates();
+        }
+    }
+
+    public dispose() {
+        this.command.dispose();
+    }
+
+    private showProjectTemplates(includeInstalledModules: boolean = false): void {
+        vscode.window
+            .showQuickPick(
+                this.getProjectTemplates(includeInstalledModules),
+                { placeHolder: "Choose a template to create a new project",
+                  ignoreFocusOut: true })
+            .then(template => {
+                if (template.label.startsWith(this.loadIcon)) {
+                    this.showProjectTemplates(true);
+                }
+                else {
+                    this.createProjectFromTemplate(template.template);
+                }
+            });
+    }
+
+    private getProjectTemplates(includeInstalledModules: boolean): Thenable<TemplateQuickPickItem[]> {
+        return this.languageClient
+            .sendRequest(
+                GetProjectTemplatesRequest.type,
+                { includeInstalledModules: includeInstalledModules })
+            .then(response => {
+                if (response.needsModuleInstall) {
+                    // TODO: Offer to install Plaster
+                    vscode.window.showErrorMessage("Plaster is not installed!");
+                    return Promise.reject<TemplateQuickPickItem[]>("Plaster needs to be installed");
+                }
+                else {
+                    var templates = response.templates.map<TemplateQuickPickItem>(
+                        template => {
+                            return {
+                                label: template.title,
+                                description: `v${template.version} by ${template.author}, tags: ${template.tags}`,
+                                detail: template.description,
+                                template: template
+                            }
+                        });
+
+                    if (!includeInstalledModules) {
+                        templates =
+                            [{ label: this.loadIcon, description: "Load additional templates from installed modules", template: undefined }]
+                                .concat(templates)
+                    }
+                    else {
+                        templates =
+                            [{ label: this.loadIcon, description: "Refresh template list", template: undefined }]
+                                .concat(templates)
+                    }
+
+                    return templates;
+                }
+            });
+    }
+
+    private createProjectFromTemplate(template: TemplateDetails): void {
+        vscode.window
+            .showInputBox(
+                { placeHolder: "Enter an absolute path to the folder where the project should be created",
+                  ignoreFocusOut: true })
+            .then(destinationPath => {
+
+                if (destinationPath) {
+                    // Show the PowerShell session output in case an error occurred
+                    vscode.commands.executeCommand("PowerShell.ShowSessionOutput");
+
+                    this.languageClient
+                        .sendRequest(
+                            NewProjectFromTemplateRequest.type,
+                            { templatePath: template.templatePath, destinationPath: destinationPath })
+                        .then(result => {
+                            if (result.creationSuccessful) {
+                                this.openWorkspacePath(destinationPath);
+                            }
+                            else {
+                                vscode.window.showErrorMessage(
+                                    "Project creation failed, read the Output window for more details.");
+                            }
+                        });
+                }
+                else {
+                    vscode.window
+                        .showErrorMessage(
+                            "New Project: You must enter an absolute folder path to continue.  Try again?",
+                            "Yes", "No")
+                        .then(
+                            response => {
+                                if (response === "Yes") {
+                                    this.createProjectFromTemplate(template);
+                                }
+                            });
+                }
+            });
+    }
+
+    private openWorkspacePath(workspacePath: string) {
+        // Open the created project in a new window
+        vscode.commands.executeCommand(
+            "vscode.openFolder",
+            vscode.Uri.file(workspacePath),
+            true);
+    }
+
+    private clearWaitingToken() {
+        if (this.waitingForClientToken) {
+            this.waitingForClientToken.dispose();
+            this.waitingForClientToken = undefined;
+        }
+    }
+}
+
+interface TemplateQuickPickItem extends vscode.QuickPickItem {
+    template: TemplateDetails
+}
+
+interface TemplateDetails {
+    title: string;
+    version: string;
+    author: string;
+    description: string;
+    tags: string;
+    templatePath: string;
+}
+
+namespace GetProjectTemplatesRequest {
+    export const type: RequestType<GetProjectTemplatesRequestArgs, GetProjectTemplatesResponseBody, string> =
+        { get method() { return 'powerShell/getProjectTemplates'; } };
+}
+
+interface GetProjectTemplatesRequestArgs {
+    includeInstalledModules: boolean;
+}
+
+interface GetProjectTemplatesResponseBody {
+    needsModuleInstall: boolean;
+    templates: TemplateDetails[];
+}
+
+namespace NewProjectFromTemplateRequest {
+    export const type: RequestType<any, NewProjectFromTemplateResponseBody, string> =
+        { get method() { return 'powerShell/newProjectFromTemplate'; } };
+}
+
+interface NewProjectFromTemplateRequestArgs {
+    destinationPath: string;
+    templatePath: string;
+}
+
+interface NewProjectFromTemplateResponseBody {
+    creationSuccessful: boolean;
+}

--- a/src/features/SelectPSSARules.ts
+++ b/src/features/SelectPSSARules.ts
@@ -5,7 +5,7 @@
 import vscode = require("vscode");
 import { IFeature } from "../feature";
 import { LanguageClient, RequestType } from "vscode-languageclient";
-import { CheckboxQuickPickItem, CheckboxQuickPick } from "../checkboxQuickPick";
+import { CheckboxQuickPickItem, showCheckboxQuickPick } from "../checkboxQuickPick";
 
 export namespace GetPSSARulesRequest {
     export const type: RequestType<any, any, void> = { get method(): string { return "powerShell/getPSSARules"; } };
@@ -43,16 +43,18 @@ export class SelectPSSARulesFeature implements IFeature {
                     return;
                 }
                 let options: CheckboxQuickPickItem[] = returnedRules.map(function (rule: RuleInfo): CheckboxQuickPickItem {
-                    return { name: rule.name, isSelected: rule.isEnabled };
+                    return { label: rule.name, isSelected: rule.isEnabled };
                 });
-                CheckboxQuickPick.show(options, (updatedOptions) => {
-                    let filepath: string = vscode.window.activeTextEditor.document.uri.fsPath;
-                    let ruleInfos: RuleInfo[] = updatedOptions.map(
-                        function (option: CheckboxQuickPickItem): RuleInfo {
-                            return { name: option.name, isEnabled: option.isSelected };
-                        });
-                    let requestParams: SetPSSARulesRequestParams = {filepath, ruleInfos};
-                    this.languageClient.sendRequest(SetPSSARulesRequest.type, requestParams);
+
+                showCheckboxQuickPick(options)
+                    .then(updatedOptions => {
+                        let filepath: string = vscode.window.activeTextEditor.document.uri.fsPath;
+                        let ruleInfos: RuleInfo[] = updatedOptions.map(
+                            function (option: CheckboxQuickPickItem): RuleInfo {
+                                return { name: option.label, isEnabled: option.isSelected };
+                            });
+                        let requestParams: SetPSSARulesRequestParams = {filepath, ruleInfos};
+                        this.languageClient.sendRequest(SetPSSARulesRequest.type, requestParams);
                 });
             });
         });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { SessionManager } from './session';
 import { PowerShellLanguageId } from './utils';
 import { ConsoleFeature } from './features/Console';
 import { OpenInISEFeature } from './features/OpenInISE';
+import { NewFileOrProjectFeature } from './features/NewFileOrProject';
 import { ExpandAliasFeature } from './features/ExpandAlias';
 import { ShowHelpFeature } from './features/ShowOnlineHelp';
 import { FindModuleFeature } from './features/PowerShellFindModule';
@@ -93,7 +94,8 @@ export function activate(context: vscode.ExtensionContext): void {
         new FindModuleFeature(),
         new ExtensionCommandsFeature(),
         new SelectPSSARulesFeature(),
-        new CodeActionsFeature()
+        new CodeActionsFeature(),
+        new NewFileOrProjectFeature()
     ];
 
     sessionManager =
@@ -106,9 +108,6 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 export function deactivate(): void {
-    // Finish the logger
-    logger.dispose();
-
     // Clean up all extension features
     extensionFeatures.forEach(feature => {
        feature.dispose();
@@ -116,4 +115,7 @@ export function deactivate(): void {
 
     // Dispose of the current session
     sessionManager.dispose();
+
+    // Dispose of the logger
+    logger.dispose();
 }


### PR DESCRIPTION
This change adds a new command called "Create New Project from Plaster
Template" which allows the user to select a Plaster template and go
through the template creation process.  Once the project is created, a new
window is opened for the new project's path.