### PR TITLE
Provide quick pick list of processes when using debugger attach configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
         "onLanguage:powershell",
         "onCommand:PowerShell.NewProjectFromTemplate",
         "onCommand:PowerShell.OpenExamplesFolder",
-        "onCommand:PowerShell.StartDebugSession"
+        "onCommand:PowerShell.StartDebugSession",
+        "onCommand:PowerShell.PickPSHostProcess"
     ],
     "dependencies": {
         "vscode-languageclient": "1.3.1"
@@ -164,6 +165,9 @@
                 },
                 "program": "./out/debugAdapter.js",
                 "runtime": "node",
+                "variables": {
+                    "PickPSHostProcess": "PowerShell.PickPSHostProcess"
+                },
                 "languages": ["powershell"],
                 "startSessionCommand": "PowerShell.StartDebugSession",
                 "configurationSnippets": [
@@ -198,8 +202,8 @@
                             "type": "PowerShell",
                             "request": "attach",
                             "name": "PowerShell Attach to Process",
-                            "processId": "${ProcessId}",
-                            "runspaceId": "1"
+                            "processId": "^\"\\${command.PickPSHostProcess}\"",
+                            "runspaceId": 1
                         }
                     },
                     {
@@ -246,8 +250,9 @@
                                 "description": "Optional: The computer name to which a remote session will be established.  Works only on PowerShell 4 and above."
                             },
                             "processId": {
-                                "type": "number",
-                                "description": "The ID of the process to be attached.  Works only on PowerShell 5 and above."
+                                "type": "string",
+                                "description": "Id of PowerShell host process to attach to.  Works only on PowerShell 5 and above.",
+                                "default": "${command.PickPSHostProcess}"
                             },
                             "runspaceId": {
                                 "type": "number",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -4,7 +4,7 @@
 
 import vscode = require('vscode');
 import { IFeature } from '../feature';
-import { LanguageClient } from 'vscode-languageclient';
+import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
 
 export class DebugSessionFeature implements IFeature {
     private command: vscode.Disposable;
@@ -39,5 +39,110 @@ export class DebugSessionFeature implements IFeature {
         }
 
         vscode.commands.executeCommand('vscode.startDebug', config);
+    }
+}
+
+interface ProcessItem extends vscode.QuickPickItem {
+	pid: string;	// payload for the QuickPick UI
+}
+
+interface PSHostProcessInfo {
+    processName: string;
+    processId: string;
+    appDomainName: string;
+    mainWindowTitle: string;
+}
+
+namespace GetPSHostProcessesRequest {
+    export const type: RequestType<any, GetPSHostProcessesResponseBody, string> =
+        { get method() { return 'powerShell/getPSHostProcesses'; } };
+}
+
+interface GetPSHostProcessesResponseBody {
+    hostProcesses: PSHostProcessInfo[];
+}
+
+export class PickPSHostProcessFeature implements IFeature {
+
+    private command: vscode.Disposable;
+    private languageClient: LanguageClient;
+    private waitingForClientToken: vscode.CancellationTokenSource;
+
+    constructor() {
+        this.command =
+            vscode.commands.registerCommand('PowerShell.PickPSHostProcess', () => {
+
+                if (!this.languageClient && !this.waitingForClientToken) {
+
+                    // If PowerShell isn't finished loading yet, show a loading message
+                    // until the LanguageClient is passed on to us
+                    this.waitingForClientToken = new vscode.CancellationTokenSource();
+                    vscode.window
+                        .showQuickPick(
+                            ["Cancel"],
+                            { placeHolder: "Select PowerShell Host Process to attach to: Please wait, starting PowerShell..." },
+                            this.waitingForClientToken.token)
+                        .then(response => { if (response === "Cancel") { this.clearWaitingToken(); } });
+
+                    // Cancel the loading prompt after 60 seconds
+                    setTimeout(() => {
+                            if (this.waitingForClientToken) {
+                                this.clearWaitingToken();
+
+                                vscode.window.showErrorMessage(
+                                    "Select PowerShell Host Process to attach to: PowerShell session took too long to start.");
+                            }
+                        }, 60000);
+                }
+                else {
+                    return this.pickPSHostProcess();
+                }
+            });
+    }
+
+    public setLanguageClient(languageClient: LanguageClient) {
+        this.languageClient = languageClient;
+
+        if (this.waitingForClientToken) {
+            this.clearWaitingToken();
+            return this.pickPSHostProcess();
+        }
+    }
+
+    public dispose() {
+        this.command.dispose();
+    }
+
+    // In node, the function returned a Promise<string> not sure about "Thenable<string>"
+	private pickPSHostProcess(): Thenable<string> {
+		return this.languageClient.sendRequest(GetPSHostProcessesRequest.type, null).then(hostProcesses => {
+			var items: ProcessItem[] = [];
+
+			for(var p in hostProcesses) {
+				items.push({
+					label: hostProcesses[p].processName,
+                    description: hostProcesses[p].processId.toString(),
+					detail: hostProcesses[p].mainWindowTitle,
+					pid: hostProcesses[p].processId
+				 });
+			};
+
+			let options : vscode.QuickPickOptions = {
+				placeHolder: "Select a PowerShell Host process to attach to",
+				matchOnDescription: true,
+				matchOnDetail: true
+			};
+
+			return vscode.window.showQuickPick(items, options).then(item => {
+				return item ? item.pid : null;
+			});
+		});
+	}
+
+    private clearWaitingToken() {
+        if (this.waitingForClientToken) {
+            this.waitingForClientToken.dispose();
+            this.waitingForClientToken = undefined;
+        }
     }
 }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -127,15 +127,23 @@ export class PickPSHostProcessFeature implements IFeature {
 				 });
 			};
 
-			let options : vscode.QuickPickOptions = {
-				placeHolder: "Select a PowerShell Host process to attach to",
-				matchOnDescription: true,
-				matchOnDetail: true
-			};
+            if (items.length === 0) {
+                return vscode.window.showInformationMessage(
+                    "There are no other PowerShell host processes to attach to.").then(_ => {
+                        return null;
+                    });
+            }
+            else {
+                let options : vscode.QuickPickOptions = {
+                    placeHolder: "Select a PowerShell Host process to attach to",
+                    matchOnDescription: true,
+                    matchOnDetail: true
+                };
 
-			return vscode.window.showQuickPick(items, options).then(item => {
-				return item ? item.pid : null;
-			});
+                return vscode.window.showQuickPick(items, options).then(item => {
+                    return item ? item.pid : null;
+                });
+            }
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { ExpandAliasFeature } from './features/ExpandAlias';
 import { ShowHelpFeature } from './features/ShowOnlineHelp';
 import { CodeActionsFeature } from './features/CodeActions';
 import { DebugSessionFeature } from './features/DebugSession';
+import { PickPSHostProcessFeature } from './features/DebugSession';
 import { SelectPSSARulesFeature } from './features/SelectPSSARules';
 import { FindModuleFeature } from './features/PowerShellFindModule';
 import { NewFileOrProjectFeature } from './features/NewFileOrProject';
@@ -103,7 +104,8 @@ export function activate(context: vscode.ExtensionContext): void {
         new SelectPSSARulesFeature(),
         new CodeActionsFeature(),
         new NewFileOrProjectFeature(),
-        new DebugSessionFeature()
+        new DebugSessionFeature(),
+        new PickPSHostProcessFeature()
     ];
 
     sessionManager =


### PR DESCRIPTION
This needs **serious review/tweaking** as Type/JavaScript is not my forte.  For instance, the node code (and this) returns null when the user doesn't select anything.   In that case, the debugger still tries to do something.  

FWIW it won't break my heart if this doesn't make 0.9.0.  That said, I'm hoping that with your understand of the VSCode side of the extension, this can be fixed to work better.  :-)