### PR TITLE
(GH-1413) Resolve promise correctly in Folding feature

### DIFF
--- a/src/features/Folding.ts
+++ b/src/features/Folding.ts
@@ -545,8 +545,8 @@ export class FoldingFeature implements IFeature {
         // Branching for the different vscode-textmate modules
         if ("loadGrammarFromPathSync" in registry) {
             // V3 of the module allows synchronous loading of a grammar
-            return new Promise( (grammar) => {
-                return registry.loadGrammarFromPathSync(grammarPath);
+            return new Promise( (resolve) => {
+                resolve(registry.loadGrammarFromPathSync(grammarPath));
             });
         } else {
             // However in V4+ this is async only


### PR DESCRIPTION
## PR Summary

Previously in PR #1414 the Folding provider was updated, however the promise
resolution was incorrect.  This caused the grammar load to never trigger the
Then command.  This commit instead uses the correct way to return the value
for the promise and, when then triggers the Then statement correctly.

Fixes #1413.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
