### PR TITLE
Have build script add dependent modules (PSSA & Plaster)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ install:
 
 script:
   - ulimit -n 4096
+  - powershell -c "Install-Module PowerShellGet -Force"
   - powershell -File build/travis.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ install:
 
 script:
   - ulimit -n 4096
-  - powershell -c "Install-Module PowerShellGet -Force"
+  - powershell -Command "Install-Module PowerShellGet -Force"
   - powershell -File build/travis.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,10 @@ install:
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
       Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force | Out-Null
       Install-Module platyPS -RequiredVersion 0.7.6 -Scope CurrentUser -Force | Out-Null
-  - powershell.exe -c "Install-Module PowerShellGet -Force"
+  - powershell.exe -Command "Install-Module PowerShellGet -Force"
 
 build_script:
-  - powershell.exe -c "Invoke-Build"
+  - powershell.exe -Command "Invoke-Build"
 
 # The build script takes care of the tests
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,9 +19,10 @@ install:
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
       Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force | Out-Null
       Install-Module platyPS -RequiredVersion 0.7.6 -Scope CurrentUser -Force | Out-Null
+  - powershell.exe -c "Install-Module PowerShellGet -Force"
 
 build_script:
-  - ps: Invoke-Build
+  - powershell.exe -c "Invoke-Build"
 
 # The build script takes care of the tests
 test: off

--- a/modules.json
+++ b/modules.json
@@ -1,0 +1,12 @@
+{
+    "PSScriptAnalyzer":{
+        "MinimumVersion":"1.0",
+        "MaximumVersion":"1.99",
+        "AllowPrerelease":false
+    },
+    "Plaster":{
+        "MinimumVersion":"1.0",
+        "MaximumVersion":"1.99",
+        "AllowPrerelease":false
+    }
+}

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -53,9 +53,9 @@ task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices 
     }
 }
 
-task Restore RestoreNodeModules, RestorePowerShellModules -Before Build
+task Restore -If { "Restore" -in $BuildTask } RestoreNodeModules, RestorePowerShellModules -Before Build
 
-task RestoreNodeModules -If { "Restore" -in $BuildTask -or !(Test-Path "./node_modules") } {
+task RestoreNodeModules -If { -not (Test-Path "./node_modules") } {
 
     Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
 
@@ -65,7 +65,7 @@ task RestoreNodeModules -If { "Restore" -in $BuildTask -or !(Test-Path "./node_m
     exec { & npm install $logLevelParam }
 }
 
-task RestorePowerShellModules -If { "Restore" -in $BuildTask -or !(Test-Path "./modules/Plaster") } {
+task RestorePowerShellModules -If { -not (Test-Path "./modules/Plaster") } {
     Save-Module -Name Plaster -Path "$PSScriptRoot/modules/"
     Save-Module -Name PSScriptAnalyzer -Path "$PSScriptRoot/modules/"
 }

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -66,8 +66,17 @@ task RestoreNodeModules -If { -not (Test-Path "$PSScriptRoot/node_modules") } {
 }
 
 task RestorePowerShellModules -If { -not (Test-Path "$PSScriptRoot/modules/Plaster") } {
-    Save-Module -Name Plaster -Path "$PSScriptRoot/modules/"
-    Save-Module -Name PSScriptAnalyzer -Path "$PSScriptRoot/modules/"
+    $modules = Get-Content -Raw "./modules.json" | ConvertFrom-Json
+    $modules.PSObject.Properties | ForEach-Object {
+        $params = @{
+            Name = $_.Name
+            MinimumVersion = $_.Value.MinimumVersion
+            MaximumVersion = $_.Value.MaximumVersion
+            AllowPrerelease = $_.Value.AllowPrerelease
+            Path = "$PSScriptRoot/modules/"
+        }
+        Save-Module @params
+    }
 }
 
 task Clean {

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -114,6 +114,7 @@ task Package {
     if ($script:psesBuildScriptPath) {
         Write-Host "`n### Copying PowerShellEditorServices module files" -ForegroundColor Green
         Copy-Item -Recurse -Force ..\PowerShellEditorServices\module\PowerShellEditorServices .\modules
+        Copy-Item -Recurse -Force ..\PowerShellEditorServices\module\PowerShellEditorServices.VSCode .\modules
     }
 
     Write-Host "`n### Packaging PowerShell-insiders.vsix`n" -ForegroundColor Green

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -66,7 +66,7 @@ task RestoreNodeModules -If { -not (Test-Path "$PSScriptRoot/node_modules") } {
 }
 
 task RestorePowerShellModules -If { -not (Test-Path "$PSScriptRoot/modules/Plaster") } {
-    $modules = Get-Content -Raw "./modules.json" | ConvertFrom-Json
+    $modules = Get-Content -Raw "$PSScriptRoot/modules.json" | ConvertFrom-Json
     $modules.PSObject.Properties | ForEach-Object {
         $params = @{
             Name = $_.Name

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -53,7 +53,9 @@ task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices 
     }
 }
 
-task Restore -If { "Restore" -in $BuildTask -or !(Test-Path "./node_modules") } -Before Build {
+task Restore RestoreNodeModules, RestorePowerShellModules -Before Build
+
+task RestoreNodeModules -If { "Restore" -in $BuildTask -or !(Test-Path "./node_modules") } {
 
     Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
 
@@ -61,6 +63,11 @@ task Restore -If { "Restore" -in $BuildTask -or !(Test-Path "./node_modules") } 
     # package install warnings don't cause PowerShell to throw up
     $logLevelParam = if ($env:AppVeyor) { "--loglevel=error" } else { "" }
     exec { & npm install $logLevelParam }
+}
+
+task RestorePowerShellModules -If { "Restore" -in $BuildTask -or !(Test-Path "./modules/Plaster") } {
+    Save-Module -Name Plaster -Path "$PSScriptRoot/modules/"
+    Save-Module -Name PSScriptAnalyzer -Path "$PSScriptRoot/modules/"
 }
 
 task Clean {

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -53,9 +53,9 @@ task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices 
     }
 }
 
-task Restore -If { "Restore" -in $BuildTask } RestoreNodeModules, RestorePowerShellModules -Before Build
+task Restore RestoreNodeModules, RestorePowerShellModules -Before Build
 
-task RestoreNodeModules -If { -not (Test-Path "./node_modules") } {
+task RestoreNodeModules -If { -not (Test-Path "$PSScriptRoot/node_modules") } {
 
     Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
 
@@ -65,7 +65,7 @@ task RestoreNodeModules -If { -not (Test-Path "./node_modules") } {
     exec { & npm install $logLevelParam }
 }
 
-task RestorePowerShellModules -If { -not (Test-Path "./modules/Plaster") } {
+task RestorePowerShellModules -If { -not (Test-Path "$PSScriptRoot/modules/Plaster") } {
     Save-Module -Name Plaster -Path "$PSScriptRoot/modules/"
     Save-Module -Name PSScriptAnalyzer -Path "$PSScriptRoot/modules/"
 }


### PR DESCRIPTION
This will add PSSA and Plaster to our build so that the vsix AppVeyor spits out _should_ be "release quality"

This vsix is a great example:
https://ci.appveyor.com/project/PowerShell/vscode-powershell/build/artifacts