### PR TITLE
Add initial support for feature flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,6 +325,11 @@
           "default": "",
           "description": "Specifies the path to a PowerShell Script Analyzer settings file. Use either an absolute path (to override the default settings for all projects) or use a path relative to your workspace."
         },
+        "powershell.developer.featureFlags": {
+          "type": "array",
+          "default": [],
+          "description": "An array of strings used to enable experimental features in the PowerShell extension."
+        },
         "powershell.developer.powerShellExePath": {
           "type": "string",
           "default": "",

--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -58,6 +58,9 @@ param(
     [string]
     $DebugServiceOnly,
 
+    [string[]]
+    $FeatureFlags,
+
     [switch]
     $WaitForDebugger,
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -266,9 +266,15 @@ export class SessionManager {
 
             var editorServicesLogPath = this.log.getLogFilePath("EditorServices");
 
+            var featureFlags =
+                this.sessionSettings.developer.featureFlags !== undefined
+                ? this.sessionSettings.developer.featureFlags.map(f => `'${f}'`).join(', ')
+                : "";
+
             startArgs +=
-                "-LogPath '" + editorServicesLogPath + "' " +
-                "-SessionDetailsPath '" + utils.getSessionFilePath() + "' ";
+                `-LogPath '${editorServicesLogPath}' ` +
+                `-SessionDetailsPath '${utils.getSessionFilePath()}' ` +
+                `-FeatureFlags @(${featureFlags})`
 
             var powerShellArgs = [
                 "-NoProfile",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export interface IScriptAnalysisSettings {
 }
 
 export interface IDeveloperSettings {
+    featureFlags?: string[];
     powerShellExePath?: string;
     bundledModulesPath?: string;
     editorServicesLogLevel?: string;
@@ -47,6 +48,7 @@ export function load(myPluginId: string): ISettings {
     };
 
     let defaultDeveloperSettings: IDeveloperSettings = {
+        featureFlags: [],
         powerShellExePath: undefined,
         bundledModulesPath: undefined,
         editorServicesLogLevel: "Normal",


### PR DESCRIPTION
This change adds initial support for feature flags in the
extension so that we can enable new experimental features
conditionally while maintaining current behavior for most users.

This introduces a new setting:

`powershell.developer.featureFlags`