### PR TITLE
Removed ShowOnlineHelp Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,11 +87,6 @@
         "category": "PowerShell"
       },
       {
-        "command": "PowerShell.OnlineHelp",
-        "title": "Get Online Help for Command (Deprecated)",
-        "category": "PowerShell"
-      },
-      {
         "command": "PowerShell.ShowHelp",
         "title": "Get Help for Command",
         "category": "PowerShell"

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -29,12 +29,6 @@ export class ShowHelpFeature implements IFeature {
 
             this.languageClient.sendRequest(ShowHelpRequestType, text);
         });
-
-        this.deprecatedCommand = vscode.commands.registerCommand("PowerShell.OnlineHelp", () => {
-            const warnText = "PowerShell.OnlineHelp is being deprecated. Use PowerShell.ShowHelp instead.";
-            vscode.window.showWarningMessage(warnText);
-            vscode.commands.executeCommand("PowerShell.ShowHelp");
-        });
     }
 
     public dispose() {


### PR DESCRIPTION
## PR Summary

Remove the ShowOnlineHelp command from the Command Palette.

Command was deprecated in 1.9.0. This is to fully remove the command.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
