### PR TITLE
Fix hang caused when format on type is enabled

### DIFF
--- a/src/features/DocumentFormatter.ts
+++ b/src/features/DocumentFormatter.ts
@@ -345,7 +345,7 @@ class PSDocumentFormattingEditProvider implements
                     // we do not return a valid array because our text edits
                     // need to be executed in a particular order and it is
                     // easier if we perform the edits ourselves
-                    return this.applyEdit(editor, uniqueEdits, range, 0, index);
+                    return this.applyEdit(editor, uniqueEdits, 0, index);
                 })
                 .then(() => {
                     // execute the same rule again if we left out violations
@@ -365,7 +365,6 @@ class PSDocumentFormattingEditProvider implements
     private applyEdit(
         editor: TextEditor,
         edits: ScriptRegion[],
-        range: Range,
         markerIndex: number,
         ruleIndex: number): Thenable<void> {
         if (markerIndex >= edits.length) {
@@ -377,27 +376,22 @@ class PSDocumentFormattingEditProvider implements
         let edit: ScriptRegion = edits[markerIndex];
         let editRange: Range = toRange(edit);
 
-        if (range === null || range.contains(editRange.start)) {
 
-            // accumulate the changes in number of lines
-            // get the difference between the number of lines in the replacement text and
-            // that of the original text
-            this.lineDiff += this.getNumLines(edit.text) - (editRange.end.line - editRange.start.line + 1);
-            return editor.edit((editBuilder) => {
-                editBuilder.replace(
-                    editRange,
-                    edit.text);
-            },
-                {
-                    undoStopAfter: undoStopAfter,
-                    undoStopBefore: undoStopBefore
-                }).then((isEditApplied) => {
-                    return this.applyEdit(editor, edits, range, markerIndex + 1, ruleIndex);
-                }); // TODO handle rejection
-        }
-        else {
-            return this.applyEdit(editor, edits, range, markerIndex + 1, ruleIndex);
-        }
+        // accumulate the changes in number of lines
+        // get the difference between the number of lines in the replacement text and
+        // that of the original text
+        this.lineDiff += this.getNumLines(edit.text) - (editRange.end.line - editRange.start.line + 1);
+        return editor.edit((editBuilder) => {
+            editBuilder.replace(
+                editRange,
+                edit.text);
+        },
+            {
+                undoStopAfter: undoStopAfter,
+                undoStopBefore: undoStopBefore
+            }).then((isEditApplied) => {
+                return this.applyEdit(editor, edits, markerIndex + 1, ruleIndex);
+            }); // TODO handle rejection
     }
 
     private getNumLines(text: string): number {

--- a/src/features/DocumentFormatter.ts
+++ b/src/features/DocumentFormatter.ts
@@ -310,18 +310,6 @@ class PSDocumentFormattingEditProvider implements
                         return -1 * editComparer(left, right);
                     });
 
-                    // We cannot handle multiple edits at the same point hence we
-                    // filter the markers so that there is only one edit per region
-                    if (edits.length > 0) {
-                        uniqueEdits.push(edits[0]);
-                        for (let edit of edits.slice(1)) {
-                            let lastEdit: ScriptRegion = uniqueEdits[uniqueEdits.length - 1];
-                            if (lastEdit.startLineNumber !== edit.startLineNumber
-                                || (edit.startColumnNumber + edit.text.length) < lastEdit.startColumnNumber) {
-                                uniqueEdits.push(edit);
-                            }
-                        }
-                    }
 
                     // we need to update the range as the edits might
                     // have changed the original layout
@@ -333,6 +321,22 @@ class PSDocumentFormattingEditProvider implements
                         // extend the range such that it starts at the first character of the
                         // start line of the range.
                         range = this.snapRangeToEdges(range, document);
+
+                        // filter edits that are contained in the input range
+                        edits = edits.filter(edit => range.contains(toRange(edit).start));
+                    }
+
+                    // We cannot handle multiple edits at the same point hence we
+                    // filter the markers so that there is only one edit per region
+                    if (edits.length > 0) {
+                        uniqueEdits.push(edits[0]);
+                        for (let edit of edits.slice(1)) {
+                            let lastEdit: ScriptRegion = uniqueEdits[uniqueEdits.length - 1];
+                            if (lastEdit.startLineNumber !== edit.startLineNumber
+                                || (edit.startColumnNumber + edit.text.length) < lastEdit.startColumnNumber) {
+                                uniqueEdits.push(edit);
+                            }
+                        }
                     }
 
                     // reset line difference to 0


### PR DESCRIPTION
The formatter would go into an infinite loop in certain cases because formatting edits were not filtered in the right way. 

Fixes #595 