### PR TITLE
Escape paths w/single quotes before passing to powershell in sq strings

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -13,6 +13,9 @@ import Settings = require("./settings");
 import utils = require("./utils");
 
 export class PowerShellProcess {
+    public static escapeSingleQuotes(pspath: string): string {
+        return pspath.replace(new RegExp("'", "g"), "''");
+    }
 
     public onExited: vscode.Event<void>;
     private onExitedEmitter = new vscode.EventEmitter<void>();
@@ -52,8 +55,8 @@ export class PowerShellProcess {
                             : "";
 
                     this.startArgs +=
-                        `-LogPath '${editorServicesLogPath}' ` +
-                        `-SessionDetailsPath '${this.sessionFilePath}' ` +
+                        `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath)}' ` +
+                        `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath)}' ` +
                         `-FeatureFlags @(${featureFlags})`;
 
                     const powerShellArgs = [
@@ -68,7 +71,7 @@ export class PowerShellProcess {
 
                     powerShellArgs.push(
                         "-Command",
-                        "& '" + startScriptPath + "' " + this.startArgs);
+                        "& '" + PowerShellProcess.escapeSingleQuotes(startScriptPath) + "' " + this.startArgs);
 
                     let powerShellExePath = this.exePath;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -173,7 +173,7 @@ export class SessionManager implements Middleware {
                 `-HostProfileId 'Microsoft.VSCode' ` +
                 `-HostVersion '${this.hostVersion}'` +
                 `-AdditionalModules @('PowerShellEditorServices.VSCode') ` +
-                `-BundledModulesPath '${this.bundledModulesPath}'` +
+                `-BundledModulesPath '${PowerShellProcess.escapeSingleQuotes(this.bundledModulesPath)}'` +
                 `-EnableConsoleRepl ` +
                 `-LanguageServicePipeName LanguageService_${id}.pipe ` +
                 `-DebugServicePipeName DebugService_${id}.pipe `;


### PR DESCRIPTION
If the user's install path has a single quote in it e.g `C:\Users\Night's Watch` then the command line we supply to powershell fails to parse because we have a single quote inside of a single-quoted string e.g.:

```
powershell.exe -Command "& 'C:\Users\Night's Watch\.vscode\extenions...' …"
```

I believe this PR to be done but I'd like to see if it fixes the original issue for ajpaul18.  **Update:** the fix was verified.

Fix #1404 
<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
