### PR TITLE
Check for the expected version of the PowerShell Editor Services module fails because of the wrong function parameters

### DIFF
--- a/scripts/Start-EditorServices.ps1
+++ b/scripts/Start-EditorServices.ps1
@@ -195,7 +195,7 @@ if ((Test-ModuleAvailable "PowerShellGet") -eq $false) {
 # Check if the expected version of the PowerShell Editor Services
 # module is installed
 $parsedVersion = New-Object System.Version @($EditorServicesVersion)
-if ((Test-ModuleAvailable "PowerShellEditorServices" -RequiredVersion $parsedVersion) -eq $false) {
+if ((Test-ModuleAvailable "PowerShellEditorServices" $parsedVersion) -eq $false) {
     if ($ConfirmInstall -and $isPS5orLater) {
         # TODO: Check for error and return failure if necessary
         Install-Module "PowerShellEditorServices" -RequiredVersion $parsedVersion -Confirm


### PR DESCRIPTION
'Test-ModuleAvailable' function does not have -RequiredVersion parameter, hence the script fails to evaluate the condition (at least for PS version 3.0.1).