### PR TITLE
add script to generate changelog

### DIFF
--- a/tools/Get-PowerShellExtensionChangelog.ps1
+++ b/tools/Get-PowerShellExtensionChangelog.ps1
@@ -1,5 +1,34 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+
+##############################
+#.SYNOPSIS
+#Generate the draft change log of the PowerShell Extension for VSCode
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER Token
+#The authentication token to use for retrieving the GitHub user log-in names for external contributors. Get it from:
+# https://github.com/settings/tokens
+#
+#.PARAMETER NewReleaseTag
+#The github tag that will be associated with the next release
+#
+#.PARAMETER HasCherryPick
+#Indicate whether there are any commits in the last release branch that were cherry-picked from the master branch
+#
+#.OUTPUTS
+#The generated change log draft of vscode-powershell AND PowerShellEditorServices
+#
+#.NOTES
+#Run from the path to /vscode-powershell
+#
+#.EXAMPLE
+#
+# .\tools\Get-PowerShellExtensionChangelog.ps1 -LastReleaseTag v1.7.0 -Token $TOKENSTR -NewReleaseTag v1.8.0
+#
+##############################
 param(
         [Parameter(Mandatory)]
         [string]$LastReleaseTag,
@@ -236,13 +265,14 @@ function Get-ChangeLog
 
 ##############################
 #.SYNOPSIS
-#Generate the draft change log of the git repo in the current directory
+#Generate the draft change log of the PowerShell Extension for VSCode
 #
 #.PARAMETER LastReleaseTag
 #The last release tag
 #
 #.PARAMETER Token
-#The authentication token to use for retrieving the GitHub user log-in names for external contributors
+#The authentication token to use for retrieving the GitHub user log-in names for external contributors. Get it from:
+# https://github.com/settings/tokens
 #
 #.PARAMETER NewReleaseTag
 #The github tag that will be associated with the next release

--- a/tools/Get-PowerShellExtensionChangelog.ps1
+++ b/tools/Get-PowerShellExtensionChangelog.ps1
@@ -1,0 +1,293 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+param(
+        [Parameter(Mandatory)]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter(Mandatory)]
+        [string]$NewReleaseTag,
+
+        [Parameter()]
+        [switch]$HasCherryPick
+    )
+
+# These powershell team members don't use 'microsoft.com' for Github email or choose to not show their emails.
+# We have their names in this array so that we don't need to query Github to find out if they are powershell team members.
+$Script:powershell_team = @(
+    "Robert Holt"
+    "Tyler Leonhardt"
+)
+
+$Script:powershell_team_emails = @(
+    "tylerl0706@gmail.com"
+)
+
+class CommitNode {
+    [string] $Hash
+    [string[]] $Parents
+    [string] $AuthorName
+    [string] $AuthorGitHubLogin
+    [string] $AuthorEmail
+    [string] $Subject
+    [string] $Body
+    [string] $PullRequest
+    [string] $ChangeLogMessage
+    [bool] $IsBreakingChange
+
+    CommitNode($hash, $parents, $name, $email, $subject, $body) {
+        $this.Hash = $hash
+        $this.Parents = $parents
+        $this.AuthorName = $name
+        $this.AuthorEmail = $email
+        $this.Subject = $subject
+        $this.Body = $body
+        $this.IsBreakingChange = $body -match "\[breaking change\]"
+
+        if ($subject -match "\(#(\d+)\)") {
+            $this.PullRequest = $Matches[1]
+        }
+    }
+}
+
+##############################
+#.SYNOPSIS
+#In the release workflow, the release branch will be merged back to master after the release is done,
+#and a merge commit will be created as the child of the release tag commit.
+#This cmdlet takes a release tag or the corresponding commit hash, find its child merge commit, and
+#return its metadata in this format: <merge-commit-hash>|<parent-commit-hashes>
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER CommitHash
+#The commit hash of the last release tag
+#
+#.OUTPUTS
+#Return the metadata of the child merge commit, in this format: <merge-commit-hash>|<parent-commit-hashes>
+##############################
+function Get-ChildMergeCommit
+{
+    [CmdletBinding(DefaultParameterSetName="TagName")]
+    param(
+        [Parameter(Mandatory, ParameterSetName="TagName")]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory, ParameterSetName="CommitHash")]
+        [string]$CommitHash
+    )
+
+    $tag_hash = $CommitHash
+    if ($PSCmdlet.ParameterSetName -eq "TagName") { $tag_hash = git rev-parse "$LastReleaseTag^0" }
+
+    ## Get the merge commits that are reachable from 'HEAD' but not from the release tag
+    $merge_commits_not_in_release_branch = git --no-pager log --merges "$tag_hash..HEAD" --format='%H||%P'
+    ## Find the child merge commit, whose parent-commit-hashes contains the release tag hash
+    $child_merge_commit = $merge_commits_not_in_release_branch | Select-String -SimpleMatch $tag_hash
+    return $child_merge_commit.Line
+}
+
+##############################
+#.SYNOPSIS
+#Create a CommitNode instance to represent a commit.
+#
+#.PARAMETER CommitMetadata
+#The commit metadata. It's in this format:
+#<commit-hash>|<parent-hashes>|<author-name>|<author-email>|<commit-subject>
+#
+#.PARAMETER CommitMetadata
+#The commit metadata, in this format:
+#<commit-hash>|<parent-hashes>|<author-name>|<author-email>|<commit-subject>
+#
+#.OUTPUTS
+#Return the 'CommitNode' object
+##############################
+function New-CommitNode
+{
+    param(
+        [Parameter(ValueFromPipeline)]
+        [ValidatePattern("^.+\|.+\|.+\|.+\|.+$")]
+        [string]$CommitMetadata
+    )
+
+    Process {
+        $hash, $parents, $name, $email, $subject = $CommitMetadata.Split("||")
+        $body = (git --no-pager show $hash -s --format=%b) -join "`n"
+        return [CommitNode]::new($hash, $parents, $name, $email, $subject, $body)
+    }
+}
+
+##############################
+#.SYNOPSIS
+#Generate the draft change log of the git repo in the current directory
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER Token
+#The authentication token to use for retrieving the GitHub user log-in names for external contributors
+#
+#.PARAMETER RepoUri
+#The uri of the API endpoint. For example: https://api.github.com/repos/PowerShell/vscode-powershell
+#
+#.PARAMETER HasCherryPick
+#Indicate whether there are any commits in the last release branch that were cherry-picked from the master branch
+#
+#.OUTPUTS
+#The generated change log draft.
+##############################
+function Get-ChangeLog
+{
+    param(
+        [Parameter(Mandatory)]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter(Mandatory)]
+        [string]$RepoUri,
+
+        [Parameter()]
+        [switch]$HasCherryPick
+    )
+
+    $tag_hash = git rev-parse "$LastReleaseTag^0"
+    $format = '%H||%P||%aN||%aE||%s'
+    $header = @{"Authorization"="token $Token"}
+
+    # Find the merge commit that merged the release branch to master.
+    $child_merge_commit = Get-ChildMergeCommit -CommitHash $tag_hash
+    $commit_hash, $parent_hashes = $child_merge_commit.Split("||")
+    # Find the other parent of the merge commit, which represents the original head of master right before merging.
+    $other_parent_hash = ($parent_hashes.Trim() -replace $tag_hash).Trim()
+
+    if ($HasCherryPick) {
+        ## Sometimes we need to cherry-pick some commits from the master branch to the release branch during the release,
+        ## and eventually merge the release branch back to the master branch. This will result in different commit nodes
+        ## in master branch that actually represent same set of changes.
+        ##
+        ## In this case, we cannot simply use the revision range "$tag_hash..HEAD" becuase it will include the original
+        ## commits in the master branch that were cherry-picked to the release branch -- they are reachable from 'HEAD'
+        ## but not reachable from the last release tag. Instead, we need to exclude the commits that were cherry-picked,
+        ## and only include the commits that are not in the last release into the change log.
+
+        # Find the commits that were only in the orginal master, excluding those that were cherry-picked to release branch.
+        $new_commits_from_other_parent = git --no-pager log --first-parent --cherry-pick --right-only "$tag_hash...$other_parent_hash" --format=$format | New-CommitNode
+        # Find the commits that were only in the release branch, excluding those that were cherry-picked from master branch.
+        $new_commits_from_last_release = git --no-pager log --first-parent --cherry-pick --left-only "$tag_hash...$other_parent_hash" --format=$format | New-CommitNode
+        # Find the commits that are actually duplicate but having different patch-ids due to resolving conflicts during the cherry-pick.
+        $duplicate_commits = Compare-Object $new_commits_from_last_release $new_commits_from_other_parent -Property PullRequest -ExcludeDifferent -IncludeEqual -PassThru
+        if ($duplicate_commits) {
+            $duplicate_pr_numbers = @($duplicate_commits | ForEach-Object -MemberName PullRequest)
+            $new_commits_from_other_parent = $new_commits_from_other_parent | Where-Object PullRequest -NotIn $duplicate_pr_numbers
+        }
+
+        # Find the commits that were made after the merge commit.
+        $new_commits_after_merge_commit = @(git --no-pager log --first-parent "$commit_hash..HEAD" --format=$format | New-CommitNode)
+        $new_commits = $new_commits_after_merge_commit + $new_commits_from_other_parent
+    } else {
+        ## No cherry-pick was involved in the last release branch.
+        ## Using a ref rang like "$tag_hash..HEAD" with 'git log' means getting the commits that are reachable from 'HEAD' but not reachable from the last release tag.
+
+        ## We use '--first-parent' for 'git log'. It means for any merge node, only follow the parent node on the master branch side.
+        ## In case we merge a branch to master for a PR, only the merge node will show up in this way, the individual commits from that branch will be ignored.
+        ## This is what we want because the merge commit itself already represents the PR.
+
+        ## First, we want to get all new commits merged during the last release
+        #$new_commits_during_last_release = @(git --no-pager log --first-parent "$tag_hash..$($other_parent_hash.TrimStart(" "))" --format=$format | New-CommitNode)
+        ## Then, we want to get all new commits merged after the last release
+        $new_commits_after_last_release  = @(git --no-pager log --first-parent "$commit_hash..HEAD" --format=$format | New-CommitNode)
+        ## Last, we get the full list of new commits
+        $new_commits = $new_commits_during_last_release + $new_commits_after_last_release
+    }
+
+    # They are very active contributors, so we keep their email-login mappings here to save a few queries to Github.
+    $community_login_map = @{}
+
+    foreach ($commit in $new_commits) {
+        if ($commit.AuthorEmail.EndsWith("@microsoft.com") -or $powershell_team -contains $commit.AuthorName -or $powershell_team_emails -contains $commit.AuthorEmail) {
+            $commit.ChangeLogMessage = "- {0}" -f $commit.Subject
+        } else {
+            if ($community_login_map.ContainsKey($commit.AuthorEmail)) {
+                $commit.AuthorGitHubLogin = $community_login_map[$commit.AuthorEmail]
+            } else {
+                $uri = "$RepoUri/commits/$($commit.Hash)"
+                $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $header -ErrorAction SilentlyContinue
+                if($response)
+                {
+                    $content = ConvertFrom-Json -InputObject $response.Content
+                    $commit.AuthorGitHubLogin = $content.author.login
+                    $community_login_map[$commit.AuthorEmail] = $commit.AuthorGitHubLogin
+                }
+            }
+            $commit.ChangeLogMessage = "- {0} (Thanks @{1}!)" -f $commit.Subject, $commit.AuthorGitHubLogin
+        }
+
+        if ($commit.IsBreakingChange) {
+            $commit.ChangeLogMessage = "{0} [Breaking Change]" -f $commit.ChangeLogMessage
+        }
+    }
+
+    $new_commits | Sort-Object -Descending -Property IsBreakingChange | ForEach-Object -MemberName ChangeLogMessage
+}
+
+##############################
+#.SYNOPSIS
+#Generate the draft change log of the git repo in the current directory
+#
+#.PARAMETER LastReleaseTag
+#The last release tag
+#
+#.PARAMETER Token
+#The authentication token to use for retrieving the GitHub user log-in names for external contributors
+#
+#.PARAMETER NewReleaseTag
+#The github tag that will be associated with the next release
+#
+#.PARAMETER HasCherryPick
+#Indicate whether there are any commits in the last release branch that were cherry-picked from the master branch
+#
+#.OUTPUTS
+#The generated change log draft of vscode-powershell AND PowerShellEditorServices
+#
+#.NOTES
+#Run from the path to /vscode-powershell
+##############################
+function Get-PowerShellExtensionChangeLog {
+    param(
+        [Parameter(Mandatory)]
+        [string]$LastReleaseTag,
+
+        [Parameter(Mandatory)]
+        [string]$Token,
+
+        [Parameter(Mandatory)]
+        [string]$NewReleaseTag,
+
+        [Parameter()]
+        [switch]$HasCherryPick
+    )
+
+    $vscodePowerShell = Get-ChangeLog -LastReleaseTag $LastReleaseTag -Token $Token -HasCherryPick:$HasCherryPick.IsPresent -RepoUri 'https://api.github.com/repos/PowerShell/vscode-powershell'
+    Push-Location ../PowerShellEditorServices
+    $pses = Get-ChangeLog -LastReleaseTag $LastReleaseTag -Token $Token -HasCherryPick:$HasCherryPick.IsPresent -RepoUri 'https://api.github.com/repos/PowerShell/PowerShellEditorServices'
+    Pop-Location
+
+    return @"
+## $NewReleaseTag
+### $([datetime]::Today.ToString("D"))
+#### [vscode-powershell](https://github.com/powershell/vscode-powershell)
+
+$($vscodePowerShell -join "`n")
+
+#### [PowerShellEditorServices](https://github.com/powershell/PowerShellEditorServices)
+
+$($pses -join "`n")
+
+"@
+}
+
+Get-PowerShellExtensionChangeLog -LastReleaseTag $LastReleaseTag -Token $Token -NewReleaseTag $NewReleaseTag -HasCherryPick:$HasCherryPick.IsPresent


### PR DESCRIPTION
In an attempt to automate more of the release process, here's a script to autogenerate the changelog listing all the commits and if they're from external contributors.

Here's what it outputs:

```
## v1.8.0
### Monday, June 25, 2018
#### [vscode-powershell](https://github.com/powershell/vscode-powershell)

- have PSES generate the random pipename
- revert transport type
- allow path to named pipes to be passed down
- Update to TypeScript 2.9.x (#1344) (Thanks @rkeithhill!)
- SpecProcId - interactive var replacement supports only string type (#1323) (Thanks @rkeithhill!)
- Switch to named pipes (#1327)
- GitHub issue template tweaks and add PSSA template (#1321) (Thanks @bergmeister!)
- Take advantage of multiple issue templatesShamelessly ripping this off from the PSSA GH repo (#1320) (Thanks @rkeithhill!)
- Change SpecifyScriptArgs command to only return string - not string[] (#1317) (Thanks @rkeithhill!)
- Update package veresion in lock file, format package.json file. (#1318) (Thanks @rkeithhill!)
- Updates to Examples PSSA settings file to include more rule config (#1312) (Thanks @rkeithhill!)
- Make SaveAs work for untitled files (#1305)
- Added Columns, Improved readability for ToC. (#1307) (Thanks @st0le!)
- Added some snippets (#1297) (Thanks @SQLDBAWithABeard!)

#### [PowerShellEditorServices](https://github.com/powershell/PowerShellEditorServices)

- add what to do when there's a vulnerability to docs (#687)
- Fix issue where MS Dynamics CRM (#686) (Thanks @rkeithhill!)
- Make AnalysisService use the latest version of PSScriptAnalyzer (#677)
- Fix PSES crash that happens if you format an empty PS doc (#685) (Thanks @rkeithhill!)
- Include ThirdPartyNotices.txt to comply with OSS guidelines
- Initial CODEOWNERS file to auto assign PR reviewers (#681) (Thanks @rkeithhill!)
- Add more useful PSSA rules that should be enabled by default (#669) (Thanks @bergmeister!)
- Add symbols to modules built in Debug configuration (#675)
- Implement initialized notification handler to get rid of log error (#674) (Thanks @rkeithhill!)
- Change logging to use Serilog (#666)
- Stop before we restart (#668)
- Add .gitattributes, .editorconfig and extensions.json (#667) (Thanks @rkeithhill!)
- ignore .idea folder that jetbrains products like to spit out (Rider, IntelliJ, Resharper) (#664)
- Close stray processes on exit (#663)
```