### PR TITLE
Move lint directive after the file-header to fix lint error

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -1,7 +1,7 @@
-// tslint:disable no-var-requires
 /*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+* Copyright (C) Microsoft Corporation. All rights reserved.
+*--------------------------------------------------------*/
+// tslint:disable no-var-requires
 
 let testRunner = require("vscode/lib/testrunner");
 


### PR DESCRIPTION
## PR Summary

Fix tslint error on test/index.ts because there is a comment (tslint directive) 
before the required file-header.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
