### PR TITLE
Add 2.0.0 to AppVeyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ osx_image: xcode8.3
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      nvm install v6.0.0
-      sudo apt-get install libunwind8
+      nvm install v6.0.0;
+      sudo apt-get install libunwind8;
     fi
 install:
   - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ osx_image: xcode8.3
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      nvm install v6.0.0;
+      nvm install v6.0.0
+      sudo apt-get install libunwind8
     fi
 install:
   - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ skip_tags: true
 branches:
   only:
   - master
-  - develop
+  - 2.0.0
 
 environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true  # Don't download unneeded packages


### PR DESCRIPTION
Adds the 2.0.0 branch to the AppVeyor build list so we can get a 2.0.0 release artefact.

Not sure what `develop` was, but I'm pretty sure we're not using it any more.