### PR TITLE
Eliminate Pester duplicate failures in Problems view.

### DIFF
--- a/examples/.vscode/tasks.json
+++ b/examples/.vscode/tasks.json
@@ -84,7 +84,7 @@
             "isTestCommand": true,
             "showOutput": "always",
             "args": [
-                "Write-Host 'Invoking Pester...'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
+                "Write-Host 'Invoking Pester...'; $ProgressPreference = 'SilentlyContinue'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"
             ],
             "problemMatcher": "$pester"


### PR DESCRIPTION
When tasks is set to 2.0.0, the tasks run in the terminal and in this case, Pester outputs a bunch of progress text to the terminal.  This results in duplicate failures being found by the problem matcher.

Work around this problem for now by eliminating the Pester progress output.  For more details see - https://github.com/Microsoft/vscode/issues/22065#issuecomment-313418250