### PR TITLE
Simplify and persist PowerShell session configuration changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -351,6 +351,12 @@
       "type": "object",
       "title": "PowerShell Configuration",
       "properties": {
+        "powershell.powerShellExePath": {
+          "type": "string",
+          "default": "",
+          "isExecutable": true,
+          "description": "Specifies the full path to a PowerShell executable. Changes the installation of PowerShell used for language and debugging services."
+        },
         "powershell.startAutomatically": {
           "type": "boolean",
           "default": true,
@@ -384,7 +390,8 @@
         "powershell.developer.powerShellExePath": {
           "type": "string",
           "default": "",
-          "description": "Specifies the full path to a PowerShell executable. Changes the installation of PowerShell used for language and debugging services."
+          "isExecutable": true,
+          "description": "Deprecated. Please use the 'powershell.powerShellExePath' setting instead"
         },
         "powershell.developer.powerShellExeIsWindowsDevBuild": {
           "type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,7 +126,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     sessionManager.setExtensionFeatures(extensionFeatures);
 
-    var extensionSettings = Settings.load(utils.PowerShellLanguageId);
+    var extensionSettings = Settings.load();
     if (extensionSettings.startAutomatically) {
         sessionManager.start();
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import vscode = require('vscode');
+import utils = require('./utils');
 
 export interface ICodeFormattingSettings {
     openBraceOnSameLine: boolean;
@@ -33,6 +34,7 @@ export interface IDeveloperSettings {
 }
 
 export interface ISettings {
+    powerShellExePath?: string;
     startAutomatically?: boolean;
     useX86Host?: boolean;
     enableProfileLoading?: boolean;
@@ -47,8 +49,10 @@ export interface IIntegratedConsoleSettings {
     focusConsoleOnExecute?: boolean;
 }
 
-export function load(myPluginId: string): ISettings {
-    let configuration: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration(myPluginId);
+export function load(): ISettings {
+    let configuration: vscode.WorkspaceConfiguration =
+        vscode.workspace.getConfiguration(
+            utils.PowerShellLanguageId);
 
     let defaultScriptAnalysisSettings: IScriptAnalysisSettings = {
         enable: true,
@@ -83,6 +87,7 @@ export function load(myPluginId: string): ISettings {
 
     return {
         startAutomatically: configuration.get<boolean>("startAutomatically", true),
+        powerShellExePath: configuration.get<string>("powerShellExePath", undefined),
         useX86Host: configuration.get<boolean>("useX86Host", false),
         enableProfileLoading: configuration.get<boolean>("enableProfileLoading", false),
         scriptAnalysis: configuration.get<IScriptAnalysisSettings>("scriptAnalysis", defaultScriptAnalysisSettings),
@@ -90,4 +95,12 @@ export function load(myPluginId: string): ISettings {
         codeFormatting: configuration.get<ICodeFormattingSettings>("codeFormatting", defaultCodeFormattingSettings),
         integratedConsole: configuration.get<IIntegratedConsoleSettings>("integratedConsole", defaultIntegratedConsoleSettings)
     };
+}
+
+export function change(settingName: string, newValue: any, global: boolean = false): Thenable<void> {
+    let configuration: vscode.WorkspaceConfiguration =
+        vscode.workspace.getConfiguration(
+            utils.PowerShellLanguageId);
+
+    return configuration.update(settingName, newValue, global);
 }


### PR DESCRIPTION
This change improves our session menu so that when the user selects a
different PowerShell version the choice is persisted in their user
settings.  The previous code for managing session configurations has
been mostly removed because it was unnecessarily complex.

We've also added a new "powershell.powerShellExePath" setting to replace
the now deprecated "powershell.developer.powerShellExePath" setting
since this is now a user-level setting.  If a user has the deprecated
setting in their configuration file, we will notify them and fix it
automatically if they wish.