### PR TITLE
Explicitly return undefined from resolveDbgConfig when sessn not started

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -53,7 +53,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
             const msg = "Cannot debug or run a PowerShell script until the PowerShell session has started. " +
                 "Wait for the PowerShell session to finish starting and try again.";
             vscode.window.showWarningMessage(msg);
-            return;
+            return undefined;
         }
 
         // Starting a debug session can be done when there is no document open e.g. attach to PS host process


### PR DESCRIPTION
## PR Summary

In the September drop of VSCode this fixes the issue with VSCode
opening launch.json in this case.  Technically using return with no expr 
works but better to be explicit in this case I think.

https://github.com/Microsoft/vscode/issues/54213#issuecomment-420965778

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
