### PR TITLE
Make SaveAs work for untitled files

### DIFF
--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -408,6 +408,7 @@ export class ExtensionCommandsFeature implements IFeature {
             case "file":
                 // If the file to save can't be found, just complete the request
                 if (!this.findTextDocument(this.normalizeFilePath(currentFileUri.fsPath))) {
+                    this.log.writeAndShowError(`File to save not found: ${currentFileUri.fsPath}.`);
                     return EditorOperationResponse.Completed;
                 }
 
@@ -417,7 +418,6 @@ export class ExtensionCommandsFeature implements IFeature {
                     if (doc.isDirty) {
                         await doc.save();
                     }
-
                     return EditorOperationResponse.Completed;
                 }
 
@@ -433,6 +433,10 @@ export class ExtensionCommandsFeature implements IFeature {
             case "untitled":
                 // We need a new name to save an untitled file
                 if (!saveFileDetails.newPath) {
+                    // TODO: Create a class handle vscode warnings and errors so we can warn easily
+                    //       without logging
+                    this.log.writeAndShowWarning(
+                        "Cannot save untitled file. Try SaveAs(\"path/to/file.ps1\") instead.");
                     return EditorOperationResponse.Completed;
                 }
 

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -443,8 +443,8 @@ export class ExtensionCommandsFeature implements IFeature {
                 } else {
                     // If not, interpret the path as relative to the workspace root
                     const workspaceRootUri = vscode.workspace.workspaceFolders[0].uri;
+                    // We don't saving to a non-file URI-schemed workspace
                     if (workspaceRootUri.scheme !== "file") {
-                        // We don't support URI schemes for file saves
                         return EditorOperationResponse.Completed;
                     }
                     newFileAbsolutePath = path.resolve(workspaceRootUri.fsPath, saveFileDetails.newPath);

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -444,10 +444,20 @@ export class ExtensionCommandsFeature implements IFeature {
                 if (path.isAbsolute(saveFileDetails.newPath)) {
                     newFileAbsolutePath = saveFileDetails.newPath;
                 } else {
+                    // In fresh contexts, workspaceFolders is not defined...
+                    if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
+                        this.log.writeAndShowWarning("Cannot save file to relative path: no workspaces are open. " +
+                            "Try saving to an absolute path, or open a workspace.");
+                        return EditorOperationResponse.Completed;
+                    }
+
                     // If not, interpret the path as relative to the workspace root
                     const workspaceRootUri = vscode.workspace.workspaceFolders[0].uri;
                     // We don't support saving to a non-file URI-schemed workspace
                     if (workspaceRootUri.scheme !== "file") {
+                        this.log.writeAndShowWarning(
+                            "Cannot save untitled file to a relative path in an untitled workspace. " +
+                            "Try saving to an absolute path or opening a workspace folder.");
                         return EditorOperationResponse.Completed;
                     }
                     newFileAbsolutePath = path.join(workspaceRootUri.fsPath, saveFileDetails.newPath);

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -176,7 +176,8 @@ export class ExtensionCommandsFeature implements IFeature {
     constructor(private log: Logger) {
         this.command = vscode.commands.registerCommand("PowerShell.ShowAdditionalCommands", () => {
             if (this.languageClient === undefined) {
-                this.log.writeAndShowError(`<ExtensionCommands>: Unable to instantiate; language client undefined.`);
+                this.log.writeAndShowError(`<${ExtensionCommandsFeature.name}>: ` +
+                    "Unable to instantiate; language client undefined.");
                 return;
             }
 
@@ -457,7 +458,7 @@ export class ExtensionCommandsFeature implements IFeature {
                 // Other URI schemes are not supported
                 const msg = JSON.stringify(saveFileDetails);
                 this.log.writeVerbose(
-                    `<ExtensionCommands>: Saving a document with scheme '${currentFileUri.scheme}' ` +
+                    `<${ExtensionCommandsFeature.name}>: Saving a document with scheme '${currentFileUri.scheme}' ` +
                     `is currently unsupported. Message: '${msg}'`);
                 return EditorOperationResponse.Completed;
         }
@@ -479,7 +480,7 @@ export class ExtensionCommandsFeature implements IFeature {
                 // TODO: Change this to be asyncronous
                 fs.writeFileSync(destinationAbsolutePath, oldDocument.getText());
             } catch (e) {
-                this.log.writeAndShowWarning("<ExtensionCommands>: " +
+                this.log.writeAndShowWarning(`<${ExtensionCommandsFeature.name}>: ` +
                     `Unable to save file to path '${destinationAbsolutePath}': ${e}`);
                 return;
             }

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -56,7 +56,7 @@ export class HelpCompletionFeature implements IFeature {
 
     public onEvent(changeEvent: TextDocumentChangeEvent): void {
         if (!(changeEvent && changeEvent.contentChanges)) {
-            this.log.writeWarning("<HelpCompletion>: " +
+            this.log.writeWarning(`<${HelpCompletionFeature.name}>: ` +
                 `Bad TextDocumentChangeEvent message: ${JSON.stringify(changeEvent)}`);
             return;
         }

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -56,7 +56,8 @@ export class HelpCompletionFeature implements IFeature {
 
     public onEvent(changeEvent: TextDocumentChangeEvent): void {
         if (!(changeEvent && changeEvent.contentChanges)) {
-            this.log.write(`Bad TextDocumentChangeEvent message: ${JSON.stringify(changeEvent)}`);
+            this.log.writeWarning("<HelpCompletion>: " +
+                `Bad TextDocumentChangeEvent message: ${JSON.stringify(changeEvent)}`);
             return;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -121,7 +121,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new ShowHelpFeature(),
         new FindModuleFeature(),
         new PesterTestsFeature(sessionManager),
-        new ExtensionCommandsFeature(),
+        new ExtensionCommandsFeature(logger),
         new SelectPSSARulesFeature(),
         new CodeActionsFeature(),
         new NewFileOrProjectFeature(),


### PR DESCRIPTION
Fixes #1303.

This makes the `$psEditor.GetEditorContext().CurrentFile.SaveAs("blah.ps1")` function work for files with an untitled schema.

It also adds some logging to make it more diagnosable (because the logic for dealing with VSCode's crazy URIs is a bit hairy).

Some cases to test (on various platforms) before we merge:
- [x] Take a normal powershell file, modify it and `Save()`
- [x] Take a normal powershell file, modify it and `SaveAs()` with a relative path (should save to path relative to the file).
- [x] Do the same but with an absolute path.
- [x] Do the same but on a different windows drive in the absolute path.
- [x] Open a new "untitled" file, change language mode to PowerShell and `Save()` (should not work)
- [x] Open a new "untitled" file, change language mode to PowerShell and `SaveAs()` with a relative path (should save relative to the workspace root).
- [x] Open a new "untitled" file, change language mode to PowerShell and `SaveAs()` to an absolute path.
- [x] Same as above but on a different windows drive.
- [x] ~~Open a new "untitled" workspace~~ Open VSCode with no workspace open, open an untitled document, change language mode to PowerShell and `SaveAs()` to an absolute path (should work).
- [x] Same as above but with a relative path (should not work, since ~~workspace is "untitled"~~ there is no workspace open).