### PR TITLE
Fix a typo in PSScriptAnalyzerSettings.psd1

### DIFF
--- a/examples/PSScriptAnalyzerSettings.psd1
+++ b/examples/PSScriptAnalyzerSettings.psd1
@@ -17,7 +17,7 @@
                      'PSShouldProcess',
                      'PSUseApprovedVerbs',
                      'PSAvoidUsingCmdletAliases',
-                     'PSUseDeclaredVarsMoreThanAssigments')
+                     'PSUseDeclaredVarsMoreThanAssignments')
 
     # Do not analyze the following rules. Use ExcludeRules when you have
     # commented out the IncludeRules settings above and want to include all


### PR DESCRIPTION
PSScriptAnalyzer: [RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md)