### PR TITLE
Add params to DebugTest.ps1.

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -4,7 +4,16 @@
         {
             "type": "PowerShell",
             "request": "launch",
-            "name": "PowerShell Interactive Session"
+            "name": "PowerShell Launch (DebugTest.ps1)",
+            "script": "${workspaceRoot}/DebugTest.ps1",
+            "args": ["-Count 42 -DelayMilliseconds 1500"],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Interactive Session",
+            "cwd": "${workspaceRoot}"
         },
         {
             "type": "PowerShell",

--- a/examples/DebugTest.ps1
+++ b/examples/DebugTest.ps1
@@ -1,3 +1,5 @@
+param([int]$Count=50, [int]$DelayMilliseconds=200)
+
 function Write-Item($itemCount) {
     $i = 1
 
@@ -10,7 +12,7 @@ function Write-Item($itemCount) {
         $i = $i + 1
 
         # Slow down execution a bit so user can test the "Pause debugger" feature.
-        Start-Sleep -Milliseconds 200
+        Start-Sleep -Milliseconds $DelayMilliseconds
     }
 }
 
@@ -23,4 +25,6 @@ function Do-Work($workCount) {
     Write-Host "Done!"
 }
 
-Do-Work 50
+$process = Get-Process -Id $pid
+
+Do-Work $Count

--- a/examples/DebugTest.ps1
+++ b/examples/DebugTest.ps1
@@ -25,6 +25,4 @@ function Do-Work($workCount) {
     Write-Host "Done!"
 }
 
-$process = Get-Process -Id $pid
-
 Do-Work $Count


### PR DESCRIPTION
This will align with part 2 of my debugging blog post for Scripting Guys.  This allows testing of launch  config that passes arguments and makes it easier to demo "attach to" but setting the delay a bit longer (say 2 secs).  Also, updated  launch.json to start with the default configuration before add tle Launch Script Configuration.