### PR TITLE
(maint) Add visual ruler for line length

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
     "editor.tabSize": 4,
     "editor.insertSpaces": true,
     "files.trimTrailingWhitespace": true,
+    // Add a visual ruler for the typescript linting line length
+    "editor.rulers": [120],
 
     "search.exclude": {
         "**/node_modules": true,


### PR DESCRIPTION
## PR Summary

Previously it was a little difficult to know when your editing would exceed
the 120 line length limit.  This commit modifies the project settings to add
a simple visual ruler at the 120 char limit.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
