### PR TITLE
Give better error msg when attach to process w/PS Core

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -48,6 +48,14 @@ export class DebugSessionFeature implements IFeature {
         var settings = Settings.load();
         let createNewIntegratedConsole = settings.debugging.createTemporaryIntegratedConsole;
 
+        if (config.request === "attach") {
+            let versionDetails = this.sessionManager.getPowerShellVersionDetais();
+            if (versionDetails.edition.toLowerCase() === "core") {
+                vscode.window.showErrorMessage("PowerShell Core does not support attaching to a PowerShell host process.");
+                return;
+            }
+        }
+
         if (generateLaunchConfig) {
             // No launch.json, create the default configuration for both unsaved (Untitled) and saved documents.
             config.type = 'PowerShell';

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -51,8 +51,10 @@ export class DebugSessionFeature implements IFeature {
         if (config.request === "attach") {
             let versionDetails = this.sessionManager.getPowerShellVersionDetais();
             if (versionDetails.edition.toLowerCase() === "core") {
-                vscode.window.showErrorMessage("PowerShell Core does not support attaching to a PowerShell host process.");
-                return;
+                let msg = "PowerShell Core does not support attaching to a PowerShell host process.";
+                return vscode.window.showErrorMessage(msg).then(_ => {
+                    return undefined;
+                });
             }
         }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -217,6 +217,10 @@ export class SessionManager implements Middleware {
         return this.sessionDetails;
     }
 
+    public getPowerShellVersionDetais() : PowerShellVersionDetails {
+        return this.versionDetails;
+    }
+
     public dispose() : void {
         // Stop the current session
         this.stop();


### PR DESCRIPTION
The current approach spits out a message in the terminal about a missing wincore pkg.

Here's the new error:
![image](https://user-images.githubusercontent.com/5177512/31866374-cd11568a-b73b-11e7-91da-50b201f5135e.png)
