### PR TITLE
WIP: Add support for side-by-side PS Core preview on Linux/macOS

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -174,7 +174,7 @@ export function getAvailablePowerShellExes(
         // Handle Linux and macOS case
         const defaultExePath =  this.getDefaultPowerShellPath(platformDetails);
         paths.push({
-            versionName: "PowerShell Core",
+            versionName: "PowerShell Core" + (/-preview/.test(defaultExePath) ? " Preview" : ""),
             exePath: defaultExePath,
         });
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -10,6 +10,9 @@ import Settings = require("./settings");
 const linuxExePath        = "/usr/bin/pwsh";
 const linuxPreviewExePath = "/usr/bin/pwsh-preview";
 
+const snapExePath         = "/snap/bin/pwsh";
+const snapPreviewExePath  = "/snap/bin/pwsh-preview";
+
 const macOSExePath        = "/usr/local/bin/pwsh";
 const macOSPreviewExePath = "/usr/local/bin/pwsh-preview";
 
@@ -86,9 +89,14 @@ export function getDefaultPowerShellPath(
         }
     } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
+        // as well as the Snaps case - https://snapcraft.io/
         powerShellExePath = linuxExePath;
         if (!fs.existsSync(linuxExePath) && fs.existsSync(linuxPreviewExePath)) {
             powerShellExePath = linuxPreviewExePath;
+        } else if (fs.existsSync(snapExePath)) {
+            powerShellExePath = snapExePath;
+        } else if (fs.existsSync(snapPreviewExePath)) {
+            powerShellExePath = snapPreviewExePath;
         }
     }
 
@@ -196,7 +204,7 @@ export function getAvailablePowerShellExes(
             osPreviewExePath = macOSPreviewExePath;
         } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
             osExePath = linuxExePath;
-            osPreviewExePath = linuxPreviewExePath;
+            osPreviewExePath = fs.existsSync(linuxPreviewExePath) ? linuxPreviewExePath : snapPreviewExePath;
         }
 
         if ((osExePath === defaultExePath) && fs.existsSync(osPreviewExePath)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -180,20 +180,21 @@ export function getAvailablePowerShellExes(
 
         // If defaultExePath is pwsh, check to see if pwsh-preview is installed and if so, make it available.
         // If the defaultExePath is already pwsh-preview, then pwsh is not installed - nothing to do.
+        let osExePath;
+        let osPreviewExePath;
         if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
-            if ((defaultExePath === macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
-                paths.push({
-                    versionName: "PowerShell Core Preview",
-                    exePath: macOSPreviewExePath,
-                });
-            }
+            osExePath = macOSExePath;
+            osPreviewExePath = macOSPreviewExePath;
         } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
-            if ((defaultExePath === linuxExePath) && fs.existsSync(linuxPreviewExePath)) {
-                paths.push({
-                    versionName: "PowerShell Core Preview",
-                    exePath: linuxPreviewExePath,
-                });
-            }
+            osExePath = linuxExePath;
+            osPreviewExePath = linuxPreviewExePath;
+        }
+
+        if ((osExePath === defaultExePath) && fs.existsSync(osPreviewExePath)) {
+            paths.push({
+                versionName: "PowerShell Core Preview",
+                exePath: osPreviewExePath,
+            });
         }
     }
 


### PR DESCRIPTION
## PR Summary

This PR supports listing the symlinks for pwsh & pwsh-preview.

Fixes #1361

The preferred default version is pwsh if both are present however, the
default will be pwsh-preview if it's installed and pwsh isn't.

So this only support side-by-side on Linux/macOS up to two versions:
stable and preview.

In the future, we may want to do what we do on Windows and search thru
the install dir for pwsh.
The would be /opt/microsoft/poweshell on LInux.
Not sure what it is on macOS.

Or maybe we should just do that now. Thoughts? 

I marked this as WIP because I need someone to test this on Linux and macOS.  :-)

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
