### PR TITLE
Add startSessionCommand handler for debugger configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "activationEvents": [
         "onLanguage:powershell",
         "onCommand:PowerShell.NewProjectFromTemplate",
-        "onCommand:PowerShell.OpenExamplesFolder"
+        "onCommand:PowerShell.OpenExamplesFolder",
+        "onCommand:PowerShell.StartDebugSession"
     ],
     "dependencies": {
         "vscode-languageclient": "1.3.1"
@@ -163,7 +164,8 @@
                 },
                 "program": "./out/debugAdapter.js",
                 "runtime": "node",
-
+                "languages": ["powershell"],
+                "startSessionCommand": "PowerShell.StartDebugSession",
                 "configurationSnippets": [
                     {
                         "label": "PowerShell: Launch Current Script Configuration",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import vscode = require('vscode');
+import { IFeature } from '../feature';
+import { LanguageClient } from 'vscode-languageclient';
+
+export class DebugSessionFeature implements IFeature {
+    private command: vscode.Disposable;
+    private examplesPath: string;
+
+    constructor() {
+        this.command = vscode.commands.registerCommand(
+            'PowerShell.StartDebugSession',
+            config => { this.startDebugSession(config); });
+    }
+
+    public setLanguageClient(languageclient: LanguageClient) {
+    }
+
+    public dispose() {
+        this.command.dispose();
+    }
+
+    private startDebugSession(config: any) {
+        if (!config.request) {
+            // No launch.json, create the default configuration
+            config.type = 'PowerShell';
+            config.name = 'PowerShell Launch Current File';
+            config.request = 'launch';
+            config.args = [];
+            config.script = vscode.window.activeTextEditor.document.fileName;
+        }
+
+        if (config.request === 'launch') {
+            // Make sure there's a usable working directory if possible
+            config.cwd = config.cwd || vscode.workspace.rootPath || config.script;
+        }
+
+        vscode.commands.executeCommand('vscode.startDebug', config);
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,13 +13,14 @@ import { PowerShellLanguageId } from './utils';
 import { ConsoleFeature } from './features/Console';
 import { ExamplesFeature } from './features/Examples';
 import { OpenInISEFeature } from './features/OpenInISE';
-import { NewFileOrProjectFeature } from './features/NewFileOrProject';
 import { ExpandAliasFeature } from './features/ExpandAlias';
 import { ShowHelpFeature } from './features/ShowOnlineHelp';
-import { FindModuleFeature } from './features/PowerShellFindModule';
-import { ExtensionCommandsFeature } from './features/ExtensionCommands';
-import { SelectPSSARulesFeature } from './features/SelectPSSARules';
 import { CodeActionsFeature } from './features/CodeActions';
+import { DebugSessionFeature } from './features/DebugSession';
+import { SelectPSSARulesFeature } from './features/SelectPSSARules';
+import { FindModuleFeature } from './features/PowerShellFindModule';
+import { NewFileOrProjectFeature } from './features/NewFileOrProject';
+import { ExtensionCommandsFeature } from './features/ExtensionCommands';
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
@@ -101,7 +102,8 @@ export function activate(context: vscode.ExtensionContext): void {
         new ExtensionCommandsFeature(),
         new SelectPSSARulesFeature(),
         new CodeActionsFeature(),
-        new NewFileOrProjectFeature()
+        new NewFileOrProjectFeature(),
+        new DebugSessionFeature()
     ];
 
     sessionManager =


### PR DESCRIPTION
This change leverages the new "setSessionCommand" configuration parameter
for debugger contributions which allows us to provide a command that will
take a debug launch configuration, tweak it, and then launch the debugger
ourselves.  This allows us to do any necessary launching or
pre-configuration of our debug adapter.  It also allows us to create a
default launch configuration on the fly if one doesn't already exist.
This means that users can now debug the current script without a
launch.json either with or without a folder open!