### PR TITLE
Add option to show last line with syntax-aware code folding

### DIFF
--- a/test/features/folding.test.ts
+++ b/test/features/folding.test.ts
@@ -96,6 +96,21 @@ suite("Features", () => {
 
                 assertFoldingRegions(result, expectedMismatchedFoldingRegions);
             });
+
+            test("Does not return duplicate or overlapping regions", async () => {
+                const expectedMismatchedFoldingRegions = [
+                    { start: 1,  end: 2,  kind: null },
+                    { start: 2,  end: 4,  kind: null },
+                ];
+
+                // Integration test against the test fixture 'folding-mismatch.ps1' that contains
+                // duplicate/overlapping ranges due to the `(` and `{` characters
+                const uri = vscode.Uri.file(path.join(fixturePath, "folding-duplicate.ps1"));
+                const document = await vscode.workspace.openTextDocument(uri);
+                const result = await provider.provideFoldingRanges(document, null, null);
+
+                assertFoldingRegions(result, expectedMismatchedFoldingRegions);
+            });
         });
     });
 });

--- a/test/fixtures/folding-duplicate.ps1
+++ b/test/fixtures/folding-duplicate.ps1
@@ -1,0 +1,5 @@
+# This script causes duplicate/overlapping ranges due to the `(` and `{` characters
+$AnArray = @(Get-ChildItem -Path C:\ -Include *.ps1 -File).Where({
+    $_.FullName -ne 'foo'}).ForEach({
+        # Do Something
+})

--- a/tools/Get-PowerShellExtensionChangelog.ps1
+++ b/tools/Get-PowerShellExtensionChangelog.ps1
@@ -188,7 +188,7 @@ function New-ChangeLogEntry
 
     $entry = if ($PRNumber)
     {
-        "- [$RepositoryName #$PRNumber]($repoUrl/pulls/$PRNumber) -"
+        "- [$RepositoryName #$PRNumber]($repoUrl/pull/$PRNumber) -"
     }
     else
     {


### PR DESCRIPTION
## PR Summary

Add a settings option to enable the last line of a syntax-aware folded section to be displayed when the section is folded. Relates to issue #1514

I have added a speculative note in the changelog.md file as I wasn't sure if I should update it or not.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready