### PR TITLE
Fix #532: DEVPATH env variable not being set for integrated console

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -284,15 +284,19 @@ export class SessionManager {
                 "-Command",
                 "& '" + startScriptPath + "' " + startArgs);
 
-            // Set DEVPATH environment variable if necessary
             if (isWindowsDevBuild) {
-                // The development build looks for this environment variable to
-                // know where to find its assemblies
-                process.env.DEVPATH = path.dirname(powerShellExePath);
-            }
-            else {
-                // It's safe to delete this variable even if it doesn't exist
-                delete process.env.DEVPATH;
+                // Windows PowerShell development builds need the DEVPATH environment
+                // variable set to the folder where development binaries are held
+
+                // NOTE: This batch file approach is needed temporarily until VS Code's
+                // createTerminal API gets an argument for setting environment variables
+                // on the launched process.
+                var batScriptPath = path.resolve(__dirname, '../sessions/powershell.bat');
+                fs.writeFileSync(
+                    batScriptPath,
+                    `@set DEVPATH=${path.dirname(powerShellExePath)}\r\n@${powerShellExePath} %*`);
+
+                powerShellExePath = batScriptPath;
             }
 
             // Make sure no old session file exists


### PR DESCRIPTION
This change adds a workaround for setting the DEVPATH environment variable
when launching the language server inside of the integrated terminal UI.
This environment variable needs to be set for Windows PowerShell
development builds but it currently can't because there's no API parameter
for passing along environment variables.  The workaround is to generate a
batch script which can set the environment variable before launching
PowerShell.