### PR TITLE
Fix issue with VSCode var syntax change . to :

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,13 @@
 			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outDir": "${workspaceRoot}/out",
+			"outFiles": ["${workspaceRoot}/out"],
 			"preLaunchTask": "Build"
 		},
 		{
 			"name": "Attach",
 			"type": "node",
+			"request": "attach",
 			"address": "localhost",
 			"port": 5858,
 			"sourceMaps": false

--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -35,7 +35,7 @@
             "type": "PowerShell",
             "request": "attach",
             "name": "PowerShell Attach to Host Process",
-            "processId": "${command.PickPSHostProcess}",
+            "processId": "${command:PickPSHostProcess}",
             "runspaceId": 1
         }
     ]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.7.0"
+    "vscode": "^1.10.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
@@ -216,7 +216,7 @@
               "type": "PowerShell",
               "request": "attach",
               "name": "PowerShell Attach to Host Process",
-              "processId": "^\"\\${command.PickPSHostProcess}\"",
+              "processId": "^\"\\${command:PickPSHostProcess}\"",
               "runspaceId": 1
             }
           },
@@ -266,7 +266,7 @@
               "processId": {
                 "type": "string",
                 "description": "The process id of the PowerShell host process to attach to.  Works only on PowerShell 5 and above.",
-                "default": "${command.PickPSHostProcess}"
+                "default": "${command:PickPSHostProcess}"
               },
               "runspaceId": {
                 "type": "number",
@@ -289,7 +289,7 @@
             "type": "PowerShell",
             "request": "attach",
             "name": "PowerShell Attach to Host Process",
-            "processId": "${command.PickPSHostProcess}",
+            "processId": "${command:PickPSHostProcess}",
             "runspaceId": 1
           },
           {


### PR DESCRIPTION
BTW I'm not 100% sure about the need to require vscode 1.10.0. I've reached out to Andre (cc'd you) to see what alternatives we have.

Also replaced the deprecated OutDir setting with OutFiles in the extension's launch.json file.

FWIW I do get errors attaching to a PowerShell host process with VSCode 1.10 that I wasn't getting with 1.9 using 0.9.0 of the extension.