### PR TITLE
Add Install-VSCode.ps1 script

### DIFF
--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+    Installs Visual Studio Code, the PowerShell extension, and optionally
+    a list of additional extensions.
+
+.DESCRIPTION
+    This script can be used to easily install Visual Studio Code and the
+    PowerShell extension on your machine.  You may also specify additional
+    extensions to be installed using the -AdditionalExtensions parameter.
+    The -LaunchWhenDone parameter will cause VS Code to be launched as
+    soon as installation has completed.
+
+    Please contribute improvements to this script on GitHub!
+
+    https://github.com/PowerShell/vscode-powershell/blob/develop/scripts/Install-VSCode.ps1
+
+.PARAMETER AdditionalExtensions
+    An array of strings that are the fully-qualified names of extensions to be
+    installed in addition to the PowerShell extension.  The fully qualified
+    name is formatted as "<publisher name>.<extension name>" and can be found
+    next to the extension's name in the details tab that appears when you
+    click an extension in the Extensions panel in Visual Studio Code.
+
+.PARAMETER LaunchWhenDone
+    When present, causes Visual Studio Code to be launched as soon as installation
+    has finished.
+
+.EXAMPLE
+    Install-VSCode.ps1 -LaunchWhenDone
+
+    Installs Visual Studio Code and the PowerShell extension and then launches
+    the editor after installation completes.
+
+.EXAMPLE
+    Install-VSCode.ps1 -AdditionalExtensions 'eamodio.gitlens', 'vscodevim.vim'
+
+    Installs Visual Studio Code, the PowerShell extension, and additional
+    extensions.
+
+.NOTES
+    This script is licensed under the MIT License:
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidateNotNull()]
+    [string[]]$AdditionalExtensions = @(),
+
+    [switch]$LaunchWhenDone
+)
+
+if (!($IsLinux -or $IsOSX)) {
+
+    $codeCmdPath = "C:\Program Files (x86)\Microsoft VS Code\bin\code.cmd"
+
+    try {
+        $ProgressPreference = 'SilentlyContinue'
+
+        if (!(Test-Path $codeCmdPath)) {
+            Write-Host "`nDownloading latest stable Visual Studio Code..." -ForegroundColor Yellow
+            Remove-Item -Force $env:TEMP\vscode-stable.exe -ErrorAction SilentlyContinue
+            Invoke-WebRequest -Uri https://vscode-update.azurewebsites.net/latest/win32/stable -OutFile $env:TEMP\vscode-stable.exe
+
+            Write-Host "`nInstalling Visual Studio Code..." -ForegroundColor Yellow
+            Start-Process -Wait $env:TEMP\vscode-stable.exe -ArgumentList /silent, /mergetasks=!runcode
+        }
+        else {
+            Write-Host "`nVisual Studio Code is already installed." -ForegroundColor Yellow
+        }
+
+        $extensions = @("ms-vscode.PowerShell") + $AdditionalExtensions
+        foreach ($extension in $extensions) {
+            Write-Host "`nInstalling extension $extension..." -ForegroundColor Yellow
+            & $codeCmdPath --install-extension $extension
+        }
+
+        if ($LaunchWhenDone) {
+            Write-Host "`nInstallation complete, starting Visual Studio Code...`n`n" -ForegroundColor Green
+            & $codeCmdPath
+        }
+        else {
+            Write-Host "`nInstallation complete!`n`n" -ForegroundColor Green
+        }
+    }
+    finally {
+        $ProgressPreference = 'Continue'
+    }
+}
+else {
+    Write-Error "This script is currently only supported on the Windows operating system."
+}


### PR DESCRIPTION
This change adds a new script that can be used to install Visual Studio
Code and the PowerShell extension.  The intent is for this script to be
shipped to the PowerShell Gallery so that one can easily get the script
and install VS Code in a single line of PowerShell.