### PR TITLE
Allow debugging in interactive session with no dir change

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,9 +257,9 @@
               "type": "PowerShell",
               "request": "launch",
               "name": "PowerShell Launch ${Script}",
-              "script": "^\"\\${workspaceRoot}/${Script}\"",
+              "script": "^\"\\${workspaceFolder}/${Script}\"",
               "args": [],
-              "cwd": "^\"\\${workspaceRoot}\""
+              "cwd": "^\"\\${workspaceFolder}\""
             }
           },
           {
@@ -271,7 +271,7 @@
               "name": "PowerShell Pester Tests",
               "script": "Invoke-Pester",
               "args": [],
-              "cwd": "^\"\\${workspaceRoot}\""
+              "cwd": "^\"\\${workspaceFolder}\""
             }
           },
           {
@@ -292,17 +292,13 @@
               "type": "PowerShell",
               "request": "launch",
               "name": "PowerShell Interactive Session",
-              "cwd": "^\"\\${workspaceRoot}\""
+              "cwd": ""
             }
           }
         ],
         "configurationAttributes": {
           "launch": {
             "properties": {
-              "program": {
-                "type": "string",
-                "description": "Deprecated. Please use the 'script' property instead to specify the absolute path to the PowerShell script to launch under the debugger."
-              },
               "script": {
                 "type": "string",
                 "description": "Optional: Absolute path to the PowerShell script to launch under the debugger."
@@ -317,8 +313,8 @@
               },
               "cwd": {
                 "type": "string",
-                "description": "Absolute path to the working directory. Default is the current workspace.",
-                "default": "${workspaceRoot}"
+                "description": "Absolute path to the working directory. Default is the current workspace folder.",
+                "default": "${workspaceFolder}"
               },
               "createTemporaryIntegratedConsole": {
                 "type": "boolean",
@@ -385,7 +381,7 @@
             "type": "PowerShell",
             "request": "launch",
             "name": "PowerShell Interactive Session",
-            "cwd": "${workspaceRoot}"
+            "cwd": ""
           }
         ]
       }


### PR DESCRIPTION
Fix #1330

This PR depends on a corresponding PR to PSES to have it handle
null/empty string differently in the non-temp console case.

For the generateLaunchConfig case, we now pass "" as cwd to PSES.
That tells PSES to not change the directory *if* we aren't running
in a temp console.  If we are in a temp console, then use old logic to
set working dir.

Update "PowerShell Interactive Session" debug config to tell PSES
to not change the working dir.

Remove "program" field from launch config. This has been marked
deprecated for over a year now.

Change refs in ${workspaceRoot} to ${workpaceFolder} to work
better in a multi-workspace environment.

Remove unused imports/field in DebugSession.ts.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
