### PR TITLE
Make the Install-VSCode script work on *nix

### DIFF
--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -579,7 +579,7 @@ try {
     elseif ($IsLinux -or $IsMacOS) {
         # On *nix we need to install extensions as the user -- VSCode refuses root
         $extsSlashes = $extensions -join '/'
-        sudo -H -u $env:SUDO_USER pwsh -c "`$exts = $extsSlashes -split '/'; foreach (`$e in `$exts) { $codeExePath --install-extension `$e }"
+        sudo -H -u $env:SUDO_USER pwsh -c "`$exts = '$extsSlashes' -split '/'; foreach (`$e in `$exts) { $codeExePath --install-extension `$e }"
     }
     else {
         foreach ($extension in $extensions) {

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -139,7 +139,9 @@ param(
 
     [switch]$LaunchWhenDone,
 
-    [switch]$EnableContextMenus
+    [switch]$EnableContextMenus,
+
+    [switch]$WhatIf
 )
 
 function Test-IsOsX64 {
@@ -404,6 +406,10 @@ function Install-VSCodeFromTar {
 
 try {
     $prevProgressPreference = $ProgressPreference
+    $ProgressPreference = 'SilentlyContinue'
+
+    $prevWhatIfPreference = $WhatIfPreference
+    $WhatIfPreference = $WhatIfPreference -or $WhatIf
 
     $onWindows = $IsWindows -or $PSVersionTable.PSVersion.Major -lt 6
 
@@ -522,4 +528,5 @@ try {
 }
 finally {
     $ProgressPreference = $prevProgressPreference
+    $WhatIfPreference = $prevWhatIfPreference
 }

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -322,7 +322,7 @@ function Get-CodePlatformInformation {
         }
     }
 
-    $info = @{
+    return @{
         AppName = $appName
         ExePath = $exePath
         Platform = $platform
@@ -330,8 +330,6 @@ function Get-CodePlatformInformation {
         FileUri = "https://vscode-update.azurewebsites.net/latest/$platform/$channel"
         Extension = $ext
     }
-
-    return $info
 }
 
 function Save-WithBitsTransfer {

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -438,10 +438,8 @@ function Install-VSCodeFromTar {
 }
 
 # We need to be running as elevated on *nix
-if ($IsLinux -or $IsMacOS) {
-    if ((id -u) -ne 0) {
-        throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable"
-    }
+if (($IsLinux -or $IsMacOS) -and (id -u) -ne 0) {
+    throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable"
 }
 
 try {

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -481,7 +481,7 @@ try {
 
             # The deb file contains the information to install its own repository,
             # so we just need to install it
-            apt install $installerPath
+            apt install -y $installerPath
             break
         }
 
@@ -501,22 +501,22 @@ try {
             switch ($pacMan) {
                 'zypper' {
                     $script:VSCodeZypperRepoEntry > /etc/zypp/repos.d/vscode.repo
-                    zypper refresh
+                    zypper refresh -y
                 }
 
                 default {
                     $script:VSCodeYumRepoEntry > /etc/yum.repos.d/vscode.repo
-                    & $pacMan check-update
+                    & $pacMan check-update -y
                 }
             }
 
             switch ($BuildEdition) {
                 'Stable' {
-                    & $pacMan install code
+                    & $pacMan install -y code
                 }
 
                 default {
-                    & $pacMan install code-insiders
+                    & $pacMan install -y code-insiders
                 }
             }
             break

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -588,7 +588,7 @@ try {
         return
     }
 
-    if ($PSCmdlet.ShouldProcess('Installation complete!', 'Write-Host') {
+    if ($PSCmdlet.ShouldProcess('Installation complete!', 'Write-Host')) {
         Write-Host "`nInstallation complete!`n`n" -ForegroundColor Green
     }
 }

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -449,8 +449,6 @@ try {
     $prevWhatIfPreference = $WhatIfPreference
     $WhatIfPreference = $WhatIfPreference -or $WhatIf
 
-    $onWindows = $IsWindows -or $PSVersionTable.PSVersion.Major -lt 6
-
     # Get information required for installation
     $codePlatformInfo = Get-CodePlatformInformation -Bitness $Architecture -BuildEdition $BuildEdition
 
@@ -462,7 +460,7 @@ try {
 
     $installerPath = [System.IO.Path]::Combine($tmpdir, $installerName)
 
-    if ($onWindows) {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
         Save-WithBitsTransfer -FileUri $codePlatformInfo.FileUri -Destination $installerPath -AppName $codePlatformInfo.AppName
     }
     # We don't want to use RPM packages -- see the installation step below

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -455,12 +455,14 @@ try {
 
     $installerPath = [System.IO.Path]::Combine($tmpdir, $installerName)
 
-    if ($PSVersionTable.PSVersion.Major -lt 6) {
+    if ($PSVersionTable.PSVersion.Major -le 5) {
         Save-WithBitsTransfer -FileUri $codePlatformInfo.FileUri -Destination $installerPath -AppName $codePlatformInfo.AppName
     }
     # We don't want to use RPM packages -- see the installation step below
     elseif ($codePlatformInfo.Extension -ne 'rpm') {
-        Invoke-WebRequest -Uri $codePlatformInfo.FileUri -OutFile $installerPath
+        if ($PSCmdlet.ShouldProcess($codePlatformInfo.FileUri, "Invoke-WebRequest -OutFile $installerPath") {
+            Invoke-WebRequest -Uri $codePlatformInfo.FileUri -OutFile $installerPath
+        }
     }
 
     # Install VSCode
@@ -586,7 +588,9 @@ try {
         return
     }
 
-    Write-Host "`nInstallation complete!`n`n" -ForegroundColor Green
+    if ($PSCmdlet.ShouldProcess('Installation complete!', 'Write-Host') {
+        Write-Host "`nInstallation complete!`n`n" -ForegroundColor Green
+    }
 }
 finally {
     $ProgressPreference = $prevProgressPreference

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -175,6 +175,10 @@ function Get-AvailablePackageManager
     if (Get-Command 'yum' -ErrorAction SilentlyContinue) {
         return 'yum'
     }
+
+    if (Get-Command 'zypper' -ErrorAction SilentlyContinue) {
+        return 'zypper'
+    }
 }
 
 function Get-CodePlatformInformation {
@@ -239,7 +243,7 @@ function Get-CodePlatformInformation {
                     break
                 }
 
-                { 'dnf','yum' -contains $_ } {
+                { 'dnf','yum','zypper' -contains $_ } {
                     $platform = 'linux-rpm-x64'
                     $ext = 'rpm'
                     break

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -293,11 +293,11 @@ function Get-CodePlatformInformation {
                     $exePath = "$installBase\Microsoft VS Code\bin\code.cmd"
                 }
 
-                'Insiders-System' {
+                'Insider-System' {
                     $exePath = "$installBase\Microsoft VS Code Insiders\bin\code-insiders.cmd"
                 }
 
-                'Insiders-User' {
+                'Insider-User' {
                     $exePath = "${env:LocalAppData}\Programs\Microsoft VS Code Insiders\bin\code-insiders.cmd"
                 }
             }
@@ -310,12 +310,12 @@ function Get-CodePlatformInformation {
             break
         }
 
-        'Insiders-System' {
+        'Insider-System' {
             $channel = 'insider'
             break
         }
 
-        'Insiders-User' {
+        'Insider-User' {
             $channel = 'insider'
             $platform += '-user'
             break
@@ -419,6 +419,7 @@ try {
     # Download the installer
     $tmpdir = [System.IO.Path]::GetTempPath()
 
+    $ext = $codePlatformInfo.Extension
     $installerName = "vscode-install.$ext"
 
     $installerPath = [System.IO.Path]::Combine($tmpdir, $installerName)
@@ -427,7 +428,7 @@ try {
         Save-WithBitsTransfer -FileUri $codePlatformInfo.FileUri -Destination $installerPath -AppName $codePlatformInfo.AppName
     }
     else {
-        Invoke-WebRequest -Uri $FileUri -OutFile $installerPath
+        Invoke-WebRequest -Uri $codePlatformInfo.FileUri -OutFile $installerPath
     }
 
     # Install VSCode
@@ -517,6 +518,7 @@ try {
 
         if ($WhatIfPreference) {
             Write-Host "Launching $appName from $codeExePath"
+            return
         }
 
         Write-Host "`nInstallation complete, starting $appName...`n`n" -ForegroundColor Green

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -460,7 +460,7 @@ try {
     }
     # We don't want to use RPM packages -- see the installation step below
     elseif ($codePlatformInfo.Extension -ne 'rpm') {
-        if ($PSCmdlet.ShouldProcess($codePlatformInfo.FileUri, "Invoke-WebRequest -OutFile $installerPath") {
+        if ($PSCmdlet.ShouldProcess($codePlatformInfo.FileUri, "Invoke-WebRequest -OutFile $installerPath")) {
             Invoke-WebRequest -Uri $codePlatformInfo.FileUri -OutFile $installerPath
         }
     }

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -139,7 +139,7 @@ param(
 
     [switch]$LaunchWhenDone,
 
-    [switch]$EnableContextMenus,
+    [switch]$EnableContextMenus
 )
 
 # Taken from https://code.visualstudio.com/docs/setup/linux#_installation

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -440,7 +440,7 @@ function Install-VSCodeFromTar {
 # We need to be running as elevated on *nix
 if ($IsLinux -or $IsMacOS) {
     if ((id -u) -ne 0) {
-        throw "Must be running as root to install VSCode"
+        throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable"
     }
 }
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.2
+.VERSION 1.3
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -142,20 +142,16 @@ param(
     [switch]$EnableContextMenus
 )
 
-function Test-IsOsX64
-{
-    if ($PSVersionTable.PSVersion.Major -lt 6)
-    {
+function Test-IsOsX64 {
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
         return (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture -eq "64-bit"
     }
 
     return [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::X64
 }
 
-function Get-LinuxReleaseInfo
-{
-    if (-not (Test-Path '/etc/*-release'))
-    {
+function Get-LinuxReleaseInfo {
+    if (-not (Test-Path '/etc/*-release')) {
         return $null
     }
 
@@ -306,8 +302,7 @@ function Get-CodePlatformInformation {
         }
     }
 
-    switch ($BuildEdition)
-    {
+    switch ($BuildEdition) {
         'Stable' {
             $channel = 'stable'
             break
@@ -407,8 +402,7 @@ function Install-VSCodeFromTar {
     ln -s "$destDir/code" /usr/bin/code
 }
 
-try
-{
+try {
     $prevProgressPreference = $ProgressPreference
 
     $onWindows = $IsWindows -or $PSVersionTable.PSVersion.Major -lt 6

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -306,7 +306,7 @@ function Get-CodePlatformInformation {
                 '64-bit' {
                     $installBase = ${env:ProgramFiles}
 
-                    if (Test-IsOsX64) {
+                    if (Test-IsOsArchX64) {
                         $platform = 'win32-x64'
                         break
                     }


### PR DESCRIPTION
## PR Summary

Made a few changes so the `Install-VSCode.ps1` script supports macOS and various Linux distros as well.

It's probably not exhaustive and could do with a bit of testing.

I added a `-WhatIf` parameter as well, so you can use that to test and it will do the downloads but won't install anything.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
