### PR TITLE
Change order of BundledModulesPath in PSModulePath

### DIFF
--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -133,7 +133,7 @@ function Get-AvailablePort {
 
 # Add BundledModulesPath to $env:PSModulePath
 if ($BundledModulesPath) {
-    $env:PSMODULEPATH = $BundledModulesPath + [System.IO.Path]::PathSeparator + $env:PSMODULEPATH
+    $env:PSMODULEPATH = $env:PSMODULEPATH + [System.IO.Path]::PathSeparator + $BundledModulesPath
 }
 
 # Check if PowerShellGet module is available


### PR DESCRIPTION
This change modifies the order of BundledModulesPath in our manipulation
of the PSModulePath to include modules with the PowerShell extension.  To
ensure that newer modules on the user's system are used for certain
integrations (like PSScriptAnalyzer or Plaster), the BundledModulesPath
needs to go at the end of PSModulePath, not the beginning.