### PR TITLE
Add debug configuration for Pester tests.

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -25,6 +25,14 @@
         },
         {
             "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Pester Tests",
+            "script": "Invoke-Pester",
+            "args": [],
+            "cwd": "${workspaceRoot}"
+        },
+        {
+            "type": "PowerShell",
             "request": "attach",
             "name": "PowerShell Attach to Host Process",
             "processId": "${command.PickPSHostProcess}",

--- a/package.json
+++ b/package.json
@@ -198,6 +198,18 @@
             }
           },
           {
+            "label": "PowerShell: Pester Tests",
+            "description": "Invokes Pester tests under debugger",
+            "body": {
+              "type": "PowerShell",
+              "request": "launch",
+              "name": "PowerShell Pester Tests",
+              "script": "Invoke-Pester",
+              "args": [],
+              "cwd": "^\"\\${workspaceRoot}\""
+            }
+          },
+          {
             "label": "PowerShell: Attach to PowerShell Host Process",
             "description": "Open host process picker to select process to attach debugger to",
             "body": {


### PR DESCRIPTION
Fix #487.  Requires PSES PR 372.