### PR TITLE
Fix #396: Extension commands loaded in profile are not being registered

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -333,6 +333,11 @@ export class SessionManager {
                     connectFunc,
                     clientOptions);
 
+            // Send the new LanguageClient to extension features
+            // so that they can register their message handlers
+            // before the connection is established.
+            this.updateExtensionFeatures(this.languageServerClient);
+
             this.languageServerClient.onReady().then(
                 () => {
                     this.languageServerClient
@@ -345,12 +350,11 @@ export class SessionManager {
                                         ? `${this.versionDetails.displayVersion} (${this.versionDetails.architecture})`
                                         : this.versionDetails.displayVersion,
                                     SessionStatus.Running);
-
-                                this.updateExtensionFeatures(this.languageServerClient)
                             });
                 },
                 (reason) => {
                     this.setSessionFailure("Could not start language service: ", reason);
+                    this.updateExtensionFeatures(undefined);
                 });
 
             this.languageServerClient.start();
@@ -358,6 +362,7 @@ export class SessionManager {
         catch (e)
         {
             this.setSessionFailure("The language service could not be started: ", e);
+            this.updateExtensionFeatures(undefined);
         }
     }
 


### PR DESCRIPTION
This change fixes an issue caused by the recent extension code refactoring
which prevents extension commands from being registered in the extension
when loaded in the user's profile.  This was caused by the LanguageClient
not being given to the ExtensionCommandsFeature early enough for it to
register its handler for the extensionCommandAdded event from the language
server.