### PR TITLE
Debugger is now activated when breakpoints are hit in Integrated Console

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -8,6 +8,10 @@ import { IFeature } from '../feature';
 import { SessionManager } from '../session';
 import { LanguageClient, RequestType, NotificationType } from 'vscode-languageclient';
 
+export namespace StartDebuggerNotification {
+    export const type = new NotificationType<void, void>('powerShell/startDebugger');
+}
+
 export class DebugSessionFeature implements IFeature {
     private command: vscode.Disposable;
     private examplesPath: string;
@@ -18,7 +22,14 @@ export class DebugSessionFeature implements IFeature {
             config => { this.startDebugSession(config); });
     }
 
-    public setLanguageClient(languageclient: LanguageClient) {
+    public setLanguageClient(languageClient: LanguageClient) {
+        languageClient.onNotification(
+            StartDebuggerNotification.type,
+            none => this.startDebugSession({
+                request: 'launch',
+                type: 'PowerShell',
+                name: 'PowerShell Interactive Session'
+            }));
     }
 
     public dispose() {


### PR DESCRIPTION
This change adds new behavior which causes VS Code's debugger UI to be
activated when a breakpoint is hit in the Integrated Console while not
currently in debug mode.  This allows the user to set breakpoints and
run scripts from the console while still leveraging VS Code's rich
debugging UI.

Resolves #619.