### PR TITLE
Fix detection of valid PS ext for debugging.

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -44,7 +44,15 @@ export class DebugSessionFeature implements IFeature {
                 let currentDocument = vscode.window.activeTextEditor.document;
 
                 if (currentDocument.isUntitled) {
-                    config.script = currentDocument.uri.toString();
+                    if (currentDocument.languageId === 'powershell') {
+                        config.script = currentDocument.uri.toString();
+                    }
+                    else {
+                        let msg = "In order to debug '" + currentDocument.fileName +
+                                  "', set the document's language mode to PowerShell or save the file with a PowerShell extension.";
+                        vscode.window.showErrorMessage(msg);
+                        return;
+                    }
                 }
                 else {
                     let isValidExtension = false;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -48,7 +48,7 @@ export class DebugSessionFeature implements IFeature {
                         config.script = currentDocument.uri.toString();
                     }
                     else {
-                        let msg = "In order to debug '" + currentDocument.fileName +
+                        let msg = "To debug '" + currentDocument.fileName +
                                   "', change the document's language mode to PowerShell or save the file with a PowerShell extension.";
                         vscode.window.showErrorMessage(msg);
                         return;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -49,7 +49,7 @@ export class DebugSessionFeature implements IFeature {
                     }
                     else {
                         let msg = "In order to debug '" + currentDocument.fileName +
-                                  "', set the document's language mode to PowerShell or save the file with a PowerShell extension.";
+                                  "', change the document's language mode to PowerShell or save the file with a PowerShell extension.";
                         vscode.window.showErrorMessage(msg);
                         return;
                     }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -42,24 +42,29 @@ export class DebugSessionFeature implements IFeature {
             // is not a file that can be debugged by PowerShell
             if (config.script === "${file}") {
                 let currentDocument = vscode.window.activeTextEditor.document;
-                let ext =
-                    currentDocument.fileName.substr(
-                        currentDocument.fileName.lastIndexOf('.') + 1);
 
-                if ((currentDocument.languageId !== 'powershell') ||
-                    (!currentDocument.isUntitled) && (ext !== "ps1" && ext !== "psm1")) {
-                    let path = currentDocument.fileName;
-                    let workspaceRootPath = vscode.workspace.rootPath;
-                    if (currentDocument.fileName.startsWith(workspaceRootPath)) {
-                        path = currentDocument.fileName.substring(vscode.workspace.rootPath.length + 1);
+                if (currentDocument.isUntitled) {
+                    config.script = currentDocument.uri.toString();
+                }
+                else {
+                    let isValidExtension = false;
+                    let extIndex = currentDocument.fileName.lastIndexOf('.');
+                    if (extIndex !== -1) {
+                        let ext = currentDocument.fileName.substr(extIndex + 1).toUpperCase();
+                        isValidExtension = (ext === "PS1" || ext === "PSM1");
                     }
 
-                    let msg = "'" + path + "' is a file type that cannot be debugged by the PowerShell debugger.";
-                    vscode.window.showErrorMessage(msg);
-                    return;
-                }
-                else if (currentDocument.isUntitled) {
-                    config.script = currentDocument.uri.toString();
+                    if ((currentDocument.languageId !== 'powershell') || !isValidExtension) {
+                        let path = currentDocument.fileName;
+                        let workspaceRootPath = vscode.workspace.rootPath;
+                        if (currentDocument.fileName.startsWith(workspaceRootPath)) {
+                            path = currentDocument.fileName.substring(vscode.workspace.rootPath.length + 1);
+                        }
+
+                        let msg = "'" + path + "' is a file type that cannot be debugged by the PowerShell debugger.";
+                        vscode.window.showErrorMessage(msg);
+                        return;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Was previously only allowing lower case ps1 and psm1.  I'm assuming that on *nix file systems, that PowerShell allows all variations of ps1,PS1,pS1,Ps1 as valid script extensions.

Fix #641 

@daviwil Currently, debugging an "untitled" script file doesn't work even if you set the language to PowerShell.  That's because this code below detects "isUntitled" and sets the `script` property to `untitled:Untitled-1`.  Seems like you were working on enabling debug of untitled/unsaved script files.  Is that coming later or should the below be working now?