### PR TITLE
Fix #751: Remove keybinding for PowerShellFindModule command

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,11 +71,6 @@
         "command": "PowerShell.OpenInISE",
         "key": "ctrl+shift+i",
         "when": "editorTextFocus && editorLangId == 'powershell'"
-      },
-      {
-        "command": "PowerShell.PowerShellFindModule",
-        "key": "ctrl+K ctrl+f",
-        "when": "editorTextFocus && editorLangId == 'powershell'"
       }
     ],
     "commands": [


### PR DESCRIPTION
This command's keybinding conflicts with VS Code's default key binding
for the Format Selection command.  The PowerShellFindModule command
isn't commonly used so we are just removing the binding instead of
finding a different one.