### PR TITLE
Add CodeAction support to show PSSA rule documentation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new PesterTestsFeature(sessionManager),
         new ExtensionCommandsFeature(logger),
         new SelectPSSARulesFeature(logger),
-        new CodeActionsFeature(),
+        new CodeActionsFeature(logger),
         new NewFileOrProjectFeature(),
         new DocumentFormatterFeature(logger, documentSelector),
         new RemoteFilesFeature(),


### PR DESCRIPTION
This corresponds to PSES PR:
https://github.com/PowerShell/PowerShellEditorServices/pull/789

Currently this points to the PSSA development branch.  Maybe that should
point to the master branch.  Could be a setting I suppose but that seems
like overkill.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
