### PR TITLE
First approach to fix issue with dbg/run start before PSES running

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -222,6 +222,10 @@ export class SessionManager implements Middleware {
         return this.sessionDetails;
     }
 
+    public getSessionStatus(): SessionStatus {
+        return this.sessionStatus;
+    }
+
     public getPowerShellVersionDetails(): IPowerShellVersionDetails {
         return this.versionDetails;
     }


### PR DESCRIPTION
## PR Summary

Fix #1433

One minor issue is that if you abort (return null|undefined) from
resolveDebugConfiguration, VSCode "helpfully" opens your launch.json
file for you.  Actually, that is quite annoying. I found an issue and on
this and voted it up - https://github.com/Microsoft/vscode/issues/54213

Also fix logic for "attach" error.  We only need to test if
OS != Windows.  If on Windows, PS Core supports attach. And tweaked the
error message wording to make more clear.

If the user attempts to start a dgb or "run with out debugging" session
before PSES is running, a NullRefEx occurs in PSES. Ideally, we would
wait in the resolveDebugConfiguration method for PSES to finish
initializing with a max wait time of say 10 seconds.  Unfortunately,
"sleep" in a loop in JavaScript is not so easy.  AFAIT requires a
significant rewrite of the method using setTimeout().  Not sure it is
worth it, unless someone more knowledgable in JS can find an easy
way to do the poll (for sessionstatus)/sleep loop.

BTW there is probably a fix we need to make in PSES to check if
SynchronizationContext is not null before we try to use it.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
