### PR TITLE
Lock TypeScript version to 2.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@types/node": "^6.0.40",
-    "typescript": "^2.0.3",
+    "typescript": "2.3.x",
     "vsce": "^1.18.0",
     "vscode": "^1.1.0"
   },


### PR DESCRIPTION
TypeScript 2.4 changed their type comparisons in a way that caused the
compiler to throw errors on code that works correctly.  There's
currently an issue with the vscode-languageserver-types library that's
causing a type clash in our code.  Until that issue is resolved I'm
locking our TypeScript version to 2.3.