### PR TITLE
Fix error when debugging untitled script with no launch.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vscode-powershell Release History
 
+## 0.12.1
+### Tuesday, April 4, 2017
+
+- Fixed [#648](https://github.com/PowerShell/vscode-powershell/issues/648) -
+  Resolved an error when launching an untitled script file in a workspace
+  with no launch.json or in a window without a workspace path
+
 ## 0.12.0
 ### Tuesday, April 4, 2017
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.12.0-insiders-{build}'
+version: '0.12.1-insiders-{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PowerShell",
   "displayName": "PowerShell",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -25,13 +25,19 @@ export class DebugSessionFeature implements IFeature {
 
     private startDebugSession(config: any) {
 
+        let currentDocument = vscode.window.activeTextEditor.document;
+
         if (!config.request) {
             // No launch.json, create the default configuration
             config.type = 'PowerShell';
             config.name = 'PowerShell Launch Current File';
             config.request = 'launch';
             config.args = [];
-            config.script = vscode.window.activeTextEditor.document.fileName;
+
+            config.script =
+                currentDocument.isUntitled
+                    ? currentDocument.uri.toString()
+                    : currentDocument.fileName;
         }
 
         if (config.request === 'launch') {
@@ -41,7 +47,6 @@ export class DebugSessionFeature implements IFeature {
             // For launch of "current script", don't start the debugger if the current file
             // is not a file that can be debugged by PowerShell
             if (config.script === "${file}") {
-                let currentDocument = vscode.window.activeTextEditor.document;
 
                 if (currentDocument.isUntitled) {
                     if (currentDocument.languageId === 'powershell') {


### PR DESCRIPTION
This change fixes an issue which causes and error to appear in the
integrated console when debugging an untitled file without a launch.json
configuration.  The fix is to use the full Uri path when crafting a
launch config for an untitled file.

Resolves #648.