### PR TITLE
First phase of streamlined development setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outDir": "${workspaceRoot}/out",
-			"preLaunchTask": "compile"
+			"preLaunchTask": "Build"
 		},
 		{
 			"name": "Attach",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,7 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-	// Controls the rendering size of tabs in characters. Accepted values: "auto", 2, 4, 6, etc. If set to "auto", the value will be guessed when a file is opened.
-	"editor.tabSize": 4,
-
-	// Controls if the editor will insert spaces for tabs. Accepted values:  "auto", true, false. If set to "auto", the value will be guessed when a file is opened.
-	"editor.insertSpaces": true,
-
-	// When enabled, will trim trailing whitespace when you save a file.
+    "editor.tabSize": 4,
+    "editor.insertSpaces": true,
     "files.trimTrailingWhitespace": true,
 
     // Lock the TypeScript SDK path to the version we use

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,55 +1,38 @@
-// Available variables which can be used inside of strings.
-// ${workspaceRoot}: the root folder of the team
-// ${file}: the current opened file
-// ${fileBasename}: the current opened file's basename
-// ${fileDirname}: the current opened file's dirname
-// ${fileExtname}: the current opened file's extension
-// ${cwd}: the current working directory of the spawned process
-
-// A task runner that calls a custom npm script that compiles the extension.
 {
-	"version": "0.1.0",
+    "version": "0.1.0",
 
-	// we want to run npm
-	"command": "npm",
+    "windows": {
+        "command": "${env.windir}\\sysnative\\windowspowershell\\v1.0\\PowerShell.exe",
+        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
+    },
+    "linux": {
+        "command": "/usr/bin/powershell",
+        "args": [ "-NoProfile" ]
+    },
+    "osx": {
+        "command": "/usr/local/bin/powershell",
+        "args": [ "-NoProfile" ]
+    },
 
-	// the command is a shell script
-	"isShellCommand": true,
+    "isShellCommand": true,
+    "showOutput": "always",
 
     "tasks": [
         {
-            "taskName": "install",
-            "showOutput": "always"
+            "taskName": "Install",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build Restore" ]
         },
         {
-            "taskName": "compile",
+            "taskName": "Clean",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build Clean" ]
+        },
+        {
+            "taskName": "Build",
+            "suppressTaskName": true,
             "isBuildCommand": true,
-            "suppressTaskName": true,
-
-            // show the output window only if unrecognized errors occur.
-            "showOutput": "silent",
-
-            // we run the custom script "compile" as defined in package.json
-            "args": ["run", "compile"],
-
-            // use the standard tsc problem matcher to find compile problems in the output.
-            "problemMatcher": "$tsc"
-        },
-        {
-            "taskName": "compile-watch",
-            "suppressTaskName": true,
-
-            // show the output window only if unrecognized errors occur.
-            "showOutput": "silent",
-
-            // we run the custom script "compile-watch" as defined in package.json
-            "args": ["run", "compile-watch"],
-
-            // The tsc compiler is started in watching mode
-            "isWatching": true,
-
-            // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-            "problemMatcher": "$tsc-watch"
+            "args": [ "Invoke-Build Build" ]
         }
     ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+vscode-powershell.build.ps1
 typings/**
 **/*.ts
 .gitignore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: '0.9.0.{build}'
+image: Visual Studio 2017 RC
+clone_depth: 10
+skip_tags: true
+
+branches:
+  only:
+  - master
+  - develop
+
+install:
+  - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
+  - ps: |
+      Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+      Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force | Out-Null
+
+build_script:
+  - ps: Invoke-Build Build
+
+# The build script takes care of the tests
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ branches:
 
 install:
   - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
+  - ps: Install-Product node '6.9.2'
   - ps: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
       Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force | Out-Null

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ to before you can proceed.
 
 ### 4. Install [Visual Studio Code Insiders Release](https://code.visualstudio.com/insiders)
 
-### 5. Install [Node.js](https://nodejs.org/en/) 4.4.1 or higher.
+### 5. Install [Node.js](https://nodejs.org/en/) 6.0.0 or higher.
 
 ## Building the Code
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,52 +1,43 @@
-# Working with the PowerShell extension code
+# Development Instructions for the PowerShell Extension
 
-## Building the code
+## Development Setup
 
-1. Install [Node.js](https://nodejs.org/en/) 4.4.1 or higher.
+You'll need to clone two repositories and set up your development environment
+to before you can proceed.
 
-2. Install the package dependencies by running one of the following commands:
+### 1. [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [vscode-powershell repository](https://github.com/PowerShell/vscode-powershell)
 
-   ```
-   # From a PowerShell prompt
-   npm install
+### 2. [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [PowerShell Editor Services repository](https://github.com/PowerShell/PowerShellEditorServices)
 
-   # Or from Visual Studio Code
-   Press Ctrl+P and type "task install"
-   ```
+### 3. Follow the [development instructions](https://github.com/PowerShell/PowerShellEditorServices#development) for PowerShell Editor Services
 
-3. Compile the code by running one of the following commands:
+### 4. Install [Visual Studio Code Insiders Release](https://code.visualstudio.com/insiders)
 
-   ```
-   # From a PowerShell prompt
-   npm run compile
+### 5. Install [Node.js](https://nodejs.org/en/) 4.4.1 or higher.
 
-   # Or from Visual Studio Code
-   Press Ctrl+P and type "task compile"
-   ```
-   This will compile the TypeScript files in the project to JavaScript files.
+## Building the Code
 
-   OR
+#### From Visual Studio Code:
 
-   You can compile the files and then have the TypeScript compiler watch for changes to
-   the source files and automatically recompile those files when changes are saved.
-   To do this, run one of the following commands:
+Press <kbd>Ctrl+P</kbd> and type `task build`
 
-   ```
-   # From a PowerShell prompt
-   npm run compile-watch
+This will compile the TypeScript files in the project to JavaScript files.
 
-   # Or from Visual Studio Code
-   Press Ctrl+P and type "task compile-watch"
-   ```
+#### From a command prompt:
 
-## Running the compiled code
+```
+Invoke-Build Build
+```
 
-1. From a PowerShell prompt, run the following command:
+## Launching the extension
 
-   ```
-   code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
-   ```
+#### From Visual Studio Code:
 
-2. If you allow the compiler to continue watching for file changes, you can use
-   the `Reload Window` command found in the command palette `(Ctrl+Shift+P)`
-   so that the new source files are loaded.
+To debug the extension, press <kbd>F5</kbd>.  To run the extension without debugging,
+press <kbd>Ctrl+F5</kbd> or <kbd>Cmd+F5</kbd> on macOS.
+
+#### From a command prompt:
+
+```
+code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
+```

--- a/package.json
+++ b/package.json
@@ -323,7 +323,6 @@
                 },
                 "powershell.developer.bundledModulesPath": {
                     "type": "string",
-                    "default": "../modules/",
                     "description": "Specifies the path to the folder containing modules that are bundled with the PowerShell extension (i.e. PowerShell Editor Services, PowerShell Script Analyzer, Plaster)"
                 },
                 "powershell.developer.editorServicesLogLevel": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,7 @@ export function load(myPluginId: string): ISettings {
 
     let defaultDeveloperSettings: IDeveloperSettings = {
         powerShellExePath: undefined,
-        bundledModulesPath: "../modules/",
+        bundledModulesPath: undefined,
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false,
         powerShellExeIsWindowsDevBuild: false

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -1,0 +1,59 @@
+#
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+#
+
+param(
+    [string]$EditorServicesRepoPath = $null
+)
+
+#Requires -Modules @{ModuleName="InvokeBuild";ModuleVersion="3.2.1"}
+
+task ResolveEditorServicesPath -Before Clean, Build {
+    $script:psesRepoPath = `
+        if ($EditorServicesRepoPath) {
+            $EditorServicesRepoPath
+        }
+        else {
+            "$PSScriptRoot/../PowerShellEditorServices/"
+        }
+
+    if (!(Test-Path $script:psesRepoPath)) {
+        # Clear the path so that it won't be used
+        Write-Host "`n### WARNING: The PowerShellEditorServices repo cannot be found at path $script:psesRepoPath`n" -ForegroundColor Yellow
+        $script:psesRepoPath = $null
+    }
+    else {
+        $script:psesRepoPath = Resolve-Path $script:psesRepoPath
+        $script:psesBuildScriptPath = Resolve-Path "$script:psesRepoPath/PowerShellEditorServices.build.ps1"
+    }
+}
+
+task Restore -If { "Restore" -in $BuildTasks -or !(Test-Path "./node_modules") } -Before Build {
+    Write-Host "`n### Restoring vscode-powershell dependencies, this could take a while`n" -ForegroundColor Green
+    exec { & npm install }
+}
+
+task Clean {
+    if ($script:psesBuildScriptPath) {
+        Write-Host "`n### Cleaning PowerShellEditorServices`n" -ForegroundColor Green
+        Invoke-Build Clean $script:psesBuildScriptPath
+    }
+
+    Write-Host "`n### Cleaning vscode-powershell`n" -ForegroundColor Green
+    Remove-Item .\out -Recurse -Force -ErrorAction Ignore
+}
+
+task Build {
+
+    # If the PSES codebase is co-located, build it first
+    if ($script:psesBuildScriptPath) {
+        Write-Host "`n### Building PowerShellEditorServices`n" -ForegroundColor Green
+        Invoke-Build BuildHost $script:psesBuildScriptPath
+    }
+
+    Write-Host "`n### Building vscode-powershell" -ForegroundColor Green
+    exec { & npm run compile }
+}
+
+task . Clean, Build

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -29,9 +29,13 @@ task ResolveEditorServicesPath -Before Clean, Build {
     }
 }
 
-task Restore -If { "Restore" -in $BuildTasks -or !(Test-Path "./node_modules") } -Before Build {
-    Write-Host "`n### Restoring vscode-powershell dependencies, this could take a while`n" -ForegroundColor Green
-    exec { & npm install }
+task Restore -If { "Restore" -in $BuildTask -or !(Test-Path "./node_modules") } -Before Build {
+    Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
+
+    # When in a CI build use the --loglevel=error parameter so that
+    # package install warnings don't cause PowerShell to throw up
+    $logLevelParam = if ($env:AppVeyor) { "--loglevel=error" } else { "" }
+    exec { & npm install $logLevelParam }
 }
 
 task Clean {


### PR DESCRIPTION
As detailed in #456, I'd like to streamline the development process for the PowerShell extension so that its easier for others to contribute.  This change establishes a new build script which can compile both the extension code and PowerShell Editor Services so that all development can be done inside of VS Code.  This development setup should work across Windows, Linux, and macOS.

Before merging I'm going to make sure that I can pull the changes for both this PR and PowerShell/PowerShellEditorServices#351 and build everything from scratch just by hitting F5, both on Windows and Ubuntu 16.04.