### PR TITLE
Add PowerShell interactive console

### DIFF
--- a/examples/PromptExamples.ps1
+++ b/examples/PromptExamples.ps1
@@ -1,10 +1,41 @@
+<# ------ Input Prompts ------ #>
 
-# Multi-choice prompt
+$fields = @(
+    New-Object "System.Management.Automation.Host.FieldDescription" "Input"
+    New-Object "System.Management.Automation.Host.FieldDescription" "Input List"
+)
+$fields[1].SetParameterType([int[]])
+
+$host.UI.Prompt("Caption", "Message", $fields)
+
+Get-Credential
+Get-Credential -Message "Test!"
+Get-Credential -UserName "myuser" -Message "Password stealer"
+
+$host.UI.PromptForCredential("Caption", "Message", $null, $null, [System.Management.Automation.PSCredentialTypes]::Default, [System.Management.Automation.PSCredentialUIOptions]::Default) 
+$host.UI.PromptForCredential("Caption", "Message", "testuser", $null, [System.Management.Automation.PSCredentialTypes]::Default, [System.Management.Automation.PSCredentialUIOptions]::Default) 
+
+Read-Host -AsSecureString
+Read-Host -Prompt "Enter a secure string" -AsSecureString
+
+$field = New-Object "System.Management.Automation.Host.FieldDescription" "SecureString"
+$field.SetParameterType([SecureString])
+$host.UI.Prompt("Caption", "Message", $field)
+
+$field = New-Object "System.Management.Automation.Host.FieldDescription" "PSCredential"
+$field.SetParameterType([PSCredential])
+$host.UI.Prompt("Caption", "Message", $field)
+
+<# ------ Choice Prompts ------ #>
+
 $choices = @(
     New-Object "System.Management.Automation.Host.ChoiceDescription" "&Apple", "Apple"
     New-Object "System.Management.Automation.Host.ChoiceDescription" "&Banana", "Banana"
     New-Object "System.Management.Automation.Host.ChoiceDescription" "&Orange", "Orange"
 )
 
-$defaults = [int[]]@(0, 2)
-$host.UI.PromptForChoice("Choose a fruit", "You may choose more than one", $choices, $defaults)
+# Single-choice prompt
+$host.UI.PromptForChoice("Choose a fruit", "You may choose one", $choices, 1)
+
+# Multi-choice prompt
+$host.UI.PromptForChoice("Choose a fruit", "You may choose more than one", $choices, [int[]]@(0, 2))

--- a/package.json
+++ b/package.json
@@ -134,8 +134,8 @@
         "category": "PowerShell"
       },
       {
-        "command": "PowerShell.ShowSessionOutput",
-        "title": "Show Session Output",
+        "command": "PowerShell.ShowSessionConsole",
+        "title": "Show Session Interactive Console",
         "category": "PowerShell"
       },
       {

--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -47,12 +47,27 @@ param(
     [ValidateSet("Normal", "Verbose", "Error")]
     $LogLevel,
 
+	[Parameter(Mandatory=$true)]
+	[ValidateNotNullOrEmpty()]
+	[string]
+	$SessionDetailsPath,
+
+    [switch]
+    $EnableConsoleRepl,
+
+    [string]
+    $DebugServiceOnly,
+
     [switch]
     $WaitForDebugger,
 
     [switch]
     $ConfirmInstall
 )
+
+function WriteSessionFile($sessionInfo) {
+    ConvertTo-Json -InputObject $sessionInfo -Compress | Set-Content -Force -Path "$SessionDetailsPath" -ErrorAction Stop
+}
 
 # Are we running in PowerShell 2 or earlier?
 if ($PSVersionTable.PSVersion.Major -le 2) {
@@ -63,7 +78,9 @@ if ($PSVersionTable.PSVersion.Major -le 2) {
     };
 
     # Notify the client that the services have started
-    Write-Output (ConvertTo-Json -InputObject $resultDetails -Compress)
+    WriteSessionFile $resultDetails
+
+    Write-Host "Unsupported PowerShell version $($PSVersionTable.PSVersion), language features are disabled.`n"
 
     exit 0;
 }
@@ -181,6 +198,8 @@ else {
 $languageServicePort = Get-AvailablePort
 $debugServicePort = Get-AvailablePort
 
+Write-Host "Starting PowerShell...`n" -ForegroundColor Blue
+
 # Create the Editor Services host
 $editorServicesHost =
     Start-EditorServicesHost `
@@ -192,6 +211,8 @@ $editorServicesHost =
         -LanguageServicePort $languageServicePort `
         -DebugServicePort $debugServicePort `
         -BundledModulesPath $BundledModulesPath `
+        -EnableConsoleRepl:$EnableConsoleRepl.IsPresent `
+        -DebugServiceOnly:$DebugServiceOnly.IsPresent `
         -WaitForDebugger:$WaitForDebugger.IsPresent
 
 # TODO: Verify that the service is started
@@ -204,7 +225,7 @@ $resultDetails = @{
 };
 
 # Notify the client that the services have started
-Write-Output (ConvertTo-Json -InputObject $resultDetails -Compress)
+WriteSessionFile $resultDetails
 
 try {
     # Wait for the host to complete execution before exiting

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -190,7 +190,6 @@ function onInputEntered(responseText: string): ShowInputPromptResponseBody {
 export class ConsoleFeature implements IFeature {
     private commands: vscode.Disposable[];
     private languageClient: LanguageClient;
-    private consoleChannel: vscode.OutputChannel;
 
     constructor() {
         this.commands = [
@@ -217,17 +216,10 @@ export class ConsoleFeature implements IFeature {
                     expression: editor.document.getText(selectionRange)
                 });
 
-                // Show the output window if it isn't already visible
-                this.consoleChannel.show(vscode.ViewColumn.Three);
-            }),
-
-            vscode.commands.registerCommand('PowerShell.ShowSessionOutput', () => {
-                // Show the output window if it isn't already visible
-                this.consoleChannel.show(vscode.ViewColumn.Three);
+                // Show the integrated console if it isn't already visible
+                vscode.commands.executeCommand("PowerShell.ShowSessionConsole");
             })
         ];
-
-        this.consoleChannel = vscode.window.createOutputChannel("PowerShell Output");
     }
 
     public setLanguageClient(languageClient: LanguageClient) {
@@ -240,14 +232,9 @@ export class ConsoleFeature implements IFeature {
         this.languageClient.onRequest(
             ShowInputPromptRequest.type,
             promptDetails => showInputPrompt(promptDetails, this.languageClient));
-
-        this.languageClient.onNotification(OutputNotification.type, (output) => {
-            this.consoleChannel.append(output.output);
-        });
     }
 
     public dispose() {
         this.commands.forEach(command => command.dispose());
-        this.consoleChannel.dispose();
     }
 }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -24,6 +24,7 @@ export class DebugSessionFeature implements IFeature {
     }
 
     private startDebugSession(config: any) {
+
         if (!config.request) {
             // No launch.json, create the default configuration
             config.type = 'PowerShell';
@@ -56,6 +57,13 @@ export class DebugSessionFeature implements IFeature {
                 }
             }
         }
+
+        // Prevent the Debug Console from opening
+        config.internalConsoleOptions = "neverOpen";
+
+        // Create or show the interactive console
+        // TODO #367: Check if "newSession" mode is configured
+        vscode.commands.executeCommand('PowerShell.ShowSessionConsole');
 
         vscode.commands.executeCommand('vscode.startDebug', config);
     }

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -79,7 +79,7 @@ task Build -Before Package {
     # If the PSES codebase is co-located, build it first
     if ($script:psesBuildScriptPath) {
         Write-Host "`n### Building PowerShellEditorServices`n" -ForegroundColor Green
-        Invoke-Build BuildHost $script:psesBuildScriptPath
+        Invoke-Build Build $script:psesBuildScriptPath
     }
 
     Write-Host "`n### Building vscode-powershell" -ForegroundColor Green


### PR DESCRIPTION
This change introduces a new terminal-based interactive console experience
in the PowerShell extension.  PowerShell Editor Services is now launched
through VS Code's interactive terminal UI so that it can serve REPL I/O
directly to the user.

This change also modifies the debugger integration such that the same
integrated terminal session is also used during script debugging.

Resolves #293.