### PR TITLE
(GH-1514) Show the last line of folding regions as per default VSCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -478,6 +478,11 @@
           "default": true,
           "description": "Enables syntax based code folding. When disabled, the default indentation based code folding is used."
         },
+        "powershell.codeFolding.showLastLine": {
+          "type": "boolean",
+          "default": true,
+          "description": "Shows the last line of a folded section similar to the default VSCode folding style. When disabled, the entire folded region is hidden."
+        },
         "powershell.codeFormatting.preset": {
           "type": "string",
           "enum": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -31,6 +31,7 @@ export interface IBugReportingSettings {
 
 export interface ICodeFoldingSettings {
     enable?: boolean;
+    showLastLine?: boolean;
 }
 
 export interface ICodeFormattingSettings {
@@ -116,6 +117,7 @@ export function load(): ISettings {
 
     const defaultCodeFoldingSettings: ICodeFoldingSettings = {
         enable: true,
+        showLastLine: false,
     };
 
     const defaultCodeFormattingSettings: ICodeFormattingSettings = {

--- a/test/features/folding.test.ts
+++ b/test/features/folding.test.ts
@@ -7,6 +7,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { DocumentSelector } from "vscode-languageclient";
 import * as folding from "../../src/features/Folding";
+import * as Settings from "../../src/settings";
 import { MockLogger } from "../test_utils";
 
 const fixturePath = path.join(__dirname, "..", "..", "..", "test", "fixtures");
@@ -20,6 +21,13 @@ function assertFoldingRegions(result, expected): void {
     }
 
     assert.equal(result.length, expected.length);
+}
+
+// Wrap the FoldingProvider class with our own custom settings for testing
+class CustomSettingFoldingProvider extends folding.FoldingProvider {
+    public customSettings: Settings.ISettings = Settings.load();
+    // Overridde the super currentSettings method with our own custom test settings
+    public currentSettings(): Settings.ISettings { return this.customSettings; }
 }
 
 suite("Features", () => {
@@ -38,21 +46,21 @@ suite("Features", () => {
 
         suite("For a single document", async () => {
             const expectedFoldingRegions = [
-                { start: 0,  end: 4,  kind: 3 },
-                { start: 1,  end: 3,  kind: 1 },
-                { start: 10, end: 15, kind: 1 },
-                { start: 16, end: 60, kind: null },
-                { start: 17, end: 22, kind: 1 },
-                { start: 23, end: 26, kind: null },
-                { start: 28, end: 31, kind: null },
-                { start: 35, end: 37, kind: 1 },
-                { start: 39, end: 49, kind: 3 },
-                { start: 41, end: 45, kind: 3 },
-                { start: 51, end: 53, kind: null },
-                { start: 56, end: 59, kind: null },
-                { start: 64, end: 66, kind: 1 },
-                { start: 67, end: 72, kind: 3 },
-                { start: 68, end: 70, kind: 1 },
+                { start: 0,  end: 3,  kind: 3 },
+                { start: 1,  end: 2,  kind: 1 },
+                { start: 10, end: 14, kind: 1 },
+                { start: 16, end: 59, kind: null },
+                { start: 17, end: 21, kind: 1 },
+                { start: 23, end: 25, kind: null },
+                { start: 28, end: 30, kind: null },
+                { start: 35, end: 36, kind: 1 },
+                { start: 39, end: 48, kind: 3 },
+                { start: 41, end: 44, kind: 3 },
+                { start: 51, end: 52, kind: null },
+                { start: 56, end: 58, kind: null },
+                { start: 64, end: 65, kind: 1 },
+                { start: 67, end: 71, kind: 3 },
+                { start: 68, end: 69, kind: 1 },
             ];
 
             test("Can detect all of the foldable regions in a document with CRLF line endings", async () => {
@@ -83,9 +91,31 @@ suite("Features", () => {
                 assertFoldingRegions(result, expectedFoldingRegions);
             });
 
+            suite("Where showLastLine setting is false", async () => {
+                const customprovider = (new CustomSettingFoldingProvider(psGrammar));
+                customprovider.customSettings.codeFolding.showLastLine = false;
+
+                test("Can detect all foldable regions in a document", async () => {
+                    // Integration test against the test fixture 'folding-lf.ps1' that contains
+                    // all of the different types of folding available
+                    const uri = vscode.Uri.file(path.join(fixturePath, "folding-lf.ps1"));
+                    const document = await vscode.workspace.openTextDocument(uri);
+                    const result = await customprovider.provideFoldingRanges(document, null, null);
+
+                    // Incrememnt the end line of the expected regions by one as we will
+                    // be hiding the last line
+                    const expectedLastLineRegions = expectedFoldingRegions.map( (item) => {
+                        item.end++;
+                        return item;
+                    });
+
+                    assertFoldingRegions(result, expectedLastLineRegions);
+                });
+            });
+
             test("Can detect all of the foldable regions in a document with mismatched regions", async () => {
                 const expectedMismatchedFoldingRegions = [
-                    { start: 2,  end: 4,  kind: 3 },
+                    { start: 2,  end: 3,  kind: 3 },
                 ];
 
                 // Integration test against the test fixture 'folding-mismatch.ps1' that contains
@@ -99,8 +129,8 @@ suite("Features", () => {
 
             test("Does not return duplicate or overlapping regions", async () => {
                 const expectedMismatchedFoldingRegions = [
-                    { start: 1,  end: 2,  kind: null },
-                    { start: 2,  end: 4,  kind: null },
+                    { start: 1,  end: 1,  kind: null },
+                    { start: 2,  end: 3,  kind: null },
                 ];
 
                 // Integration test against the test fixture 'folding-mismatch.ps1' that contains


### PR DESCRIPTION
## PR Summary

Previously the code folding provider would hide the last line of the region,
however the default VS Code code folding behaviour is to instead hide from
the beginning to end minus one, lines.  This commit;

* Adds a configuration parameter to show/hide the last line in a region,
  defaulting to Show the last line
* Modifies conversion method for the internal region class to FoldingRange
  object to show/hide the last line based on the extension settings
* Modifies the tests for the default value and adds tests for the show and hide
  scenarios

This code is based on a solution created by;
ens-rpitcher <russell.pitcher@attenda.com>

Fixes #1514 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] PR has tests
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
