### PR TITLE
Fix tasks to run under VSCode 1.17.2 on Linux

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,48 +17,39 @@
     "tasks": [
         {
             "taskName": "Install",
-            "suppressTaskName": true,
-            "args": [
-                "Invoke-Build Restore"
-            ]
+            "type": "shell",
+            "command": "Invoke-Build Restore"
         },
         {
             "taskName": "CleanAll",
-            "suppressTaskName": true,
-            "args": [
-                "Invoke-Build CleanAll"
-            ]
+            "type": "shell",
+            "command": "Invoke-Build CleanAll"
         },
         {
             "taskName": "Clean",
-            "suppressTaskName": true,
-            "args": [
-                "Invoke-Build Clean"
-            ]
+            "type": "shell",
+            "command": "Invoke-Build Clean"
         },
         {
             "taskName": "BuildAll",
-            "suppressTaskName": true,
-            "isBuildCommand": true,
-            "args": [
-                "Invoke-Build BuildAll"
-            ],
+            "type": "shell",
+            "command": "Invoke-Build BuildAll",
             "problemMatcher": []
         },
         {
             "taskName": "Build",
-            "suppressTaskName": true,
-            "args": [
-                "Invoke-Build Build"
-            ],
+            "type": "shell",
+            "command": "Invoke-Build Build",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
             "problemMatcher": []
         },
         {
             "taskName": "Test",
-            "suppressTaskName": true,
-            "args": [
-                "Invoke-Build Test"
-            ],
+            "type": "shell",
+            "command": "Invoke-Build Test",
             "group": {
                 "kind": "test",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,43 +3,37 @@
 
     "windows": {
         "command": "${env:windir}/System32/WindowsPowerShell/v1.0/powershell.exe",
-        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass" ]
+        "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
     },
     "linux": {
         "command": "/usr/bin/powershell",
-        "args": [ "-NoProfile" ]
+        "args": [ "-NoProfile", "-Command" ]
     },
     "osx": {
         "command": "/usr/local/bin/powershell",
-        "args": [ "-NoProfile" ]
+        "args": [ "-NoProfile", "-Command" ]
     },
 
     "tasks": [
         {
             "taskName": "Install",
-            "type": "shell",
-            "command": "Invoke-Build Restore"
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "Restore" ]
         },
         {
             "taskName": "CleanAll",
-            "type": "shell",
-            "command": "Invoke-Build CleanAll"
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "CleanAll" ]
         },
         {
             "taskName": "Clean",
-            "type": "shell",
-            "command": "Invoke-Build Clean"
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "Clean" ]
         },
         {
             "taskName": "BuildAll",
-            "type": "shell",
-            "command": "Invoke-Build BuildAll",
-            "problemMatcher": []
-        },
-        {
-            "taskName": "Build",
-            "type": "shell",
-            "command": "Invoke-Build Build",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "BuildAll" ],
             "group": {
                 "kind": "build",
                 "isDefault": true
@@ -47,9 +41,16 @@
             "problemMatcher": []
         },
         {
+            "taskName": "Build",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "Build" ],
+            "group": "build",
+            "problemMatcher": []
+        },
+        {
             "taskName": "Test",
-            "type": "shell",
-            "command": "Invoke-Build Test",
+            "suppressTaskName": true,
+            "args": [ "Invoke-Build", "Test" ],
             "group": {
                 "kind": "test",
                 "isDefault": true


### PR DESCRIPTION
None of these were working correctly on Ubuntu 16.04.

Looking at the original file in VSCode 1.17.2 showed deprecation warnings on `suppressTaskName`.  But you can't "just" remove that field other it was sticking in the task name as part of the command.  Switching to `command` seems to fix this.