### PR TITLE
Switch tasks comand to use System32 instead of sysnative. 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
 
     "windows": {
-        "command": "${env:windir}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
@@ -13,8 +13,6 @@
         "command": "/usr/local/bin/powershell",
         "args": [ "-NoProfile" ]
     },
-
-    "showOutput": "always",
 
     "tasks": [
         {

--- a/examples/.vscode/tasks.json
+++ b/examples/.vscode/tasks.json
@@ -33,7 +33,7 @@
 
     // Start PowerShell
     "windows": {
-        "command": "${env:windir}\\sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
+        "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
         "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
     },
     "linux": {
@@ -45,15 +45,11 @@
         "args": [ "-NoProfile" ]
     },
 
-    // Show the output window always
-    "showOutput": "always",
-
     // Associate with test task runner
     "tasks": [
         {
             "taskName": "Clean",
             "suppressTaskName": true,
-            "showOutput": "always",
             "args": [
                 "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Clean;",
                 "Invoke-Command { Write-Host 'Completed Clean task in task runner.' }"
@@ -63,7 +59,6 @@
             "taskName": "Build",
             "suppressTaskName": true,
             "isBuildCommand": true,
-            "showOutput": "always",
             "args": [
                 "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Build;",
                 "Invoke-Command { Write-Host 'Completed Build task in task runner.' }"
@@ -72,7 +67,6 @@
         {
             "taskName": "Publish",
             "suppressTaskName": true,
-            "showOutput": "always",
             "args": [
                 "Write-Host 'Invoking PSake...'; Invoke-PSake build.ps1 -taskList Publish;",
                 "Invoke-Command { Write-Host 'Completed Publish task in task runner.' }"
@@ -82,7 +76,6 @@
             "taskName": "Test",
             "suppressTaskName": true,
             "isTestCommand": true,
-            "showOutput": "always",
             "args": [
                 "Write-Host 'Invoking Pester...'; $ProgressPreference = 'SilentlyContinue'; Invoke-Pester -PesterOption @{IncludeVSCodeMarker=$true};",
                 "Invoke-Command { Write-Host 'Completed Test task in task runner.' }"


### PR DESCRIPTION
This should work in both 32-bit and 64-bit VSCode.

Also removed showOutput=always as that is the default plus it is deprecated.