### PR TITLE
add vscode-powershell email

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You have two options for sending us the logs:
 
   1. If you are editing scripts that contain sensitive information (intellectual property,
      deployment or administrative information, etc), e-mail the logs directly to
-     *tyleonha [at] microsoft.com* or reach out to one of the [other maintainers](https://github.com/powershell/vscode-powershell#maintainers) directly.
+     *vscode-powershell@microsoft.com*.
 
   2. If you are editing scripts that don't contain sensitive information, you can drag and
      drop your logs ZIP file into the GitHub issue that you are creating.


### PR DESCRIPTION
This email includes a few folks on the PowerShell team and should be used for folks that have sensitive information and want to talk/give logs to someone from Microsoft directly.
 
The email is vscode-powershell@microsoft.com