### PR TITLE
Fix typo in PowerShell.json

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -14,7 +14,7 @@
           "",
           "\tGUID = '<pasteNewGUIDhere>'",
           "",
-          "\tCopyright = '2017 ${company:Copyright Holder}",
+          "\tCopyright = '2017 ${company:Copyright Holder}'",
           "",
           "\tDescription = '${Description:What does this module do?}'",
           "",


### PR DESCRIPTION
Noticed the value for Copyright in the Manifest snippet was missing a closing single quote. This fixes it.