### PR TITLE
Add right-click context menu for Run Selection command

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,15 @@
         "category": "PowerShell"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "when": "resourceLangId == powershell",
+          "command": "PowerShell.RunSelection",
+          "group": "2_powershell"
+        }
+      ]
+    },
     "snippets": [
       {
         "language": "powershell",


### PR DESCRIPTION
This change adds a new context menu action in the editor pane for the Run
Selection command.

Resolves #581.