### PR TITLE
Use uri.toString() instead of fsPath to get untittled:untitled-1 path

### DIFF
--- a/src/features/SelectPSSARules.ts
+++ b/src/features/SelectPSSARules.ts
@@ -47,7 +47,7 @@ export class SelectPSSARulesFeature implements IFeature {
                         this.languageClient.sendRequest(
                             SetPSSARulesRequestType,
                             {
-                                filepath: vscode.window.activeTextEditor.document.uri.fsPath,
+                                filepath: vscode.window.activeTextEditor.document.uri.toString(),
                                 ruleInfos: updatedOptions.map((option: ICheckboxQuickPickItem): RuleInfo => {
                                     return { name: option.label, isEnabled: option.isSelected };
                                 }),


### PR DESCRIPTION
If you use fsPath you get a path of "Untitled-1" which doesn't work
with PSES IsInMemory method.

Fix #1155 where selecting PSSA rules in Untitled-1 file crashes PSES.