### PR TITLE
Defend HelpCompletion from null message from VSCode

### DIFF
--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -6,6 +6,7 @@ import { Disposable, EndOfLine, Position, Range, SnippetString,
     TextDocument, TextDocumentChangeEvent, window, workspace } from "vscode";
 import { LanguageClient, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
+import { Logger } from "../logging";
 
 export const CommentHelpRequestType =
     new RequestType<any, any, void, void>("powerShell/getCommentHelp");
@@ -27,7 +28,7 @@ export class HelpCompletionFeature implements IFeature {
     private languageClient: LanguageClient;
     private disposable: Disposable;
 
-    constructor() {
+    constructor(private log: Logger) {
         this.helpCompletionProvider = new HelpCompletionProvider();
         const subscriptions = [];
         workspace.onDidChangeTextDocument(this.onEvent, this, subscriptions);
@@ -44,7 +45,8 @@ export class HelpCompletionFeature implements IFeature {
     }
 
     public onEvent(changeEvent: TextDocumentChangeEvent): void {
-        if (!changeEvent) {
+        if (!(changeEvent && changeEvent.contentChanges && changeEvent.contentChanges[0])) {
+            this.log.write(`Bad change event message: ${JSON.stringify(changeEvent)}`);
             return;
         }
 

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -45,19 +45,21 @@ export class HelpCompletionFeature implements IFeature {
     }
 
     public onEvent(changeEvent: TextDocumentChangeEvent): void {
-        if (!(changeEvent && changeEvent.contentChanges && changeEvent.contentChanges[0])) {
-            this.log.write(`Bad change event message: ${JSON.stringify(changeEvent)}`);
+        if (!(changeEvent && changeEvent.contentChanges)) {
+            this.log.write(`Bad TextDocumentChangeEvent message: ${JSON.stringify(changeEvent)}`);
             return;
         }
 
-        this.helpCompletionProvider.updateState(
-            changeEvent.document,
-            changeEvent.contentChanges[0].text,
-            changeEvent.contentChanges[0].range);
+        if (changeEvent.contentChanges.length > 0) {
+            this.helpCompletionProvider.updateState(
+                changeEvent.document,
+                changeEvent.contentChanges[0].text,
+                changeEvent.contentChanges[0].range);
 
-        // todo raise an event when trigger is found, and attach complete() to the event.
-        if (this.helpCompletionProvider.triggerFound) {
-            this.helpCompletionProvider.complete().then(() => this.helpCompletionProvider.reset());
+            // todo raise an event when trigger is found, and attach complete() to the event.
+            if (this.helpCompletionProvider.triggerFound) {
+                this.helpCompletionProvider.complete().then(() => this.helpCompletionProvider.reset());
+            }
         }
     }
 }

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -44,6 +44,10 @@ export class HelpCompletionFeature implements IFeature {
     }
 
     public onEvent(changeEvent: TextDocumentChangeEvent): void {
+        if (!changeEvent) {
+            return;
+        }
+
         this.helpCompletionProvider.updateState(
             changeEvent.document,
             changeEvent.contentChanges[0].text,

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,7 +124,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new DebugSessionFeature(context, sessionManager),
         new PickPSHostProcessFeature(),
         new SpecifyScriptArgsFeature(context),
-        new HelpCompletionFeature(),
+        new HelpCompletionFeature(logger),
         new CustomViewsFeature(),
     ];
 


### PR DESCRIPTION
Small change to ensure that null messages from VSCode don't cause errors, to fix #1230.