### PR TITLE
Add Pester problem matcher to pkg,json.

### DIFF
--- a/examples/.vscode/tasks.json
+++ b/examples/.vscode/tasks.json
@@ -87,24 +87,7 @@
                 "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
             ],
-            "problemMatcher": [
-                {
-                    "owner": "powershell",
-                    "fileLocation": ["absolute"],
-                    "severity": "error",
-                    "pattern": [
-                        {
-                            "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
-                            "message": 1
-                        },
-                        {
-                            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
-                            "file": 1,
-                            "line": 2
-                        }
-                    ]
-                }
-            ]
+            "problemMatcher": "$pesterError"
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,25 @@
         }
       ]
     },
+    "problemMatchers": [
+      {
+        "name": "pesterError",
+        "owner": "powershell",
+        "fileLocation": ["absolute"],
+        "severity": "error",
+        "pattern": [
+            {
+                "regexp": "^\\s*(\\[-\\]\\s*.*?)(\\d+)ms\\s*$",
+                "message": 1
+            },
+            {
+                "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
+                "file": 1,
+                "line": 2
+            }
+        ]
+      }
+    ],
     "snippets": [
       {
         "language": "powershell",


### PR DESCRIPTION
Should this matcher be called `$pesterError` or just `$pester`?