### PR TITLE
Add keybinding for snippet menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,13 @@
         "command": "PowerShell.RunSelection",
         "key": "f8",
         "when": "editorTextFocus && editorLangId == 'powershell'"
+      },
+      {
+        "command": "editor.action.insertSnippet",
+        "when": "editorTextFocus && editorLangId == 'powershell'",
+        "mac": "cmd+alt+j",
+        "win": "ctrl+alt+j",
+        "linux": "ctrl+alt+j"
       }
     ],
     "commands": [


### PR DESCRIPTION
The ISE had a keybinding (<kbd>Ctrl</kbd>+<kbd>J</kbd>) that would open up a list of all the snippets you have available.

This adds a keybinding for the same thing in VSCode.

Unfortunately, <kbd>Ctrl</kbd>+<kbd>J</kbd> wasn't available... it's set to "Toggle Pane". So a similar keybinding was added:

<kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> on Windows & linux
<kbd>Cmd</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> on macOS
