### PR TITLE
Improve "Attach to Host Process" menu flow

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -67,48 +67,14 @@ export class PickPSHostProcessFeature implements IFeature {
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
     private waitingForClientToken: vscode.CancellationTokenSource;
+    private getLanguageClientResolve: (value?: LanguageClient | Thenable<LanguageClient>) => void;
 
     constructor() {
+
         this.command =
             vscode.commands.registerCommand('PowerShell.PickPSHostProcess', () => {
-
-                if (!this.languageClient && !this.waitingForClientToken) {
-                    return new Promise<string>((resolve, reject) => {
-                        reject("PowerShell has not fully initialized.  Try to attach again after PowerShell has been initialized.");
-                    });
-
-                    // // If PowerShell isn't finished loading yet, show a loading message
-                    // // until the LanguageClient is passed on to us
-                    // var cancelled = false;
-                    // var timedOut = false;
-                    // this.waitingForClientToken = new vscode.CancellationTokenSource();
-
-                    // vscode.window
-                    //     .showQuickPick(
-                    //         ["Cancel"],
-                    //         { placeHolder: "Attach to PowerShell host process: Please wait, starting PowerShell..." },
-                    //         this.waitingForClientToken.token)
-                    //     .then(response => {
-                    //         if (response === "Cancel") {
-                    //             this.clearWaitingToken();
-                    //         }
-                    //     });
-
-                    // // Cancel the loading prompt after 60 seconds
-                    // setTimeout(() => {
-                    //         if (this.waitingForClientToken) {
-                    //             this.clearWaitingToken();
-
-                    //             vscode.window.showErrorMessage(
-                    //                 "Attach to PowerShell host process: PowerShell session took too long to start.");
-                    //         }
-                    //     }, 60000);
-
-                    // // Wait w/timeout on language client to be initialized and then return this.pickPSHostProcess;
-                }
-                else {
-                    return this.pickPSHostProcess();
-                }
+                return this.getLanguageClient()
+                           .then(_ => this.pickPSHostProcess(), _ => undefined);
             });
     }
 
@@ -116,8 +82,8 @@ export class PickPSHostProcessFeature implements IFeature {
         this.languageClient = languageClient;
 
         if (this.waitingForClientToken) {
+            this.getLanguageClientResolve(this.languageClient);
             this.clearWaitingToken();
-            // Signal language client initialized
         }
     }
 
@@ -125,35 +91,75 @@ export class PickPSHostProcessFeature implements IFeature {
         this.command.dispose();
     }
 
-    // In node, the function returned a Promise<string> not sure about "Thenable<string>"
-	private pickPSHostProcess(): Promise<string> {
-        return new Promise((resolve, reject) => {
-            this.languageClient.sendRequest(GetPSHostProcessesRequest.type, null).then(hostProcesses => {
-                var items: ProcessItem[] = [];
+    private getLanguageClient(): Thenable<LanguageClient> {
+        if (this.languageClient) {
+            return Promise.resolve(this.languageClient);
+        }
+        else {
+            // If PowerShell isn't finished loading yet, show a loading message
+            // until the LanguageClient is passed on to us
+            this.waitingForClientToken = new vscode.CancellationTokenSource();
 
-                for(var p in hostProcesses) {
-                    items.push({
-                        label: hostProcesses[p].processName,
-                        description: hostProcesses[p].processId.toString(),
-                        detail: hostProcesses[p].mainWindowTitle,
-                        pid: hostProcesses[p].processId
-                    });
-                };
+            return new Promise<LanguageClient>(
+                (resolve, reject) => {
+                    this.getLanguageClientResolve = resolve;
 
-                if (items.length === 0) {
-                    reject("There are no PowerShell host processes to attach to.");
+                    vscode.window
+                        .showQuickPick(
+                            ["Cancel"],
+                            { placeHolder: "Attach to PowerShell host process: Please wait, starting PowerShell..." },
+                            this.waitingForClientToken.token)
+                        .then(response => {
+                            if (response === "Cancel") {
+                                this.clearWaitingToken();
+                                reject();
+                            }
+                        });
+
+                    // Cancel the loading prompt after 60 seconds
+                    setTimeout(() => {
+                            if (this.waitingForClientToken) {
+                                this.clearWaitingToken();
+                                reject();
+
+                                vscode.window.showErrorMessage(
+                                    "Attach to PowerShell host process: PowerShell session took too long to start.");
+                            }
+                        }, 60000);
                 }
-                else {
-                    let options : vscode.QuickPickOptions = {
-                        placeHolder: "Select a PowerShell host process to attach to",
-                        matchOnDescription: true,
-                        matchOnDetail: true
-                    };
+            );
+        }
+    }
 
-                    return vscode.window.showQuickPick(items, options).then(item => {
-                        resolve(item ? item.pid : "");
-                    });
+	private pickPSHostProcess(): Thenable<string> {
+        return this.languageClient.sendRequest(GetPSHostProcessesRequest.type, null).then(hostProcesses => {
+            var items: ProcessItem[] = [];
+
+            for (var p in hostProcesses) {
+                var windowTitle = "";
+                if (hostProcesses[p].mainWindowTitle) {
+                    windowTitle = `, Title: ${hostProcesses[p].mainWindowTitle}`;
                 }
+
+                items.push({
+                    label: hostProcesses[p].processName,
+                    description: `PID: ${hostProcesses[p].processId.toString()}${windowTitle}`,
+                    pid: hostProcesses[p].processId
+                });
+            };
+
+            if (items.length === 0) {
+                return Promise.reject("There are no PowerShell host processes to attach to.");
+            }
+
+            let options : vscode.QuickPickOptions = {
+                placeHolder: "Select a PowerShell host process to attach to",
+                matchOnDescription: true,
+                matchOnDetail: true
+            };
+
+            return vscode.window.showQuickPick(items, options).then(item => {
+                return item ? item.pid : "";
             });
         });
 	}


### PR DESCRIPTION
This change improves the flow of the "Attach to Host Process" menu when
the language service hasn't started yet.  It also changes the text display
slightly.

Here's a screenshot of the updated menu items:

![image](https://cloud.githubusercontent.com/assets/79405/22081037/c205e516-dd76-11e6-834a-66f4c38e181d.png)
