### PR TITLE
Allow inclusion of JavaScript and CSS file paths in the HtmlContentView

### DIFF
--- a/examples/Assets/script.js
+++ b/examples/Assets/script.js
@@ -1,0 +1,3 @@
+var h1 = document.createElement('h1');
+h1.appendChild(document.createTextNode('Hello from JavaScript!'));
+document.body.appendChild(h1);

--- a/examples/Assets/style.css
+++ b/examples/Assets/style.css
@@ -1,0 +1,4 @@
+body {
+    color: white;
+    background-color: cornflowerblue;
+}

--- a/examples/ContentViewTest.ps1
+++ b/examples/ContentViewTest.ps1
@@ -1,0 +1,8 @@
+$params = @{
+    HtmlBodyContent = "Testing JavaScript and CSS paths..."
+    JavaScriptPaths = ".\Assets\script.js"
+    StyleSheetPaths = ".\Assets\style.css"
+}
+
+$view = New-VSCodeHtmlContentView -Title "Test View" -ShowInColumn Two
+Set-VSCodeHtmlContentView -View $view @params


### PR DESCRIPTION
This change adds the client-side behavior for new parameters to
Set-VSCodeHtmlContentView which allow the user to specify JavaScriptPaths
and StyleSheetPaths to include local JavaScript and CSS files into their
HTML views.

Resolves #910.