### PR TITLE
Snippet: error-terminating

### DIFF
--- a/docs/community_snippets.md
+++ b/docs/community_snippets.md
@@ -18,6 +18,7 @@ _To contribute, check out our [guide here](#contributing)._
 |:------------------|
 | [CalculatedProperty](#calculatedproperty): _Create a calculated property for use in a select-object call by @corbob_ |
 | [DateTimeWriteVerbose](#datetimewriteverbose): _Write-Verbose with the time and date pre-pended to your message by @ThmsRynr_ |
+| [Error-Terminating](#error-terminating): _Create a full terminating error by @omniomi_ |
 | [Parameter-Credential](#parameter-credential): _Add a standard credential parameter to your function by @omniomi_ |
 | [PSCustomObject](#pscustomobject): _A simple PSCustomObject by @brettmillerb_ |
 
@@ -52,6 +53,26 @@ Quickly add a `Write-Verbose` with the current date and time inserted before the
         "Write-Verbose \"[$(Get-Date -format G)] ${1:message}\"$0"
     ],
     "description": "Pre-pend datetime for Write-Verbose"
+}
+```
+
+### Error-Terminating
+
+Quickly add a fully defined error record and throw. by @omniomi
+
+#### Snippet
+
+```json
+"Throw Terminating Error": {
+    "prefix": "error-terminating",
+    "body": [
+        "\\$Exception     = New-Object ${1:System.ArgumentException} (\"${2:Invalid argument provided.}\")\r",
+        "\\$ErrorCategory = [System.Management.Automation.ErrorCategory]::${3:InvalidArgument}\r",
+        "# Exception, ErrorId as [string], Category, and TargetObject (e.g. the parameter that was invalid)\r",
+        "\\$ErrorRecord   = New-Object System.Management.Automation.ErrorRecord(\\$Exception, '${4:InvalidArgument}', \\$ErrorCategory, ${5:\\$null})\r",
+        "\\$PSCmdlet.ThrowTerminatingError(\\$ErrorRecord)"
+    ],
+    "description": "Throw a full terminating error."
 }
 ```
 


### PR DESCRIPTION
Was going through my snippets and felt this one would also be useful. It generates the following:

```PowerShell
$Exception     = New-Object System.ArgumentException ("Invalid argument provided.")
$ErrorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
# Exception, ErrorId as [string], Category, and TargetObject (e.g. the parameter that was invalid)
$ErrorRecord   = New-Object System.Management.Automation.ErrorRecord($Exception, 'InvalidArgument', $ErrorCategory, $null)
$PSCmdlet.ThrowTerminatingError($ErrorRecord)
```

with tab stops on the exception type, exception message, category selection, ErrorId, and TargetObject.

`$PSCmdlet.ThrowTerminatingError($ErrorRecord)` can be easily replaced with `throw $ErrorRecord` for scripts.