### PR TITLE
Fix Pester CodeLens not working for running/debugging tests

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -43,7 +43,7 @@ export class PesterTestsFeature implements IFeature {
             request: "launch",
             type: "PowerShell",
             name: "PowerShell Launch Pester Tests",
-            script: `Invoke-Pester`,
+            script: "Invoke-Pester",
             args: [
                 "-Script",
                 `'${scriptPath}'`,

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -2,9 +2,8 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import ChildProcess = require("child_process");
+import * as path from "path";
 import vscode = require("vscode");
-import Window = vscode.window;
 import { IFeature, LanguageClient } from "../feature";
 import { SessionManager } from "../session";
 import Settings = require("../settings");
@@ -40,12 +39,11 @@ export class PesterTestsFeature implements IFeature {
             request: "launch",
             type: "PowerShell",
             name: "PowerShell Launch Pester Tests",
-            script: "Invoke-Pester",
+            script: `Invoke-Pester`,
             args: [
-                `-Script "${uri.fsPath}"`,
-                describeBlockName
-                    ? `-TestName '${describeBlockName}'`
-                    : "",
+                "-Script",
+                // Let PSES handle path quoting since it also handles escaping ' e.g. C:\temp\don't-use-this-path
+                `${uri.fsPath}`,
             ],
             internalConsoleOptions: "neverOpen",
             noDebug: !runInDebugger,
@@ -53,8 +51,13 @@ export class PesterTestsFeature implements IFeature {
             cwd:
                 currentDocument.isUntitled
                     ? vscode.workspace.rootPath
-                    : currentDocument.fileName,
+                    : path.dirname(currentDocument.fileName),
         };
+
+        if (describeBlockName) {
+            launchConfig.args.push("-TestName");
+            launchConfig.args.push(`'${describeBlockName}'`);
+        }
 
         // Create or show the interactive console
         // TODO #367: Check if "newSession" mode is configured

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -35,6 +35,10 @@ export class PesterTestsFeature implements IFeature {
         const currentDocument = vscode.window.activeTextEditor.document;
         const settings = Settings.load();
 
+        // Since we pass the script path to PSES in single quotes to avoid issues with PowerShell
+        // special chars like & $ @ () [], we do have to double up the interior single quotes.
+        const scriptPath = uri.fsPath.replace(/'/g, "''");
+
         const launchConfig = {
             request: "launch",
             type: "PowerShell",
@@ -42,8 +46,9 @@ export class PesterTestsFeature implements IFeature {
             script: `Invoke-Pester`,
             args: [
                 "-Script",
-                // Let PSES handle path quoting since it also handles escaping ' e.g. C:\temp\don't-use-this-path
-                `${uri.fsPath}`,
+                `'${scriptPath}'`,
+                "-PesterOption",
+                "@{IncludeVSCodeMarker=$true}",
             ],
             internalConsoleOptions: "neverOpen",
             noDebug: !runInDebugger,


### PR DESCRIPTION
Fixes #1500

## PR Summary

If we are using an array of args we cannot combine param and value e.g.
`-TestName 'foo'` should be specified as two args.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
