### PR TITLE
Remove macOS OpenSSL Error for PS Core Beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,6 @@ dist: trusty
 osx_image: xcode8.3
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      brew install openssl;
-      mkdir -p /usr/local/lib;
-      ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/;
-      ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/;
-    fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       nvm install v6.0.0;
     fi

--- a/build/download.sh
+++ b/build/download.sh
@@ -113,34 +113,8 @@ case "$OSTYPE" in
         esac
         ;;
     darwin*)
-        patched=0
-        if hash brew 2>/dev/null; then
-            brew update
-            if [[ ! -d $(brew --prefix openssl) ]]; then
-               echo "Installing OpenSSL with brew..."
-               if ! brew install openssl; then
-                   echo "ERROR: OpenSSL failed to install! Crypto functions will not work..." >&2
-                   # Don't abort because it is not fatal
-               elif ! brew install curl --with-openssl; then
-                   echo "ERROR: curl failed to build against OpenSSL; SSL functions will not work..." >&2
-                   # Still not fatal
-               else
-                   # OpenSSL installation succeeded; reme           mber to patch System.Net.Http after PowerShell installation
-                   patched=1
-               fi
-            fi
-
-        else
-            echo "ERROR: brew not found! OpenSSL may not be available..." >&2
-            # Don't abort because it is not fatal
-        fi
-
         echo "Installing $package with sudo ..."
         sudo installer -pkg "./$package" -target /
-        if [[ $patched -eq 1 ]]; then
-            echo "Patching System.Net.Http for libcurl and OpenSSL..."
-            find /usr/local/microsoft/powershell -name System.Net.Http.Native.dylib | xargs sudo install_name_tool -change /usr/lib/libcurl.4.dylib /usr/local/opt/curl/lib/libcurl.4.dylib
-        fi
         ;;
 esac
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -19,9 +19,12 @@ This issue has been resolved in PowerShell 5.1.
 
 ### 1. PowerShell IntelliSense does not work, can't debug scripts
 
-The most common problem when the PowerShell extension doesn't work on macOS is that
-OpenSSL is not installed.  You can check for the installation of OpenSSL by looking for
-the following files:
+The most common problem when the PowerShell extension doesn't work on macOS is that you have
+an alpha version of PowerShell installed. To upgrade to the latest beta, please follow the
+[Install Instructions](https://github.com/PowerShell/PowerShell/blob/master/docs/installation/linux.md#macos-1012).
+
+If you'd prefer to use an alpha version of PowerShell, then OpenSSL must be installed.
+You can check for the installation of OpenSSL by looking for the following files:
 
 If installed using Homebrew:
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -91,16 +91,18 @@ export class SessionManager implements Middleware {
 
         this.createStatusBarItem();
 
-        // Check for OpenSSL dependency on macOS.  Look for the default Homebrew installation
-        // path and if that fails check the system-wide library path.
-        if (os.platform() == "darwin") {
+        this.powerShellExePath = this.getPowerShellExePath();
+
+        // Check for OpenSSL dependency on macOS when running PowerShell Core alpha. Look for the default
+        // Homebrew installation path and if that fails check the system-wide library path.
+        if (os.platform() == "darwin" && this.getPowerShellVersionLabel() == "alpha") {
             if (!(utils.checkIfFileExists("/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib") &&
                     utils.checkIfFileExists("/usr/local/opt/openssl/lib/libssl.1.0.0.dylib")) &&
                 !(utils.checkIfFileExists("/usr/local/lib/libcrypto.1.0.0.dylib") &&
                     utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib"))) {
                     var thenable =
                         vscode.window.showWarningMessage(
-                            "The PowerShell extension will not work without OpenSSL on macOS and OS X",
+                            "The PowerShell extension will not work without OpenSSL on macOS and OS X when using PowerShell alpha",
                             "Show Documentation");
 
                     thenable.then(
@@ -117,7 +119,6 @@ export class SessionManager implements Middleware {
         }
 
         this.suppressRestartPrompt = false;
-        this.powerShellExePath = this.getPowerShellExePath();
 
         if (this.powerShellExePath) {
 
@@ -637,6 +638,33 @@ export class SessionManager implements Middleware {
         }
 
         return resolvedPath;
+    }
+
+    private getPowerShellVersionLabel(): string {
+        if (this.powerShellExePath) {
+            var powerShellCommandLine = [
+                this.powerShellExePath,
+                "-NoProfile",
+                "-NonInteractive"
+            ];
+
+            // Only add ExecutionPolicy param on Windows
+            if (utils.isWindowsOS()) {
+                powerShellCommandLine.push("-ExecutionPolicy", "Bypass")
+            }
+
+            powerShellCommandLine.push(
+                "-Command",
+                "'$PSVersionTable | ConvertTo-Json'");
+
+            var powerShellOutput = cp.execSync(powerShellCommandLine.join(' '));
+            var versionDetails = JSON.parse(powerShellOutput.toString());
+            return versionDetails.PSVersion.Label;
+        }
+        else {
+            // TODO: throw instead?
+            return null;
+        }
     }
 
     private showSessionConsole(isExecute?: boolean) {


### PR DESCRIPTION
.NET Core removed its dependency on OpenSSL on Mac in version 2.0.
PowerShell Core Beta requires .NET Core 2.0 so it's safe to allow
the PowerShell extension to launch if it detects the user is
running PowerShell Core Beta