### PR TITLE
Workaround VSCode bug where ${script} var not expanded

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -121,7 +121,15 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                         vscode.window.showErrorMessage(msg);
                         return;
                     }
+
+                    if (config.script === "${file}") {
+                        config.script = currentDocument.fileName;
+                    }
                 }
+            }
+
+            if (config.cwd === "${file}") {
+                config.cwd = currentDocument.fileName;
             }
 
             if (config.createTemporaryIntegratedConsole !== undefined) {


### PR DESCRIPTION
This happens when you start a debug session from a git diff window.  Helps address 