### PR TITLE
add build.ps1 to align with PSES and other PowerShell projects

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,4 +1,7 @@
 #!/usr/bin/env pwsh
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 param(
     [Parameter()]
     [switch]

--- a/build.ps1
+++ b/build.ps1
@@ -3,15 +3,15 @@
 # Licensed under the MIT License.
 
 param(
-    [Parameter()]
+    [Parameter(ParameterSetName="Bootstrap")]
     [switch]
     $Bootstrap,
 
-    [Parameter()]
+    [Parameter(ParameterSetName="Build")]
     [switch]
     $Clean,
 
-    [Parameter()]
+    [Parameter(ParameterSetName="Build")]
     [switch]
     $Test
 )
@@ -22,15 +22,6 @@ $NeededTools = @{
     PowerShellGet = "PowerShellGet latest"
     InvokeBuild = "InvokeBuild latest"
 }
-
-if ((-not $PSVersionTable["OS"]) -or $PSVersionTable["OS"].Contains("Windows")) {
-    $OS = "Windows"
-} elseif ($PSVersionTable["OS"].Contains("Darwin")) {
-    $OS = "macOS"
-} else {
-    $OS = "Linux"
-}
-
 
 function needsVSCode () {
     try {


### PR DESCRIPTION
Resolves:  https://github.com/PowerShell/vscode-powershell/issues/1127

Here's the build.ps1 PR for PowerShellEditorServices:
https://github.com/PowerShell/PowerShellEditorServices/pull/623

## In scope:

* running `build.ps1` checks for missing tools and runs `Invoke-Build Build`
* running `build.ps1 -Clean` checks for missing tools and runs `Invoke-Build Clean` and then `Invoke-Build Build`
* running `build.ps1 -Test` checks for missing tools and runs `Invoke-Build Build` and then `Invoke-Build Test`
* running `build.ps1 -Bootstrap` informs you of what tools you are missing
    - the dependencies it checks for are:
        - VSCode
        - Node.js 6 or greater 
        - PowerShellGet
        - InvokeBuild
