### PR TITLE
Update to handle PS Core binary name change

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -73,7 +73,7 @@ export function getDefaultPowerShellPath(
     }
     else if (platformDetails.operatingSystem == OperatingSystem.MacOS) {
         powerShellExePath = "/usr/local/bin/powershell";
-        if (fs.existsSync("/usr/loca/bin/pwsh")) {
+        if (fs.existsSync("/usr/local/bin/pwsh")) {
             powerShellExePath = "/usr/local/bin/pwsh";
         }
     }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -73,9 +73,15 @@ export function getDefaultPowerShellPath(
     }
     else if (platformDetails.operatingSystem == OperatingSystem.MacOS) {
         powerShellExePath = "/usr/local/bin/powershell";
+        if (fs.existsSync("/usr/loca/bin/pwsh")) {
+            powerShellExePath = "/usr/local/bin/pwsh";
+        }
     }
     else if (platformDetails.operatingSystem == OperatingSystem.Linux) {
         powerShellExePath = "/usr/bin/powershell";
+        if (fs.existsSync("/usr/bin/pwsh")) {
+            powerShellExePath = "/usr/bin/pwsh";
+        }
     }
 
     return powerShellExePath;
@@ -146,9 +152,14 @@ export function getAvailablePowerShellExes(platformDetails: PlatformDetails): Po
                 .map(item => path.join(psCoreInstallPath, item))
                 .filter(item => fs.lstatSync(item).isDirectory())
                 .map(item => {
+                    let exePath = path.join(item, "pwsh.exe");
+                    if (!fs.existsSync(exePath)) {
+                        exePath = path.join(item, "powershell.exe");
+                    }
+
                     return {
                         versionName: `PowerShell Core ${path.parse(item).base}`,
-                        exePath: path.join(item, "powershell.exe")
+                        exePath: exePath
                     };
                 });
 
@@ -158,12 +169,10 @@ export function getAvailablePowerShellExes(platformDetails: PlatformDetails): Po
         }
     }
     else {
+
         paths.push({
             versionName: "PowerShell Core",
-            exePath:
-                os.platform() === "darwin"
-                        ? "/usr/local/bin/powershell"
-                        : "/usr/bin/powershell"
+            exePath: this.getDefaultPowerShellPath(platformDetails)
         });
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -560,6 +560,14 @@ export class SessionManager implements Middleware {
              this.sessionSettings.developer.powerShellExePath ||
              "").trim();
 
+        // New versions of PS Core uninstall the previous version
+        // so make sure the path stored in the settings exists.
+        if (!fs.existsSync(powerShellExePath)) {
+            this.log.write(
+                `Path specified by 'powerShellExePath' setting - '${powerShellExePath}' - not found, reverting to default PowerShell path.`);
+            powerShellExePath = "";
+        }
+
         if (this.platformDetails.operatingSystem === OperatingSystem.Windows &&
             powerShellExePath.length > 0) {
 


### PR DESCRIPTION
Fix #1064

Also fixes case where the powerShellExePath setting is no longer valid.  This happens when a Windows users installs an updated pre-release version of PS Core.  That uninstalls previous versions.