### PR TITLE
Log when languageClient not loaded during initialization

### DIFF
--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -6,6 +6,7 @@ import vscode = require("vscode");
 import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
 import { ICheckboxQuickPickItem, showCheckboxQuickPick } from "../controls/checkboxQuickPick";
 import { IFeature } from "../feature";
+import { Logger } from "../logging";
 
 export const EvaluateRequestType = new RequestType<IEvaluateRequestArguments, void, void, void>("evaluate");
 export const OutputNotificationType = new NotificationType<IOutputNotificationBody, void>("output");
@@ -200,11 +201,12 @@ export class ConsoleFeature implements IFeature {
     private languageClient: LanguageClient;
     private resolveStatusBarPromise: (value?: {} | PromiseLike<{}>) => void;
 
-    constructor() {
+    constructor(private log: Logger) {
         this.commands = [
             vscode.commands.registerCommand("PowerShell.RunSelection", async () => {
                 if (this.languageClient === undefined) {
-                    // TODO: Log error message
+                    this.log.writeAndShowError(`<${ConsoleFeature.name}>: ` +
+                    "Unable to instantiate; language client undefined.");
                     return;
                 }
 

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -206,7 +206,7 @@ export class ConsoleFeature implements IFeature {
             vscode.commands.registerCommand("PowerShell.RunSelection", async () => {
                 if (this.languageClient === undefined) {
                     this.log.writeAndShowError(`<${ConsoleFeature.name}>: ` +
-                    "Unable to instantiate; language client undefined.");
+                        "Unable to instantiate; language client undefined.");
                     return;
                 }
 

--- a/src/features/ExpandAlias.ts
+++ b/src/features/ExpandAlias.ts
@@ -6,6 +6,7 @@ import vscode = require("vscode");
 import Window = vscode.window;
 import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
+import { Logger } from "../logging";
 
 export const ExpandAliasRequestType = new RequestType<string, any, void, void>("powerShell/expandAlias");
 
@@ -13,10 +14,11 @@ export class ExpandAliasFeature implements IFeature {
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
 
-    constructor() {
+    constructor(private log: Logger) {
         this.command = vscode.commands.registerCommand("PowerShell.ExpandAlias", () => {
             if (this.languageClient === undefined) {
-                // TODO: Log error message
+                this.log.writeAndShowError(`<${ExpandAliasFeature.name}>: ` +
+                    "Unable to instantiate; language client undefined.");
                 return;
             }
 

--- a/src/features/SelectPSSARules.ts
+++ b/src/features/SelectPSSARules.ts
@@ -6,6 +6,7 @@ import vscode = require("vscode");
 import { LanguageClient, RequestType } from "vscode-languageclient";
 import { ICheckboxQuickPickItem, showCheckboxQuickPick } from "../controls/checkboxQuickPick";
 import { IFeature } from "../feature";
+import { Logger } from "../logging";
 
 export const GetPSSARulesRequestType = new RequestType<any, any, void, void>("powerShell/getPSSARules");
 export const SetPSSARulesRequestType = new RequestType<any, any, void, void>("powerShell/setPSSARules");
@@ -20,9 +21,11 @@ export class SelectPSSARulesFeature implements IFeature {
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
 
-    constructor() {
+    constructor(private log: Logger) {
         this.command = vscode.commands.registerCommand("PowerShell.SelectPSSARules", () => {
             if (this.languageClient === undefined) {
+                this.log.writeAndShowError(`<${SelectPSSARulesFeature.name}>: ` +
+                    "Unable to instantiate; language client undefined.");
                 return;
             }
 

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -5,6 +5,7 @@
 import vscode = require("vscode");
 import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
+import { Logger } from "../logging";
 
 export const ShowHelpRequestType =
     new RequestType<string, void, void, void>("powerShell/showHelp");
@@ -14,10 +15,11 @@ export class ShowHelpFeature implements IFeature {
     private deprecatedCommand: vscode.Disposable;
     private languageClient: LanguageClient;
 
-    constructor() {
+    constructor(private log: Logger) {
         this.command = vscode.commands.registerCommand("PowerShell.ShowHelp", () => {
             if (this.languageClient === undefined) {
-                // TODO: Log error message
+                this.log.writeAndShowError(`<${ShowHelpFeature.name}>: ` +
+                    "Unable to instantiate; language client undefined.");
                 return;
             }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -118,16 +118,16 @@ export function activate(context: vscode.ExtensionContext): void {
 
     // Create features
     extensionFeatures = [
-        new ConsoleFeature(),
+        new ConsoleFeature(logger),
         new ExamplesFeature(),
         new OpenInISEFeature(),
         new GenerateBugReportFeature(sessionManager),
-        new ExpandAliasFeature(),
-        new ShowHelpFeature(),
+        new ExpandAliasFeature(logger),
+        new ShowHelpFeature(logger),
         new FindModuleFeature(),
         new PesterTestsFeature(sessionManager),
         new ExtensionCommandsFeature(logger),
-        new SelectPSSARulesFeature(),
+        new SelectPSSARulesFeature(logger),
         new CodeActionsFeature(),
         new NewFileOrProjectFeature(),
         new DocumentFormatterFeature(logger, documentSelector),


### PR DESCRIPTION
## PR Summary

@rjmholt commented on another PR #1406 that we should be logging when the languageClient isn't loaded: https://github.com/PowerShell/vscode-powershell/pull/1406#discussion_r209326219 This takes the pattern used in ExtensionsCommandsFeature and duplicates it to the 4 other instances of this check (3 of them labeled TODO).

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress