### PR TITLE
Add "remote files" feature that handles files from remote sessions

### DIFF
--- a/src/features/RemoteFiles.ts
+++ b/src/features/RemoteFiles.ts
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import os = require('os');
+import path = require('path');
+import vscode = require('vscode');
+import { IFeature } from '../feature';
+import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
+
+export class RemoteFilesFeature implements IFeature {
+
+    private tempSessionPathPrefix: string;
+
+    constructor() {
+        // Get the common PowerShell Editor Services temporary file path
+        // so that remote files from previous sessions can be closed.
+        this.tempSessionPathPrefix =
+            path.join(os.tmpdir(), 'PSES-')
+                .toLowerCase();
+
+        // At startup, close any lingering temporary remote files
+        this.closeRemoteFiles();
+
+        // TEMPORARY: Register for the onDidSave event so that we can alert
+        // the user when they attempt to save a remote file.  We don't
+        // currently propagate saved content back to the remote session.
+        vscode.workspace.onDidSaveTextDocument(doc => {
+            if (this.isDocumentRemote(doc)) {
+                vscode.window.showWarningMessage(
+                    "Changes to remote files are not yet saved back in the remote session, coming in 0.10.0.");
+            }
+        })
+    }
+
+    public setLanguageClient(languageclient: LanguageClient) {
+    }
+
+    public dispose() {
+        // Close any leftover remote files before exiting
+        this.closeRemoteFiles();
+    }
+
+    private isDocumentRemote(doc: vscode.TextDocument) {
+        return doc.languageId === "powershell" &&
+               doc.fileName.toLowerCase().startsWith(this.tempSessionPathPrefix);
+    }
+
+    private closeRemoteFiles() {
+        var remoteDocuments =
+            vscode.workspace.textDocuments.filter(
+                doc => this.isDocumentRemote(doc));
+
+        function innerCloseFiles(): Thenable<{}> {
+            if (remoteDocuments.length > 0) {
+                var doc = remoteDocuments.pop();
+
+                return vscode.window
+                    .showTextDocument(doc)
+                    .then(editor => vscode.commands.executeCommand("workbench.action.closeActiveEditor"))
+                    .then(_ => innerCloseFiles());
+            }
+        };
+
+        innerCloseFiles();
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { OpenInISEFeature } from './features/OpenInISE';
 import { ExpandAliasFeature } from './features/ExpandAlias';
 import { ShowHelpFeature } from './features/ShowOnlineHelp';
 import { CodeActionsFeature } from './features/CodeActions';
+import { RemoteFilesFeature } from './features/RemoteFiles';
 import { DebugSessionFeature } from './features/DebugSession';
 import { PickPSHostProcessFeature } from './features/DebugSession';
 import { SelectPSSARulesFeature } from './features/SelectPSSARules';
@@ -106,6 +107,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new CodeActionsFeature(),
         new NewFileOrProjectFeature(),
         new DocumentFormatterFeature(),
+        new RemoteFilesFeature(),
         new DebugSessionFeature(),
         new PickPSHostProcessFeature()
     ];


### PR DESCRIPTION
This change adds a new remote files feature which basically just handles
the cleanup of remote session files when the extension is loaded or
unloaded.  This is to ensure that the user doesn't accidentally edit a
locally cached remote file thinking it is their local copy.  It also shows
a warning to the user when they save changes to a remote file because we
currently don't propagate those changes back to the remote session.