### PR TITLE
`Restart Current Session` in every session quick pick

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -729,12 +729,11 @@ export class SessionManager implements Middleware {
     }
 
     private showSessionMenu() {
-        let menuItems: SessionMenuItem[] = [];
-
         const currentExePath = (this.powerShellExePath || "").toLowerCase();
         const availablePowerShellExes =
             getAvailablePowerShellExes(this.platformDetails, this.sessionSettings);
 
+        let sessionText: string;
         if (this.sessionStatus === SessionStatus.Running) {
             const currentPowerShellExe =
                 availablePowerShellExes
@@ -747,43 +746,37 @@ export class SessionManager implements Middleware {
                     `(${this.versionDetails.architecture}) ${this.versionDetails.edition} Edition ` +
                     `[${this.versionDetails.version}]`;
 
-            const powerShellItems =
-                availablePowerShellExes
-                    .filter((item) => item.exePath.toLowerCase() !== currentExePath)
-                    .map((item) => {
-                        return new SessionMenuItem(
-                            `Switch to ${item.versionName}`,
-                            () => { this.changePowerShellExePath(item.exePath); });
-                    });
-
-            menuItems = [
-                new SessionMenuItem(
-                    `Current session: ${powerShellSessionName}`,
-                    () => { vscode.commands.executeCommand("PowerShell.ShowLogs"); }),
-
-                new SessionMenuItem(
-                    "Restart Current Session",
-                    () => { this.restartSession(); }),
-
-                ...powerShellItems,
-            ];
+            sessionText = `Current session: ${powerShellSessionName}`;
 
         } else if (this.sessionStatus === SessionStatus.Failed) {
-            menuItems = [
-                new SessionMenuItem(
-                    `Session initialization failed, click here to show PowerShell extension logs`,
-                    () => { vscode.commands.executeCommand("PowerShell.ShowLogs"); }),
-
-                new SessionMenuItem(
-                    "Restart Current Session",
-                    () => { this.restartSession(); }),
-            ];
+            sessionText = "Session initialization failed, click here to show PowerShell extension logs";
         }
 
-        menuItems.push(
+        const powerShellItems =
+            availablePowerShellExes
+                .filter((item) => item.exePath.toLowerCase() !== currentExePath)
+                .map((item) => {
+                    return new SessionMenuItem(
+                        `Switch to ${item.versionName}`,
+                        () => { this.changePowerShellExePath(item.exePath); });
+                });
+
+        const menuItems: SessionMenuItem[] = [
+            new SessionMenuItem(
+                sessionText,
+                () => { vscode.commands.executeCommand("PowerShell.ShowLogs"); }),
+
+            new SessionMenuItem(
+                "Restart Current Session",
+                () => { this.restartSession(); }),
+
+            // Add all of the different PowerShell options
+            ...powerShellItems,
+
             new SessionMenuItem(
                 "Open Session Logs Folder",
-                () => { vscode.commands.executeCommand("PowerShell.OpenLogFolder"); }));
+                () => { vscode.commands.executeCommand("PowerShell.OpenLogFolder"); }),
+        ];
 
         vscode
             .window

--- a/src/session.ts
+++ b/src/session.ts
@@ -747,6 +747,15 @@ export class SessionManager implements Middleware {
                     `(${this.versionDetails.architecture}) ${this.versionDetails.edition} Edition ` +
                     `[${this.versionDetails.version}]`;
 
+            const powerShellItems =
+                availablePowerShellExes
+                    .filter((item) => item.exePath.toLowerCase() !== currentExePath)
+                    .map((item) => {
+                        return new SessionMenuItem(
+                            `Switch to ${item.versionName}`,
+                            () => { this.changePowerShellExePath(item.exePath); });
+                    });
+
             menuItems = [
                 new SessionMenuItem(
                     `Current session: ${powerShellSessionName}`,
@@ -755,25 +764,21 @@ export class SessionManager implements Middleware {
                 new SessionMenuItem(
                     "Restart Current Session",
                     () => { this.restartSession(); }),
+
+                ...powerShellItems,
             ];
+
         } else if (this.sessionStatus === SessionStatus.Failed) {
             menuItems = [
                 new SessionMenuItem(
                     `Session initialization failed, click here to show PowerShell extension logs`,
                     () => { vscode.commands.executeCommand("PowerShell.ShowLogs"); }),
+
+                new SessionMenuItem(
+                    "Restart Current Session",
+                    () => { this.restartSession(); }),
             ];
         }
-
-        const powerShellItems =
-            availablePowerShellExes
-                .filter((item) => item.exePath.toLowerCase() !== currentExePath)
-                .map((item) => {
-                    return new SessionMenuItem(
-                        `Switch to ${item.versionName}`,
-                        () => { this.changePowerShellExePath(item.exePath); });
-                });
-
-        menuItems = menuItems.concat(powerShellItems);
 
         menuItems.push(
             new SessionMenuItem(

--- a/src/session.ts
+++ b/src/session.ts
@@ -734,22 +734,33 @@ export class SessionManager implements Middleware {
             getAvailablePowerShellExes(this.platformDetails, this.sessionSettings);
 
         let sessionText: string;
-        if (this.sessionStatus === SessionStatus.Running) {
-            const currentPowerShellExe =
+
+        switch (this.sessionStatus) {
+            case SessionStatus.Running:
+            case SessionStatus.Initializing:
+            case SessionStatus.NotStarted:
+            case SessionStatus.NeverStarted:
+            case SessionStatus.Stopping:
+                const currentPowerShellExe =
                 availablePowerShellExes
                     .find((item) => item.exePath.toLowerCase() === currentExePath);
 
-            const powerShellSessionName =
-                currentPowerShellExe ?
-                    currentPowerShellExe.versionName :
-                    `PowerShell ${this.versionDetails.displayVersion} ` +
-                    `(${this.versionDetails.architecture}) ${this.versionDetails.edition} Edition ` +
-                    `[${this.versionDetails.version}]`;
+                const powerShellSessionName =
+                    currentPowerShellExe ?
+                        currentPowerShellExe.versionName :
+                        `PowerShell ${this.versionDetails.displayVersion} ` +
+                        `(${this.versionDetails.architecture}) ${this.versionDetails.edition} Edition ` +
+                        `[${this.versionDetails.version}]`;
 
-            sessionText = `Current session: ${powerShellSessionName}`;
+                sessionText = `Current session: ${powerShellSessionName}`;
+                break;
 
-        } else if (this.sessionStatus === SessionStatus.Failed) {
-            sessionText = "Session initialization failed, click here to show PowerShell extension logs";
+            case SessionStatus.Failed:
+                sessionText = "Session initialization failed, click here to show PowerShell extension logs";
+                break;
+
+            default:
+                throw new TypeError("Not a valid value for the enum 'SessionStatus'");
         }
 
         const powerShellItems =


### PR DESCRIPTION
## PR Summary

fixes #1614 

This does some reorganizing of the quick pick dialog for sessions. It makes sure the `Restart Current Session` command is always available and only shows the `Switch to X` when a session is running.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
