### PR TITLE
Add 'Open Examples Folder' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "main": "./out/main",
     "activationEvents": [
         "onLanguage:powershell",
-        "onCommand:PowerShell.NewProjectFromTemplate"
+        "onCommand:PowerShell.NewProjectFromTemplate",
+        "onCommand:PowerShell.OpenExamplesFolder"
     ],
     "dependencies": {
         "vscode-languageclient": "1.3.1"
@@ -138,6 +139,11 @@
             {
                 "command": "PowerShell.NewProjectFromTemplate",
                 "title": "Create New Project from Plaster Template",
+                "category": "PowerShell"
+            },
+            {
+                "command": "PowerShell.OpenExamplesFolder",
+                "title": "Open Examples Folder",
                 "category": "PowerShell"
             }
         ],

--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -1,0 +1,30 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import vscode = require('vscode');
+import path = require('path');
+import { IFeature } from '../feature';
+import { LanguageClient } from 'vscode-languageclient';
+
+export class ExamplesFeature implements IFeature {
+    private command: vscode.Disposable;
+    private examplesPath: string;
+
+    constructor() {
+        this.examplesPath = path.resolve(__dirname, "../../examples");
+        this.command = vscode.commands.registerCommand('PowerShell.OpenExamplesFolder', () => {
+            vscode.commands.executeCommand(
+                "vscode.openFolder",
+                vscode.Uri.file(this.examplesPath),
+                true);
+        });
+    }
+
+    public setLanguageClient(languageclient: LanguageClient) {
+    }
+
+    public dispose() {
+        this.command.dispose();
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { IFeature } from './feature';
 import { SessionManager } from './session';
 import { PowerShellLanguageId } from './utils';
 import { ConsoleFeature } from './features/Console';
+import { ExamplesFeature } from './features/Examples';
 import { OpenInISEFeature } from './features/OpenInISE';
 import { NewFileOrProjectFeature } from './features/NewFileOrProject';
 import { ExpandAliasFeature } from './features/ExpandAlias';
@@ -88,6 +89,7 @@ export function activate(context: vscode.ExtensionContext): void {
     // Create features
     extensionFeatures = [
         new ConsoleFeature(),
+        new ExamplesFeature(),
         new OpenInISEFeature(),
         new ExpandAliasFeature(),
         new ShowHelpFeature(),


### PR DESCRIPTION
This change introduces a new command called "Open Examples Folder" which
opens the bundled folder of example scripts.  This saves us from having to
tell people where to find the folder since it's not the easiest path to
get to.