### PR TITLE
Update dbg config snippets to be consistent w/node

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -4,9 +4,17 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "PowerShell Launch (current file)",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}"
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "PowerShell Launch (DebugTest.ps1)",
             "script": "${workspaceRoot}/DebugTest.ps1",
-            "args": ["-Count 42 -DelayMilliseconds 1500"],
+            "args": ["-Count 55 -DelayMilliseconds 250"],
             "cwd": "${workspaceRoot}"
         },
         {
@@ -14,14 +22,6 @@
             "request": "launch",
             "name": "PowerShell Interactive Session",
             "cwd": "${workspaceRoot}"
-        },
-        {
-            "type": "PowerShell",
-            "request": "launch",
-            "name": "PowerShell Launch (current file)",
-            "script": "${file}",
-            "args": [],
-            "cwd": "${file}"
         },
         {
             "type": "PowerShell",

--- a/package.json
+++ b/package.json
@@ -174,8 +174,8 @@
         "startSessionCommand": "PowerShell.StartDebugSession",
         "configurationSnippets": [
           {
-            "label": "PowerShell: Launch Current Script Configuration",
-            "description": "A new configuration for launching the current opened PowerShell script",
+            "label": "PowerShell: Launch (current file)",
+            "description": "Launch current file (in active editor window) under debugger",
             "body": {
               "type": "PowerShell",
               "request": "launch",
@@ -186,8 +186,8 @@
             }
           },
           {
-            "label": "PowerShell: Launch Script Configuration",
-            "description": "A new configuration for launching a PowerShell script",
+            "label": "PowerShell: Launch Script",
+            "description": "Launch specified script under debugger",
             "body": {
               "type": "PowerShell",
               "request": "launch",
@@ -198,8 +198,8 @@
             }
           },
           {
-            "label": "PowerShell: Attach to PowerShell Host Process Configuration",
-            "description": "A new configuration for debugging a runspace in another host process.",
+            "label": "PowerShell: Attach to PowerShell Host Process",
+            "description": "Open host process picker to select process to attach debugger to",
             "body": {
               "type": "PowerShell",
               "request": "attach",
@@ -209,8 +209,8 @@
             }
           },
           {
-            "label": "PowerShell: Launch Interactive Session Configuration",
-            "description": "A new configuration for debugging an interactive session.",
+            "label": "PowerShell: Interactive Session",
+            "description": "Start interactive session (Debug Console) under debugger",
             "body": {
               "type": "PowerShell",
               "request": "launch",


### PR DESCRIPTION
The branch name is a misnomer now.  This does not add Pester tests to the dbg config snippets.  Also, set the examples launch.json, DebugTests.ps1 config to use better args.