### PR TITLE
[Ignore] Make build.ps1 work when no params given

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+[CmdletBinding(DefaultParameterSetName = "Build")]
 param(
     [Parameter(ParameterSetName="Bootstrap")]
     [switch]


### PR DESCRIPTION
## PR Summary

Executing `build.ps1` with no parameters fails currently (contrary to documentation). So this fixes it.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
