### PR TITLE
Replace hardcoded c:\windows with ${env:windir}.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
 
     "windows": {
-        "command": "C:\\Windows\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "command": "${env:windir}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {

--- a/examples/.vscode/tasks.json
+++ b/examples/.vscode/tasks.json
@@ -33,7 +33,7 @@
 
     // Start PowerShell
     "windows": {
-        "command": "C:\\Windows\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "command": "${env:windir}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {


### PR DESCRIPTION
We used to have ${env.windir} but then VSCode broke us so we switched back to C:\Windows.

It turns out that the VSCode folks changed the syntax to ${env:windir} - replacing the dot with a colon.

Here's the VSCode issue describing this: https://github.com/Microsoft/vscode/issues/28365#issuecomment-308231940