### PR TITLE
Break down build tasks in build script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,15 +2,26 @@
 	"version": "0.1.0",
 	"configurations": [
 		{
-            "name": "Launch Extension",
-            "type": "extensionHost",
-            "request": "launch",
-            "runtimeExecutable": "${execPath}",
+			"name": "Launch Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
 			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/out"],
 			"preLaunchTask": "BuildAll"
+		},
+		{
+			"name": "Launch Extension (Build client only)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
+			"stopOnEntry": false,
+			"sourceMaps": true,
+			"outFiles": ["${workspaceRoot}/out"],
+			"preLaunchTask": "Build"
 		},
 		{
 			"name": "Attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"stopOnEntry": false,
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/out"],
-			"preLaunchTask": "Build"
+			"preLaunchTask": "BuildAll"
 		},
 		{
 			"name": "Attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,14 +24,24 @@
             "args": [ "Invoke-Build Restore" ]
         },
         {
+            "taskName": "CleanAll",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build CleanAll" ]
+        },
+        {
             "taskName": "Clean",
             "suppressTaskName": true,
             "args": [ "Invoke-Build Clean" ]
         },
         {
-            "taskName": "Build",
+            "taskName": "BuildAll",
             "suppressTaskName": true,
             "isBuildCommand": true,
+            "args": [ "Invoke-Build BuildAll" ]
+        },
+        {
+            "taskName": "Build",
+            "suppressTaskName": true,
             "args": [ "Invoke-Build Build" ]
         }
     ]

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -32,7 +32,7 @@ task GetExtensionVersion -Before Package {
     }
 }
 
-task ResolveEditorServicesPath -Before Clean, Build {
+task ResolveEditorServicesPath -Before Clean, BuildEditorServices {
 
     $script:psesRepoPath = `
         if ($EditorServicesRepoPath) {
@@ -74,16 +74,19 @@ task Clean {
     Remove-Item .\out -Recurse -Force -ErrorAction Ignore
 }
 
-task Build -Before Package {
+task Build BuildEditorServices, BuildClient -Before Package
 
-    # If the PSES codebase is co-located, build it first
+task BuildClient {
+    Write-Host "`n### Building vscode-powershell" -ForegroundColor Green
+    exec { & npm run compile }
+}
+
+task BuildEditorServices {
+       # If the PSES codebase is co-located, build it first
     if ($script:psesBuildScriptPath) {
         Write-Host "`n### Building PowerShellEditorServices`n" -ForegroundColor Green
         Invoke-Build Build $script:psesBuildScriptPath
     }
-
-    Write-Host "`n### Building vscode-powershell" -ForegroundColor Green
-    exec { & npm run compile }
 }
 
 task Package {


### PR DESCRIPTION
Previously, there was no way to build/clean only vscode-powershell typescript project from the invoke-build script. This PR solves that by dividing the original `build` task into `build` and `buildEditorServices` tasks. 