### PR TITLE
Allow quick fix to work in untitled documents

### DIFF
--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -9,21 +9,15 @@ export class CodeActionsFeature implements IFeature {
 
     constructor() {
         this.command = vscode.commands.registerCommand('PowerShell.ApplyCodeActionEdits', (edit: any) => {
-            var editor = Window.activeTextEditor;
-            var filePath = editor.document.fileName;
-            var workspaceEdit = new vscode.WorkspaceEdit();
-            workspaceEdit.set(
-                vscode.Uri.file(filePath),
-                [
-                    new vscode.TextEdit(
-                        new vscode.Range(
-                            edit.StartLineNumber - 1,
-                            edit.StartColumnNumber - 1,
-                            edit.EndLineNumber - 1,
-                            edit.EndColumnNumber - 1),
-                        edit.Text)
-                ]);
-            vscode.workspace.applyEdit(workspaceEdit);
+            Window.activeTextEditor.edit((editBuilder) => {
+                editBuilder.replace(
+                    new vscode.Range(
+                        edit.StartLineNumber - 1,
+                        edit.StartColumnNumber - 1,
+                        edit.EndLineNumber - 1,
+                        edit.EndColumnNumber - 1),
+                    edit.Text);
+            });
         });
     }
 


### PR DESCRIPTION
In the previous iteration of this feature, the edits can be applied to files open in a workspace. This commit removes that restriction.

Resolves #392 