### PR TITLE
Send document Uri instead of path for extension command execution

### DIFF
--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -313,7 +313,7 @@ export class ExtensionCommandsFeature implements IFeature {
 
     private getEditorContext(): EditorContext {
         return {
-            currentFilePath: vscode.window.activeTextEditor.document.fileName,
+            currentFilePath: vscode.window.activeTextEditor.document.uri.toString(),
             cursorPosition: asPosition(vscode.window.activeTextEditor.selection.active),
             selectionRange:
                 asRange(


### PR DESCRIPTION
This change fixes an issue which causes the language server to crash
when running a registered $psEditor command from within an untitled
file.  This happens because the workspace code in the language server
expects to receive Uri paths instead of local file paths when referring
to an editor buffer.  The fix is to send the untitled file's Uri instead
of its non-existent file path.

Resolves #810.
Resolves PowerShell/PowerShellEditorServices #434.