### PR TITLE
Add tslint rule file-header to enforce copyright in TS files

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,8 @@
     "rules": {
         "indent": [true, "spaces", 4],
         "max-classes-per-file": false,
-        "object-literal-sort-keys": false
+        "object-literal-sort-keys": false,
+        "file-header": [true, "Copyright \\(C\\) Microsoft Corporation. All rights reserved."]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
I would like to add a "fix" string which this page says is supported:
https://palantir.github.io/tslint/rules/file-header/

But the comment style of the fix doesn't follow our style and is
apparently not configurable e.g.:
```
/*!
 * <copyright fix line>
 */
```
Fix #1394

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
