### PR TITLE
Add Stroustrup style.

### DIFF
--- a/package.json
+++ b/package.json
@@ -416,8 +416,9 @@
           "type":"string",
           "enum": [
             "Custom",
+            "Allman",
             "OTBS",
-            "Allman"
+            "Stroustrup"
           ],
           "default": "Custom",
           "description": "Sets the codeformatting options to follow the given indent style in a way that is compatible with PowerShell syntax. For more information about the brace styles please refer to https://github.com/PoshCode/PowerShellPracticeAndStyle/issues/81."

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,8 +9,9 @@ import utils = require('./utils');
 
 enum CodeFormattingPreset {
     Custom,
+    Allman,
     OTBS,
-    Allman
+    Stroustrup
 }
 
 export interface ICodeFormattingSettings {


### PR DESCRIPTION
With three named styles it seemed appropriate to list them in alpha order.  However, I left Custom first.  Note that VSCode lists the names in alpha order.