### PR TITLE
Add scripts for VSTS to pick PSES branches to include

### DIFF
--- a/tools/releaseBuild/findPsesBuild.ps1
+++ b/tools/releaseBuild/findPsesBuild.ps1
@@ -1,0 +1,9 @@
+$branch = [uri]::EscapeDataString($env:PSES_BRANCH)
+$buildsUrl = $env:VSTS_PSES_URL_TEMPLATE -f $branch
+$headers = @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
+$builds = Invoke-RestMethod -ContentType application/json -Uri $buildsUrl -Headers $headers
+Write-Host "Got PSES_BRANCH: ${env:PSES_BRANCH}"
+Write-Host "Requested URL: $buildsUrl"
+Write-Host "Got response:`n$(ConvertTo-Json $builds)"
+Write-Host "setting PSES_BUILDID to $($builds.value[0].Id)"
+Write-Host "##vso[task.setvariable variable=PSES_BUILDID]$($builds.value[0].Id)"

--- a/tools/releaseBuild/setVstsVariables.ps1
+++ b/tools/releaseBuild/setVstsVariables.ps1
@@ -1,5 +1,5 @@
 $vstsVariables = @{
-    PSES_BRANCH = '2.0.0'
+    PSES_BRANCH = 'master'
 }
 
 # Use VSTS's API to set an env vars

--- a/tools/releaseBuild/setVstsVariables.ps1
+++ b/tools/releaseBuild/setVstsVariables.ps1
@@ -1,0 +1,11 @@
+$vstsVariables = @{
+    PSES_BRANCH = '2.0.0'
+}
+
+# Use VSTS's API to set an env vars
+foreach ($var in $vstsVariables.Keys)
+{
+    $val = $vstsVariables[$var]
+    Write-Host "Setting var '$var' to value '$val'"
+    Write-Host "##vso[task.setvariable variable=$var]$val"
+}


### PR DESCRIPTION
## PR Summary

Adds scripts to be used by the build to determine what PSES branch to build against.

This means a given branch of the VSCode extension can set the `PSES_BRANCH` environment variable in `tools/releaseBuild/setVstsVariables.ps1` to determine what branch of EditorServices will get pulled into that build.

Quick design consideration: should this instead be expanded out to a JSON or a PSD1 file?

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
