### PR TITLE
Enable debugging of untitled script files

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     // Use a custom PowerShell Script Analyzer settings file for this workspace.
     // Relative paths for this setting are always relative to the workspace root dir.
-    "powershell.scriptAnalysis.settingsPath": "./PSScriptAnalyzerSettings.psd1"
+    "powershell.scriptAnalysis.settingsPath": "./PSScriptAnalyzerSettings.psd1",
+    "files.defaultLanguage": "powershell"
 }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -41,19 +41,25 @@ export class DebugSessionFeature implements IFeature {
             // For launch of "current script", don't start the debugger if the current file
             // is not a file that can be debugged by PowerShell
             if (config.script === "${file}") {
-                let filename = vscode.window.activeTextEditor.document.fileName;
-                let ext = filename.substr(filename.lastIndexOf('.') + 1);
-                let langId = vscode.window.activeTextEditor.document.languageId;
-                if ((langId !== 'powershell') || (ext !== "ps1" && ext !== "psm1")) {
-                    let path = filename;
+                let currentDocument = vscode.window.activeTextEditor.document;
+                let ext =
+                    currentDocument.fileName.substr(
+                        currentDocument.fileName.lastIndexOf('.') + 1);
+
+                if ((currentDocument.languageId !== 'powershell') ||
+                    (!currentDocument.isUntitled) && (ext !== "ps1" && ext !== "psm1")) {
+                    let path = currentDocument.fileName;
                     let workspaceRootPath = vscode.workspace.rootPath;
-                    if (filename.startsWith(workspaceRootPath)) {
-                        path = filename.substring(vscode.workspace.rootPath.length + 1);
+                    if (currentDocument.fileName.startsWith(workspaceRootPath)) {
+                        path = currentDocument.fileName.substring(vscode.workspace.rootPath.length + 1);
                     }
 
                     let msg = "'" + path + "' is a file type that cannot be debugged by the PowerShell debugger.";
                     vscode.window.showErrorMessage(msg);
                     return;
+                }
+                else if (currentDocument.isUntitled) {
+                    config.script = currentDocument.uri.toString();
                 }
             }
         }


### PR DESCRIPTION
This change enables untitled files to be debugged when they are set to the
'powershell' language mode.

Fixes #555.