### PR TITLE
onDebug to onDebugResolve:type

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.19.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
@@ -26,7 +26,7 @@
   },
   "main": "./out/src/main",
   "activationEvents": [
-    "onDebugResolve:type",
+    "onDebugResolve:powershell",
     "onLanguage:powershell",
     "onCommand:PowerShell.NewProjectFromTemplate",
     "onCommand:PowerShell.OpenExamplesFolder",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "main": "./out/src/main",
   "activationEvents": [
-    "onDebug",
+    "onDebugResolve:type",
     "onLanguage:powershell",
     "onCommand:PowerShell.NewProjectFromTemplate",
     "onCommand:PowerShell.OpenExamplesFolder",


### PR DESCRIPTION
The [docs](https://code.visualstudio.com/updates/v1_19#_debug-contributions-in-packagejson) say, in 1.19, VSCode made more fine-grained debugger activation events.

Read the link for the full details but the rule of thumb goes as followed:

> Rule of thumb: If activation of a debug extensions is lightweight, use `onDebug`. If it is heavyweight, use `onDebugInitialConfigurations` and/or `onDebugResolve` depending on whether the `DebugConfigurationProvider` implements the corresponding methods `provideDebugConfigurations` and/or `resolveDebugConfiguration`.

The vscode-powershell extension implements just `resolveDebugConfiguration` [here](https://github.com/PowerShell/vscode-powershell/blob/1371181091fd67525c6b5e89c78ea9d15ba26b45/src/features/DebugSession.ts#L37) so we just need to replace `onDebug` with `onDebugResolve:type`

Resolves https://github.com/PowerShell/vscode-powershell/issues/1179