### PR TITLE
Set the extension's log level based on settings value

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,10 @@ export function activate(context: vscode.ExtensionContext): void {
     // Create the logger
     logger = new Logger();
 
+    // Set the log level
+    const extensionSettings = Settings.load();
+    logger.MinimumLogLevel = LogLevel[extensionSettings.developer.editorServicesLogLevel];
+
     sessionManager =
         new SessionManager(
             requiredEditorServicesVersion,
@@ -138,7 +142,6 @@ export function activate(context: vscode.ExtensionContext): void {
 
     sessionManager.setExtensionFeatures(extensionFeatures);
 
-    const extensionSettings = Settings.load();
     if (extensionSettings.startAutomatically) {
         sessionManager.start();
     }


### PR DESCRIPTION
## PR Summary

We set the log level in the Logger class during construction but then never seem to set it again.  This PR loads the settings and sets the desired log level right after the logger is constructed and before all the features are initialized.  This is important as some of the features want to do diagnostic logging. Without this change, we never see those diagnostic messages in the log.

There is some risk in moving the `Settings.load()` earlier in the startup process but I think the `Settings` class is pretty much a stand-alone, non-Feature based class.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
