### PR TITLE
Change resourceLangId to editorLangId Fixes 1473

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,12 +160,12 @@
     "menus": {
       "editor/context": [
         {
-          "when": "resourceLangId == powershell",
+          "when": "editorLangId == powershell",
           "command": "PowerShell.RunSelection",
           "group": "2_powershell"
         },
         {
-          "when": "resourceLangId == powershell",
+          "when": "editorLangId == powershell",
           "command": "PowerShell.OnlineHelp",
           "group": "2_powershell"
         }


### PR DESCRIPTION

## PR Summary

Right Click will now work with a unsaved file, or a file with non-standard PowerShell extension that is manually set to PowerShell Language.

Uses editorLangId instead of resourceLangId as editorLangId pulls from the editor's set language and not the file's extension: https://code.visualstudio.com/docs/getstarted/keybindings

## PR Checklist


- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress

