### PR TITLE
(GH-1459) Folding provider should not crash with mismatched region tokens

### DIFF
--- a/src/features/Folding.ts
+++ b/src/features/Folding.ts
@@ -283,7 +283,7 @@ export class FoldingProvider implements vscode.FoldingRangeProvider {
             if (token.scopes.indexOf(startScopeName) !== -1) {
                 tokenStack.push(token);
             }
-            if (token.scopes.indexOf(endScopeName) !== -1) {
+            if ((tokenStack.length > 0) && (token.scopes.indexOf(endScopeName) !== -1)) {
                 result.unshift((new LineNumberRange(matchType)).fromTokenPair(tokenStack.pop(), token, document));
             }
         });

--- a/test/features/folding.test.ts
+++ b/test/features/folding.test.ts
@@ -82,6 +82,20 @@ suite("Features", () => {
 
                 assertFoldingRegions(result, expectedFoldingRegions);
             });
+
+            test("Can detect all of the foldable regions in a document with mismatched regions", async () => {
+                const expectedMismatchedFoldingRegions = [
+                    { start: 2,  end: 4,  kind: 3 },
+                ];
+
+                // Integration test against the test fixture 'folding-mismatch.ps1' that contains
+                // comment regions with mismatched beginning and end
+                const uri = vscode.Uri.file(path.join(fixturePath, "folding-mismatch.ps1"));
+                const document = await vscode.workspace.openTextDocument(uri);
+                const result = await provider.provideFoldingRanges(document, null, null);
+
+                assertFoldingRegions(result, expectedMismatchedFoldingRegions);
+            });
         });
     });
 });

--- a/test/fixtures/folding-mismatch.ps1
+++ b/test/fixtures/folding-mismatch.ps1
@@ -1,0 +1,7 @@
+#endregion should not fold - mismatched
+
+#region This should fold
+$something = 'foldable'
+#endregion
+
+#region should not fold - mismatched


### PR DESCRIPTION
## PR Summary

Previously the folding provider would crash with an error if the document
contained mismatched begin and end region comments e.g. If the document
started with `# endregion`.  This was due to the token stack code always
assuming there was at least one element in the stack.  This commit modifies
the end region detection to only trigger if there was a previous begin region.

Fixes #1459 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
