### PR TITLE
Add 2 snippets to simplify supressing benign PSScriptAnalyzer errors …

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -871,5 +871,21 @@
             "}"
         ],
         "description": "sequence snippet (for use inside a workflow)"
-    }
+    },
+    "PSSA warning override decoration.1": {
+		"prefix": "Suppress - PSSA",
+		"description": "Suppress warnings for a specific rule",
+		"body": [
+			"#Suppress warning",
+			"[Diagnostics.CodeAnalysis.SuppressMessageAttribute('${1:PSUseDeclaredVarsMoreThanAssignments}', '$2')]"
+		]
+	}
+	,"PSSA warning override decoration.2": {
+		"prefix": "Suppress - PSSA",
+		"description": "Suppress warnings for a specific class, for a specific function",
+		"body": [
+			"#Suppress warning",
+			"[Diagnostics.CodeAnalysis.SuppressMessageAttribute('${1:PSProvideDefaultParameterValue}', '$2', Scope='Function', Target='*')]"
+		]
+	}
 }


### PR DESCRIPTION
in reference to issue #781 I have created 2 snippets that should be broadly applicable to users that use PSSA to guard the code quality.

This combined with the display of the PSSA rulename as part of the warning in the Problem pane will allow simplify the proper use of PSSA.
