### PR TITLE
Fix extension startup on Linux/macOS with PS 6 Alpha 18

### DIFF
--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -181,7 +181,7 @@ function Get-AvailablePort {
 
 # Add BundledModulesPath to $env:PSModulePath
 if ($BundledModulesPath) {
-    $env:PSMODULEPATH = $env:PSMODULEPATH + [System.IO.Path]::PathSeparator + $BundledModulesPath
+    $env:PSModulePath = $env:PSModulePath + [System.IO.Path]::PathSeparator + $BundledModulesPath
 }
 
 # Check if PowerShellGet module is available


### PR DESCRIPTION
This change fixes an issue caused by PowerShell 6 Alpha 18 where the
PSModulePath casing on UNIX systems has been changed from PSMODULEPATH
back to PSModulePath.  This change broke the startup script that
manipulates the PSModulePath so the extension fails to load in the new
version.

This is a breaking change for those using a previous version of
PowerShell 6 on UNIX systems.

Fixes #662.