### PR TITLE
increment version for prereleases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.8.2-insiders-{build}'
+version: '1.8.3-insiders-{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PowerShell",
   "displayName": "PowerShell",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import utils = require("./utils");
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
-const requiredEditorServicesVersion = "1.8.2";
+const requiredEditorServicesVersion = "1.8.3";
 
 let logger: Logger;
 let sessionManager: SessionManager;

--- a/tools/releaseBuild/Image/DockerFile
+++ b/tools/releaseBuild/Image/DockerFile
@@ -23,7 +23,7 @@ COPY build.ps1 containerFiles/build.ps1
 
 # Add an environment variable for build versioning
 ENV VSTS_BUILD=1
-ENV VSTS_BUILD_VERSION=1.8.2
+ENV VSTS_BUILD_VERSION=1.8.3
 
 # Uncomment to debug locally
 # RUN Import-Module ./containerFiles/dockerInstall.psm1; `


### PR DESCRIPTION
This increments the version so VSIX's are considered "previews" and are not overridden by the current release.

Related to https://github.com/PowerShell/PowerShellEditorServices/pull/717

addresses https://github.com/PowerShell/vscode-powershell/issues/1445