### PR TITLE
Change initialization order when starting language client

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -456,10 +456,6 @@ export class SessionManager {
                     connectFunc,
                     clientOptions);
 
-            // Send the new LanguageClient to extension features
-            // so that they can register their message handlers
-            // before the connection is established.
-            this.updateExtensionFeatures(this.languageServerClient);
 
             this.languageServerClient.onReady().then(
                 () => {
@@ -474,14 +470,19 @@ export class SessionManager {
                                         : this.versionDetails.displayVersion,
                                     SessionStatus.Running);
                             });
+
+                    // Send the new LanguageClient to extension features
+                    // so that they can register their message handlers
+                    // before the connection is established.
+                    this.updateExtensionFeatures(this.languageServerClient);
+                    this.languageServerClient.onNotification(
+                        RunspaceChangedEvent.type,
+                        (runspaceDetails) => { this.setStatusBarVersionString(runspaceDetails); });
                 },
                 (reason) => {
                     this.setSessionFailure("Could not start language service: ", reason);
                 });
 
-            this.languageServerClient.onNotification(
-                RunspaceChangedEvent.type,
-                (runspaceDetails) => { this.setStatusBarVersionString(runspaceDetails); });
 
             this.languageServerClient.start();
         }


### PR DESCRIPTION
Using the newer version of language client we cannot add some handlers unless the client server is ready. 