### PR TITLE
Add setting to enable use of Windows PowerShell developer builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,6 +316,11 @@
                     "default": "",
                     "description": "Specifies the full path to a PowerShell executable.  Used to change the installation of PowerShell used for language and debugging services."
                 },
+                "powershell.developer.powerShellExeIsWindowsDevBuild": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, indicates that the powerShellExePath points to a developer build of Windows PowerShell and should be configured appropriately."
+                },
                 "powershell.developer.bundledModulesPath": {
                     "type": "string",
                     "default": "../modules/",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export interface IDeveloperSettings {
     bundledModulesPath?: string;
     editorServicesLogLevel?: string;
     editorServicesWaitForDebugger?: boolean;
+    powerShellExeIsWindowsDevBuild?: boolean;
 }
 
 export interface ISettings {
@@ -43,7 +44,8 @@ export function load(myPluginId: string): ISettings {
         powerShellExePath: undefined,
         bundledModulesPath: "../modules/",
         editorServicesLogLevel: "Normal",
-        editorServicesWaitForDebugger: false
+        editorServicesWaitForDebugger: false,
+        powerShellExeIsWindowsDevBuild: false
     };
 
     let defaultCodeFormattingSettings: ICodeFormattingSettings = {


### PR DESCRIPTION
This change adds a new setting called
"powershell.developer.powerShellExeIsWindowsDevBuild" which identifies
that the specified powerShellExePath refers to a developer build of
Windows PowerShell.  This is needed because an environment variable needs
to be set before using such a build with the PowerShell extension.