### PR TITLE
Add key binding for Show Additional Commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
         "when": "editorTextFocus && editorLangId == 'powershell'"
       },
       {
+        "command": "PowerShell.ShowAdditionalCommands",
+        "key": "ctrl+alt+a",
+        "when": "editorTextFocus && editorLangId == 'powershell'"
+      },
+      {
         "command": "PowerShell.RunSelection",
         "key": "f8",
         "when": "editorTextFocus && editorLangId == 'powershell'"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       },
       {
         "command": "PowerShell.ShowAdditionalCommands",
-        "key": "ctrl+alt+a",
+        "key": "shift+alt+s",
         "when": "editorTextFocus && editorLangId == 'powershell'"
       },
       {


### PR DESCRIPTION
Adds default keyboard shortcut Ctrl-Alt-A for "Show Additional Commands from Modules".
Resolves #196 