### PR TITLE
Fix session collision issues when using multiple VS Code windows

### DIFF
--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -26,10 +26,17 @@ var debugAdapterLogWriter =
 // debug server
 process.stdin.pause();
 
+var debugSessionFilePath = utils.getDebugSessionFilePath();
+debugAdapterLogWriter.write("Session file path: " + debugSessionFilePath + ", pid: " + process.pid + " \r\n");
+
 function startDebugging() {
     // Read the details of the current session to learn
     // the connection details for the debug service
-    let sessionDetails = utils.readSessionFile();
+    let sessionDetails = utils.readSessionFile(debugSessionFilePath);
+
+    // Delete the session file after it has been read so that
+    // it isn't used mistakenly by another debug session
+    utils.deleteSessionFile(debugSessionFilePath);
 
     // Establish connection before setting up the session
     debugAdapterLogWriter.write("Connecting to port: " + sessionDetails.debugServicePort + "\r\n");
@@ -94,13 +101,12 @@ function startDebugging() {
     )
 }
 
-var sessionFilePath = utils.getSessionFilePath();
 function waitForSessionFile(triesRemaining: number) {
 
     debugAdapterLogWriter.write(`Waiting for session file, tries remaining: ${triesRemaining}...\r\n`);
 
     if (triesRemaining > 0) {
-        if (utils.checkIfFileExists(sessionFilePath)) {
+        if (utils.checkIfFileExists(debugSessionFilePath)) {
             debugAdapterLogWriter.write(`Session file present, connecting to debug adapter...\r\n\r\n`);
             startDebugging();
         }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -3,14 +3,16 @@
  *--------------------------------------------------------*/
 
 import vscode = require('vscode');
+import utils = require('../utils');
 import { IFeature } from '../feature';
+import { SessionManager } from '../session';
 import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
 
 export class DebugSessionFeature implements IFeature {
     private command: vscode.Disposable;
     private examplesPath: string;
 
-    constructor() {
+    constructor(private sessionManager: SessionManager) {
         this.command = vscode.commands.registerCommand(
             'PowerShell.StartDebugSession',
             config => { this.startDebugSession(config); });
@@ -101,6 +103,11 @@ export class DebugSessionFeature implements IFeature {
         // Create or show the interactive console
         // TODO #367: Check if "newSession" mode is configured
         vscode.commands.executeCommand('PowerShell.ShowSessionConsole', true);
+
+        // Write out temporary debug session file
+        utils.writeSessionFile(
+            utils.getDebugSessionFilePath(),
+            this.sessionManager.getSessionDetails());
 
         vscode.commands.executeCommand('vscode.startDebug', config);
     }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -52,7 +52,7 @@ export class Logger {
             this.writeLine(message)
 
             additionalMessages.forEach((line) => {
-                this.writeLine(message);
+                this.writeLine(line);
             });
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,9 +36,6 @@ var logger: Logger = undefined;
 var sessionManager: SessionManager = undefined;
 var extensionFeatures: IFeature[] = [];
 
-// Clean up the session file just in case one lingers from a previous session
-utils.deleteSessionFile();
-
 export function activate(context: vscode.ExtensionContext): void {
 
     checkForUpdatedVersion(context);
@@ -99,6 +96,11 @@ export function activate(context: vscode.ExtensionContext): void {
     // Create the logger
     logger = new Logger();
 
+    sessionManager =
+        new SessionManager(
+            requiredEditorServicesVersion,
+            logger);
+
     // Create features
     extensionFeatures = [
         new ConsoleFeature(),
@@ -113,16 +115,12 @@ export function activate(context: vscode.ExtensionContext): void {
         new NewFileOrProjectFeature(),
         new DocumentFormatterFeature(),
         new RemoteFilesFeature(),
-        new DebugSessionFeature(),
+        new DebugSessionFeature(sessionManager),
         new PickPSHostProcessFeature(),
         new SpecifyScriptArgsFeature(context)
     ];
 
-    sessionManager =
-        new SessionManager(
-            requiredEditorServicesVersion,
-            logger,
-            extensionFeatures);
+    sessionManager.setExtensionFeatures(extensionFeatures);
 
     var extensionSettings = Settings.load(utils.PowerShellLanguageId);
     if (extensionSettings.startAutomatically) {


### PR DESCRIPTION
This change fixes an issue where multiple VS Code windows would
inadvertently share the same language server and debug adapter ports,
causing one of the windows to send all of its output and behavior to the
other window.  The fix is to make session file management more unique
between each window in the same VS Code process.

Resolves #626.