### PR TITLE
Implement InvokeRegisteredEditorCommand 

### DIFF
--- a/src/features/CustomViews.ts
+++ b/src/features/CustomViews.ts
@@ -179,7 +179,7 @@ class HtmlContentView extends CustomView {
 
     getContent(): string {
         // Return an HTML page which disables JavaScript in content by default
-        return `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src *; style-src 'self'; script-src 'none';"></head><body>${this.htmlContent}</body></html>`;
+        return `<html><head></head><body>${this.htmlContent}</body></html>`;
     }
 }
 

--- a/src/features/CustomViews.ts
+++ b/src/features/CustomViews.ts
@@ -179,7 +179,7 @@ class HtmlContentView extends CustomView {
 
     getContent(): string {
         // Return an HTML page which disables JavaScript in content by default
-        return `<html><head></head><body>${this.htmlContent}</body></html>`;
+        return `<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src *; style-src 'self'; script-src 'none';"></head><body>${this.htmlContent}</body></html>`;
     }
 }
 


### PR DESCRIPTION
This PR registers a new vscode-command. The command accepts a command name as a parameter so it can be invoked through a link inside of a HTMLContentView ([see here](https://code.visualstudio.com/docs/extensionAPI/vscode-api-commands#_links))
For further information, take a look [here](https://github.com/PowerShell/vscode-powershell/issues/917) 