### PR TITLE
(GH-1523) Remove duplicate/overlapping folding regions

### DIFF
--- a/test/features/folding.test.ts
+++ b/test/features/folding.test.ts
@@ -96,6 +96,21 @@ suite("Features", () => {
 
                 assertFoldingRegions(result, expectedMismatchedFoldingRegions);
             });
+
+            test("Does not return duplicate or overlapping regions", async () => {
+                const expectedMismatchedFoldingRegions = [
+                    { start: 1,  end: 2,  kind: null },
+                    { start: 2,  end: 4,  kind: null },
+                ];
+
+                // Integration test against the test fixture 'folding-mismatch.ps1' that contains
+                // duplicate/overlapping ranges due to the `(` and `{` characters
+                const uri = vscode.Uri.file(path.join(fixturePath, "folding-duplicate.ps1"));
+                const document = await vscode.workspace.openTextDocument(uri);
+                const result = await provider.provideFoldingRanges(document, null, null);
+
+                assertFoldingRegions(result, expectedMismatchedFoldingRegions);
+            });
         });
     });
 });

--- a/test/fixtures/folding-duplicate.ps1
+++ b/test/fixtures/folding-duplicate.ps1
@@ -1,0 +1,5 @@
+# This script causes duplicate/overlapping ranges due to the `(` and `{` characters
+$AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
+    $_.FullName -ne 'foo'}).ForEach({
+        # Do Something
+})


### PR DESCRIPTION
## PR Summary

Previously the syntax folder returned an ordered list of folding ranges which
VS Code would "ignore" overlapping or duplicate ranges.  However on manual
testing, it showed that duplicate region did exist and could be folded/unfolded
using the "Fold All" and "Unfold All" commands, but could NOT be manipulated
manually in the editor using the +/- indicator.

This commit adds a filter which removes any duplicate or overlapping regions
which is easily detected via similar region start lines.  This commit also adds
a test for this scenario.

Fixes #1523 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] TESTS!
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
