### PR TITLE
Restore ability to start debug session when script run in PSIC hits bkpt

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -5,13 +5,16 @@
 import vscode = require("vscode");
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider,
     ExtensionContext, ProviderResult, WorkspaceFolder } from "vscode";
-import { LanguageClient, RequestType } from "vscode-languageclient";
+import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
 import { getPlatformDetails, OperatingSystem } from "../platform";
 import { PowerShellProcess} from "../process";
 import { SessionManager } from "../session";
 import Settings = require("../settings");
 import utils = require("../utils");
+
+export const StartDebuggerNotificationType =
+    new NotificationType<void, void>("powerShell/startDebugger");
 
 export class DebugSessionFeature implements IFeature, DebugConfigurationProvider {
 
@@ -29,7 +32,14 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
     }
 
     public setLanguageClient(languageClient: LanguageClient) {
-        // There is no implementation for this IFeature method
+        languageClient.onNotification(
+            StartDebuggerNotificationType,
+            () =>
+                vscode.debug.startDebugging(undefined, {
+                    request: "launch",
+                    type: "PowerShell",
+                    name: "PowerShell Interactive Session",
+        }));
     }
 
     // DebugConfigurationProvider method


### PR DESCRIPTION
Fix #956

## PR Summary

Restores some code that I took out in PR #1062 when VSCode removed a debug API we were using and
switched to a debug config provider model.  So sorry guys, this one was my bad.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
