### PR TITLE
Get VSCode to stop prompting about output options for tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,17 +18,20 @@
         {
             "taskName": "Install",
             "suppressTaskName": true,
-            "args": [ "Invoke-Build", "Restore" ]
+            "args": [ "Invoke-Build", "Restore" ],
+            "problemMatcher": []
         },
         {
             "taskName": "CleanAll",
             "suppressTaskName": true,
-            "args": [ "Invoke-Build", "CleanAll" ]
+            "args": [ "Invoke-Build", "CleanAll" ],
+            "problemMatcher": []
         },
         {
             "taskName": "Clean",
             "suppressTaskName": true,
-            "args": [ "Invoke-Build", "Clean" ]
+            "args": [ "Invoke-Build", "Clean" ],
+            "problemMatcher": []
         },
         {
             "taskName": "BuildAll",


### PR DESCRIPTION
This has been driving me batty as I've been testing different versions of the vscode protocol.