### PR TITLE
Restarting PowerShell session now retains previous configuration

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -710,7 +710,7 @@ export class SessionManager {
 
                 new SessionMenuItem(
                     "Restart Current Session",
-                    () => { this.restartSession(); }),
+                    () => { this.restartSession(this.sessionConfiguration); }),
             ];
         }
         else if (this.sessionStatus === SessionStatus.Failed) {


### PR DESCRIPTION
This change fixes #807 which states that restarting the current
PowerShell session using the "Restart Current Session" command doesn't
retain the current session configuration if the user previously switched
their configuration using the session menu.  The fix is to change the
call to restartSession to use the current session configuration when
this command is invoked.