### PR TITLE
Fix issue w/launch config not using the temp integrated console setting

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -133,7 +133,11 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                 config.cwd = currentDocument.fileName;
             }
 
-            if (config.createTemporaryIntegratedConsole !== undefined) {
+            // If the createTemporaryIntegratedConsole field is not specified in the launch config, set the field using
+            // the value from the corresponding setting.  Otherwise, the launch config value overrides the setting.
+            if (config.createTemporaryIntegratedConsole === undefined) {
+                config.createTemporaryIntegratedConsole = createNewIntegratedConsole;
+            } else {
                 createNewIntegratedConsole = config.createTemporaryIntegratedConsole;
             }
         }


### PR DESCRIPTION
This ensures we pass the correct value to PSES so that it won't exit the temp console after execution.