### PR TITLE
Implementation of additional exe paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,6 +400,33 @@
           "isExecutable": true,
           "description": "Specifies the full path to a PowerShell executable. Changes the installation of PowerShell used for language and debugging services."
         },
+        "powershell.powerShellAdditionalExePaths": {
+            "type":"array",
+            "description": "Specifies an array of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
+            "isExecutable": true,
+            "uniqueItems": true,
+            "items": {
+                "type": "object",
+                "required":[
+                    "versionName",
+                    "exePath"
+                ],
+                "properties": {
+                    "versionName": {
+                        "type":"string",
+                        "description": "Specifies the version name of this PowerShell executable. The version name can be referenced via the powershell.powerShellDefaultVersion setting."
+                    },
+                    "exePath": {
+                        "type":"string",
+                        "description": "Specifies the path to the PowerShell executable. Typically this is a path to a non-standard install location."
+                    }
+                }
+            }
+        },
+        "powershell.powerShellDefaultVersion": {
+            "type":"string",
+            "description": "Specifies the name of the PowerShell version used in the startup session when the extension loads e.g \"Windows PowerShell (x86)\" or \"PowerShell Core 6.0.2 (x64)\"."
+        },
         "powershell.startAutomatically": {
           "type": "boolean",
           "default": true,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,14 +108,13 @@ export function fixWindowsPowerShellPath(powerShellExePath: string, platformDeta
     return powerShellExePath;
 }
 
-export function getAvailablePowerShellExes(platformDetails: IPlatformDetails): IPowerShellExeDetails[] {
+export function getAvailablePowerShellExes(
+    platformDetails: IPlatformDetails,
+    sessionSettings: Settings.ISettings | undefined): IPowerShellExeDetails[] {
 
     let paths: IPowerShellExeDetails[] = [];
 
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
-        const psCoreInstallPath =
-            (!platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
-
         if (platformDetails.isProcess64Bit) {
             paths.push({
                 versionName: WindowsPowerShell64BitLabel,
@@ -140,19 +139,22 @@ export function getAvailablePowerShellExes(platformDetails: IPlatformDetails): I
             });
         }
 
+        const psCoreInstallPath =
+            (!platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
+
         if (fs.existsSync(psCoreInstallPath)) {
+            const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
             const psCorePaths =
                 fs.readdirSync(psCoreInstallPath)
                 .map((item) => path.join(psCoreInstallPath, item))
-                .filter((item) => fs.lstatSync(item).isDirectory())
+                .filter((item) => {
+                    const exePath = path.join(item, "pwsh.exe");
+                    return fs.lstatSync(item).isDirectory() && fs.existsSync(exePath);
+                })
                 .map((item) => {
-                    let exePath = path.join(item, "pwsh.exe");
-                    if (!fs.existsSync(exePath)) {
-                        exePath = path.join(item, "powershell.exe");
-                    }
-
+                    const exePath = path.join(item, "pwsh.exe");
                     return {
-                        versionName: `PowerShell Core ${path.parse(item).base}`,
+                        versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
                         exePath,
                     };
                 });
@@ -162,10 +164,22 @@ export function getAvailablePowerShellExes(platformDetails: IPlatformDetails): I
             }
         }
     } else {
+        // Handle Linux and macOS case
         paths.push({
             versionName: "PowerShell Core",
             exePath: this.getDefaultPowerShellPath(platformDetails),
         });
+    }
+
+    // When unit testing, we don't have session settings to test so skip reading this setting
+    if (sessionSettings) {
+        // Add additional PowerShell paths as configured in settings
+        for (const additionalPowerShellExePath of sessionSettings.powerShellAdditionalExePaths) {
+            paths.push({
+                versionName: additionalPowerShellExePath.versionName,
+                exePath: additionalPowerShellExePath.exePath,
+            });
+        }
     }
 
     return paths;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -151,13 +151,10 @@ export function getAvailablePowerShellExes(
                     const exePath = path.join(item, "pwsh.exe");
                     return fs.lstatSync(item).isDirectory() && fs.existsSync(exePath);
                 })
-                .map((item) => {
-                    const exePath = path.join(item, "pwsh.exe");
-                    return {
-                        versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
-                        exePath,
-                    };
-                });
+                .map((item) => ({
+                    versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
+                    exePath: path.join(item, "pwsh.exe"),
+                }));
 
             if (psCorePaths) {
                 paths = paths.concat(psCorePaths);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,11 @@ enum CodeFormattingPreset {
     Stroustrup,
 }
 
+export interface IPowerShellAdditionalExePathSettings {
+    versionName: string;
+    exePath: string;
+}
+
 export interface IBugReportingSettings {
     project: string;
 }
@@ -50,6 +55,8 @@ export interface IDeveloperSettings {
 }
 
 export interface ISettings {
+    powerShellAdditionalExePaths?: IPowerShellAdditionalExePathSettings[];
+    powerShellDefaultVersion?: string;
     powerShellExePath?: string;
     startAutomatically?: boolean;
     useX86Host?: boolean;
@@ -115,6 +122,10 @@ export function load(): ISettings {
     return {
         startAutomatically:
             configuration.get<boolean>("startAutomatically", true),
+        powerShellAdditionalExePaths:
+            configuration.get<IPowerShellAdditionalExePathSettings[]>("powerShellAdditionalExePaths", undefined),
+        powerShellDefaultVersion:
+            configuration.get<string>("powerShellDefaultVersion", undefined),
         powerShellExePath:
             configuration.get<string>("powerShellExePath", undefined),
         useX86Host:

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -5,7 +5,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as platform from "../src/platform";
-import { SessionManager } from "../src/session";
 
 function checkDefaultPowerShellPath(platformDetails, expectedPath) {
     test("returns correct default path", () => {

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -5,6 +5,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import * as platform from "../src/platform";
+import { SessionManager } from "../src/session";
 
 function checkDefaultPowerShellPath(platformDetails, expectedPath) {
     test("returns correct default path", () => {
@@ -21,7 +22,7 @@ function checkAvailableWindowsPowerShellPaths(
 
         // The system may return PowerShell Core paths so only
         // enumerate the first list items.
-        const enumeratedPaths = platform.getAvailablePowerShellExes(platformDetails);
+        const enumeratedPaths = platform.getAvailablePowerShellExes(platformDetails, undefined);
         for (let i; i < expectedPaths.length; i++) {
             assert.equal(enumeratedPaths[i], expectedPaths[i]);
         }


### PR DESCRIPTION
Fix #1243 

BTW this does change the session menu to represent the "current" session with the same name as the session name as it appears when it is not selected.  By doing it this way, it is easier to find the "versionName" field for the `powershell.powerShellDefaultVersion` setting.  

Here's the list before:

![image](https://user-images.githubusercontent.com/5177512/38786218-5da8cba0-40db-11e8-9bc7-acb617655bfb.png)

And after:

![image](https://user-images.githubusercontent.com/5177512/38786260-9729a4ee-40db-11e8-8d89-19aed4ec2298.png)

I put in some extra logic to only display PS Cores where pwsh.exe is present instead of just the directory as it appears the PS Core uninstaller leaves the empty dir on the file system.  :-(

As for the extra info (edition / specific version number), you can easily get that by executing `$PSVersionTable` in the PSIC.

Here is the setting for adding other PowerShell exes:
```
    "powershell.powerShellAdditionalExePaths": [
        {
          "versionName": "PowerShell Core Build - Debug",
          "exePath": "C:\\Users\\Keith\\GitHub\\rkeithhill\\PowerShell\\debug\\pwsh.exe"
        }
    ]
```
The above is a User setting only.  The following is both a User and Workspace setting:
```
    "powershell.powerShellDefaultVersion": "PowerShell Core Build - Debug"
```