### PR TITLE
Update Issue Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -17,9 +17,10 @@ https://github.com/PowerShell/EditorSyntax/issues
 - Output from `$PSVersionTable`:
 
 ```
-Copy / paste the below commands into PowerShell, and paste the output here
+Copy / paste the below commands into the PowerShell Integrated Terminal, and paste the output here
 
 code -v
+$pseditor.EditorServicesVersion
 code --list-extensions --show-versions
 $PSVersionTable
 ```


### PR DESCRIPTION
Now that we have $PSEditor in the terminal, we can run a command to return the PowerShell extension version for issues. Look like a good idea?