### PR TITLE
Enable debugging in temporary Integrated Console sessions

### DIFF
--- a/examples/.vscode/launch.json
+++ b/examples/.vscode/launch.json
@@ -12,6 +12,15 @@
         {
             "type": "PowerShell",
             "request": "launch",
+            "name": "PowerShell Launch Current File in Temporary Console",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}",
+            "createTemporaryIntegratedConsole": true
+        },
+        {
+            "type": "PowerShell",
+            "request": "launch",
             "name": "PowerShell Launch Current File w/Args Prompt",
             "script": "${file}",
             "args": [ "${command:SpecifyScriptArgs}" ],

--- a/package.json
+++ b/package.json
@@ -212,6 +212,19 @@
             }
           },
           {
+            "label": "PowerShell: Launch Current File in Temporary Console",
+            "description": "Launch current file (in active editor window) under debugger in a temporary Integrated Console.",
+            "body": {
+              "type": "PowerShell",
+              "request": "launch",
+              "name": "PowerShell Launch Current File in Temporary Console",
+              "script": "^\"\\${file}\"",
+              "args": [],
+              "cwd": "^\"\\${file}\"",
+              "createTemporaryIntegratedConsole": true
+            }
+          },
+          {
             "label": "PowerShell: Launch - Current File w/Args Prompt",
             "description": "Launch current file (in active editor window) under debugger, prompting first for script arguments",
             "body": {
@@ -292,6 +305,11 @@
                 "type": "string",
                 "description": "Absolute path to the working directory. Default is the current workspace.",
                 "default": "${workspaceRoot}"
+              },
+              "createTemporaryIntegratedConsole": {
+                "type": "boolean",
+                "description": "Determines whether a temporary PowerShell Integrated Console is created for each debugging session, useful for debugging PowerShell classes and binary modules.  Overrides the user setting 'powershell.debugging.createTemporaryIntegratedConsole'.",
+                "default": false
               }
             }
           },
@@ -322,6 +340,15 @@
             "script": "${file}",
             "args": [],
             "cwd": "${file}"
+          },
+          {
+            "type": "PowerShell",
+            "request": "launch",
+            "name": "PowerShell Launch Current File in Temporary Console",
+            "script": "${file}",
+            "args": [],
+            "cwd": "${file}",
+            "createTemporaryIntegratedConsole": true
           },
           {
             "type": "PowerShell",
@@ -447,6 +474,11 @@
           "type": "boolean",
           "default": true,
           "description": "Switches focus to the console when a script selection is run or a script file is debugged. This is an accessibility feature. To disable it, set to false."
+        },
+        "powershell.debugging.createTemporaryIntegratedConsole": {
+          "type": "boolean",
+          "default": false,
+          "description": "Determines whether a temporary PowerShell Integrated Console is created for each debugging session, useful for debugging PowerShell classes and binary modules."
         },
         "powershell.developer.bundledModulesPath": {
           "type": "string",

--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -55,7 +55,7 @@ param(
     [switch]
     $EnableConsoleRepl,
 
-    [string]
+    [switch]
     $DebugServiceOnly,
 
     [string[]]

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import os = require('os');
+import fs = require('fs');
+import net = require('net');
+import path = require('path');
+import utils = require('./utils');
+import vscode = require('vscode');
+import cp = require('child_process');
+import Settings = require('./settings');
+
+import { Logger } from './logging';
+
+export class PowerShellProcess {
+
+    private sessionFilePath: string;
+    private consoleTerminal: vscode.Terminal = undefined;
+    private consoleCloseSubscription: vscode.Disposable;
+    private sessionDetails: utils.EditorServicesSessionDetails;
+
+    private onExitedEmitter = new vscode.EventEmitter<void>();
+    public onExited: vscode.Event<void> = this.onExitedEmitter.event;
+
+    constructor(
+        public exePath: string,
+        private log: Logger,
+        private sessionSettings: Settings.ISettings) {
+
+        this.sessionFilePath =
+            utils.getSessionFilePath(
+                Math.floor(100000 + Math.random() * 900000));
+    }
+
+    public start(startArgs: string): Thenable<utils.EditorServicesSessionDetails> {
+
+        return new Promise<utils.EditorServicesSessionDetails>(
+            (resolve, reject) => {
+                try
+                {
+                    let startScriptPath =
+                        path.resolve(
+                            __dirname,
+                            '../scripts/Start-EditorServices.ps1');
+
+                    var editorServicesLogPath = this.log.getLogFilePath("EditorServices");
+
+                    var featureFlags =
+                        this.sessionSettings.developer.featureFlags !== undefined
+                            ? this.sessionSettings.developer.featureFlags.map(f => `'${f}'`).join(', ')
+                            : "";
+
+                    startArgs +=
+                        `-LogPath '${editorServicesLogPath}' ` +
+                        `-SessionDetailsPath '${this.sessionFilePath}' ` +
+                        `-FeatureFlags @(${featureFlags})`
+
+                    var powerShellArgs = [
+                        "-NoProfile",
+                        "-NonInteractive"
+                    ]
+
+                    // Only add ExecutionPolicy param on Windows
+                    if (utils.isWindowsOS()) {
+                        powerShellArgs.push("-ExecutionPolicy", "Unrestricted")
+                    }
+
+                    powerShellArgs.push(
+                        "-Command",
+                        "& '" + startScriptPath + "' " + startArgs);
+
+                    var powerShellExePath = this.exePath;
+
+                    if (this.sessionSettings.developer.powerShellExeIsWindowsDevBuild) {
+                        // Windows PowerShell development builds need the DEVPATH environment
+                        // variable set to the folder where development binaries are held
+
+                        // NOTE: This batch file approach is needed temporarily until VS Code's
+                        // createTerminal API gets an argument for setting environment variables
+                        // on the launched process.
+                        var batScriptPath = path.resolve(__dirname, '../sessions/powershell.bat');
+                        fs.writeFileSync(
+                            batScriptPath,
+                            `@set DEVPATH=${path.dirname(powerShellExePath)}\r\n@${powerShellExePath} %*`);
+
+                        powerShellExePath = batScriptPath;
+                    }
+
+                    this.log.write(`${utils.getTimestampString()} Language server starting...`);
+
+                    // Make sure no old session file exists
+                    utils.deleteSessionFile(this.sessionFilePath);
+
+                    // Launch PowerShell in the integrated terminal
+                    this.consoleTerminal =
+                        vscode.window.createTerminal(
+                            "PowerShell Integrated Console",
+                            powerShellExePath,
+                            powerShellArgs);
+
+                    if (this.sessionSettings.integratedConsole.showOnStartup) {
+                        this.consoleTerminal.show(true);
+                    }
+
+                    // Start the language client
+                    utils.waitForSessionFile(
+                        this.sessionFilePath,
+                        (sessionDetails, error) => {
+                            // Clean up the session file
+                            utils.deleteSessionFile(this.sessionFilePath);
+
+                            if (error) {
+                                reject(error);
+                            }
+                            else {
+                                this.sessionDetails = sessionDetails;
+                                resolve(this.sessionDetails);
+                            }
+                    });
+
+                // this.powerShellProcess.stderr.on(
+                //     'data',
+                //     (data) => {
+                //         this.log.writeError("ERROR: " + data);
+
+                //         if (this.sessionStatus === SessionStatus.Initializing) {
+                //             this.setSessionFailure("PowerShell could not be started, click 'Show Logs' for more details.");
+                //         }
+                //         else if (this.sessionStatus === SessionStatus.Running) {
+                //             this.promptForRestart();
+                //         }
+                //     });
+
+                this.consoleCloseSubscription =
+                    vscode.window.onDidCloseTerminal(
+                        terminal => {
+                            if (terminal === this.consoleTerminal) {
+                                this.log.write(os.EOL + "powershell.exe terminated or terminal UI was closed" + os.EOL);
+                                this.onExitedEmitter.fire();
+                            }
+                        });
+
+                this.consoleTerminal.processId.then(
+                    pid => {
+                        console.log("powershell.exe started, pid: " + pid + ", exe: " + powerShellExePath);
+                        this.log.write(
+                            "powershell.exe started --",
+                            "    pid: " + pid,
+                            "    exe: " + powerShellExePath,
+                            "    args: " + startScriptPath + ' ' + startArgs + os.EOL + os.EOL);
+                    });
+            }
+            catch (e)
+            {
+                reject(e);
+            }
+        });
+    }
+
+    public showConsole(preserveFocus: boolean) {
+        if (this.consoleTerminal) {
+            this.consoleTerminal.show(preserveFocus);
+        }
+    }
+
+    public dispose() {
+
+        // Clean up the session file
+        utils.deleteSessionFile(this.sessionFilePath);
+
+        if (this.consoleCloseSubscription) {
+            this.consoleCloseSubscription.dispose();
+            this.consoleCloseSubscription = undefined;
+        }
+
+        if (this.consoleTerminal) {
+            this.log.write(os.EOL + "Terminating PowerShell process...");
+            this.consoleTerminal.dispose();
+            this.consoleTerminal = undefined;
+        }
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -32,6 +32,10 @@ export interface IScriptAnalysisSettings {
     settingsPath: string;
 }
 
+export interface IDebuggingSettings {
+    createTemporaryIntegratedConsole?: boolean;
+}
+
 export interface IDeveloperSettings {
     featureFlags?: string[];
     powerShellExePath?: string;
@@ -47,6 +51,7 @@ export interface ISettings {
     useX86Host?: boolean;
     enableProfileLoading?: boolean;
     scriptAnalysis?: IScriptAnalysisSettings;
+    debugging?: IDebuggingSettings;
     developer?: IDeveloperSettings;
     codeFormatting?: ICodeFormattingSettings;
     integratedConsole?: IIntegratedConsoleSettings;
@@ -65,6 +70,10 @@ export function load(): ISettings {
     let defaultScriptAnalysisSettings: IScriptAnalysisSettings = {
         enable: true,
         settingsPath: ""
+    };
+
+    let defaultDebuggingSettings: IDebuggingSettings = {
+        createTemporaryIntegratedConsole: false,
     };
 
     let defaultDeveloperSettings: IDeveloperSettings = {
@@ -100,6 +109,7 @@ export function load(): ISettings {
         useX86Host: configuration.get<boolean>("useX86Host", false),
         enableProfileLoading: configuration.get<boolean>("enableProfileLoading", false),
         scriptAnalysis: configuration.get<IScriptAnalysisSettings>("scriptAnalysis", defaultScriptAnalysisSettings),
+        debugging: configuration.get<IDebuggingSettings>("debugging", defaultDebuggingSettings),
         developer: configuration.get<IDeveloperSettings>("developer", defaultDeveloperSettings),
         codeFormatting: configuration.get<ICodeFormattingSettings>("codeFormatting", defaultCodeFormattingSettings),
         integratedConsole: configuration.get<IIntegratedConsoleSettings>("integratedConsole", defaultIntegratedConsoleSettings)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,3 +124,7 @@ export function getTimestampString() {
     var time = new Date();
     return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`
 }
+
+export function isWindowsOS(): boolean {
+    return os.platform() == "win32";
+}


### PR DESCRIPTION
This change enables the user to configure their debugging sessions to
launch a fresh PowerShell process each time they start the debugger.
This is useful when debugging scripts or modules which use PowerShell
classes or managed assemblies which cannot be reloaded within the same
process.

Resolves #367.