### PR TITLE
Fix issue with cwd being set to untitled file path

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -42,7 +42,7 @@ export class DebugSessionFeature implements IFeature {
 
         if (config.request === 'launch') {
             // Make sure there's a usable working directory if possible
-            config.cwd = config.cwd || vscode.workspace.rootPath || config.script;
+            config.cwd = config.cwd || vscode.workspace.rootPath;
 
             // For launch of "current script", don't start the debugger if the current file
             // is not a file that can be debugged by PowerShell
@@ -79,6 +79,12 @@ export class DebugSessionFeature implements IFeature {
                         return;
                     }
                 }
+            }
+            else if (config.script) {
+                // In this case, the user has explicitly defined a script path
+                // so make sure to set the cwd to that path if the cwd wasn't
+                // explicitly set
+                config.cwd = config.cwd || config.script;
             }
         }
 


### PR DESCRIPTION
This change fixes an issue with untitled file paths being sent in the
cwd parameter to debug adapter when in a window that doesn't have a
workspace loaded.  The fix is to change our cwd selection logic to be
more aware of an untitled file being used.

Resolves #655.