### PR TITLE
Fix #353: Cannot start PowerShell debugger on Windows when offline

### DIFF
--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -32,7 +32,7 @@ let sessionDetails = utils.readSessionFile();
 
 // Establish connection before setting up the session
 debugAdapterLogWriter.write("Connecting to port: " + sessionDetails.debugServicePort + "\r\n");
-let debugServiceSocket = net.connect(sessionDetails.debugServicePort);
+let debugServiceSocket = net.connect(sessionDetails.debugServicePort, '127.0.0.1');
 
 // Write any errors to the log file
 debugServiceSocket.on(


### PR DESCRIPTION
This issue was caused by not fully specifying the localhost IP address
(127.0.0.1) in debugAdapter.ts's socket connection code.