### PR TITLE
DO NOT MERGE F8 always runs in active terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.25.0"
+    "vscode": "^1.29.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
@@ -46,8 +46,8 @@
     "mocha": "~4.0.1",
     "tslint": "~5.11.0",
     "typescript": "~3.2.1",
-    "vsce": "~1.46.0",
-    "vscode": "~1.1.22"
+    "vsce": "~1.53.2",
+    "vscode": "~1.1.24"
   },
   "extensionDependencies": [
     "vscode.powershell"

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -7,6 +7,7 @@ import { LanguageClient, NotificationType, RequestType } from "vscode-languagecl
 import { ICheckboxQuickPickItem, showCheckboxQuickPick } from "../controls/checkboxQuickPick";
 import { IFeature } from "../feature";
 import { Logger } from "../logging";
+import Settings = require("../settings");
 
 export const EvaluateRequestType = new RequestType<IEvaluateRequestArguments, void, void, void>("evaluate");
 export const OutputNotificationType = new NotificationType<IOutputNotificationBody, void>("output");
@@ -207,6 +208,19 @@ export class ConsoleFeature implements IFeature {
                 if (this.languageClient === undefined) {
                     this.log.writeAndShowError(`<${ConsoleFeature.name}>: ` +
                         "Unable to instantiate; language client undefined.");
+                    return;
+                }
+
+                if (vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
+                    this.log.write("PSIC is not active terminal. Running in active terminal using 'runSelectedText'");
+                    await vscode.commands.executeCommand("workbench.action.terminal.runSelectedText");
+
+                    // We need to honor the focusConsoleOnExecute setting here too. However, the boolean that `show`
+                    // takes is called `preserveFocus` which when `true` the terminal will not take focus.
+                    // This is the inverse of focusConsoleOnExecute so we have to inverse the boolean.
+                    vscode.window.activeTerminal.show(!Settings.load().integratedConsole.focusConsoleOnExecute);
+                    await vscode.commands.executeCommand("workbench.action.terminal.scrollToBottom");
+
                     return;
                 }
 


### PR DESCRIPTION
## PR Summary

fixes #1607

Note: I decided against having this behavior to be configurable. The thought was that most people will only use the PowerShell Integrated Console.

In #1607 I brought up worry about people getting confused that their intellisense cache was not updating if they use pwsh instead of PSIC... I think perhaps this is a worry that does not exist and if it does and they open an issue, we can educate them.

Thoughts?

~NOTE this relies on an engine update to 1.29 which is the current release. We probably don't want to merge this in until 1.30 is released~
1.30 has been released

~NOTE I seem to have found a potential bug (Microsoft/vscode#64390) in VSCode with this change... can't merge this in until it's sorted~

The bug has been fixed. We can probably merge this in when 1.31.0 drops.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests - N/A
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
