### PR TITLE
Fixes some issues with code formatter

### DIFF
--- a/src/features/DocumentFormatter.ts
+++ b/src/features/DocumentFormatter.ts
@@ -4,7 +4,6 @@
 
 import vscode = require('vscode');
 import {
-    languages,
     TextDocument,
     TextEdit,
     FormattingOptions,
@@ -13,7 +12,7 @@ import {
     DocumentRangeFormattingEditProvider,
     Range,
 } from 'vscode';
-import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
+import { LanguageClient, RequestType } from 'vscode-languageclient';
 import Window = vscode.window;
 import { IFeature } from '../feature';
 import * as Settings from '../settings';


### PR DESCRIPTION
Fixes the following issues:
* If the user switches the active editor when code formatter is running, the formatter can write to the new active editor.
* If the user executes "format document" on a document when the document is already being formatted, the extension creates a redundant request for formatting the same document. 
* If for any reason PSES crashes, then the formatting status is not cleaned up from the status bar.