### PR TITLE
(GH-1428) Make region folding case insensitive and strict whitespace 

### DIFF
--- a/src/features/Folding.ts
+++ b/src/features/Folding.ts
@@ -354,7 +354,7 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
     ): ILineNumberRangeList {
         const result = [];
 
-        const emptyLine = /^[\s]+$/;
+        const emptyLine = /^\s*$/;
 
         let startLine: number = -1;
         let nextLine: number = -1;
@@ -421,9 +421,9 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
     ): ITokenList {
         const result = [];
 
-        const emptyLine = /^[\s]+$/;
-        const startRegionText = /^#\s*region\b/;
-        const endRegionText = /^#\s*endregion\b/;
+        const emptyLine = /^\s*$/;
+        const startRegionText = /^#region\b/i;
+        const endRegionText = /^#endregion\b/i;
 
         tokens.forEach((token) => {
             if (token.scopes.indexOf("punctuation.definition.comment.powershell") !== -1) {

--- a/test/features/folding.test.ts
+++ b/test/features/folding.test.ts
@@ -38,16 +38,18 @@ suite("Features", () => {
 
         suite("For a single document", async () => {
             const expectedFoldingRegions = [
-                { start: 1,  end: 6,  kind: 1 },
-                { start: 7,  end: 51, kind: 3 },
-                { start: 8,  end: 13, kind: 1 },
-                { start: 14, end: 17, kind: 3 },
-                { start: 19, end: 22, kind: 3 },
-                { start: 26, end: 28, kind: 1 },
-                { start: 30, end: 40, kind: 3 },
-                { start: 32, end: 36, kind: 3 },
-                { start: 42, end: 44, kind: 3 },
-                { start: 47, end: 50, kind: 3 },
+                { start: 0,  end: 4,  kind: 3 },
+                { start: 1,  end: 3,  kind: 1 },
+                { start: 10, end: 15, kind: 1 },
+                { start: 16, end: 60, kind: 3 },
+                { start: 17, end: 22, kind: 1 },
+                { start: 23, end: 26, kind: 3 },
+                { start: 28, end: 31, kind: 3 },
+                { start: 35, end: 37, kind: 1 },
+                { start: 39, end: 49, kind: 3 },
+                { start: 41, end: 45, kind: 3 },
+                { start: 51, end: 53, kind: 3 },
+                { start: 56, end: 59, kind: 3 },
             ];
 
             test("Can detect all of the foldable regions in a document with CRLF line endings", async () => {

--- a/test/fixtures/folding-crlf.ps1
+++ b/test/fixtures/folding-crlf.ps1
@@ -1,3 +1,12 @@
+#RegIon This should fold
+<#
+Nested different comment types.  This should fold
+#>
+#EnDReGion
+
+# region This should not fold due to whitespace
+$shouldFold = $false
+#    endRegion
 function short-func-not-fold {};
 <#
 .SYNOPSIS
@@ -30,7 +39,7 @@ double quoted herestrings should also fold
 
   #region This fools the indentation folding.
   Write-Host "Hello"
-    # region Nested regions should be foldable
+    #region Nested regions should be foldable
     Write-Host "Hello"
     # comment1
     Write-Host "Hello"
@@ -38,7 +47,7 @@ double quoted herestrings should also fold
     Write-Host "Hello"
     # comment2
     Write-Host "Hello"
-    # endregion
+    #endregion
 
   $c = {
     Write-Host "Script blocks should be foldable"

--- a/test/fixtures/folding-lf.ps1
+++ b/test/fixtures/folding-lf.ps1
@@ -1,3 +1,12 @@
+#RegIon This should fold
+<#
+Nested different comment types.  This should fold
+#>
+#EnDReGion
+
+# region This should not fold due to whitespace
+$shouldFold = $false
+#    endRegion
 function short-func-not-fold {};
 <#
 .SYNOPSIS
@@ -30,7 +39,7 @@ double quoted herestrings should also fold
 
   #region This fools the indentation folding.
   Write-Host "Hello"
-    # region Nested regions should be foldable
+    #region Nested regions should be foldable
     Write-Host "Hello"
     # comment1
     Write-Host "Hello"
@@ -38,7 +47,7 @@ double quoted herestrings should also fold
     Write-Host "Hello"
     # comment2
     Write-Host "Hello"
-    # endregion
+    #endregion
 
   $c = {
     Write-Host "Script blocks should be foldable"


### PR DESCRIPTION
## PR Summary

Previously the code folding feature would fail to find region blocks starting
with `Region` or ending with `EndRegion`.  This was due to the regex only
looking for lower case.  This commit updates the start and end region
detection to be case insensitive, similar to that defined in
https://github.com/Microsoft/vscode/commit/64186b0a262f0ff89a060cf8dbbf8de7ff831a00

This commit adds has strict whitespace rules for the region/endregion keyword
which means only `#region` will match whereas `# region` will not.

Previously the code folding had trouble detecting the beginning of comment
blocks and regions which were not indented.  This was due to the empty line
regex expecting at least one whitespace character to be considered "an empty
line".  This commit modifies the empty line regex to also allow an empty string
which is indeed, an empty line.

Fixes #1428

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
