### PR TITLE
[Ignore] use pwsh available on path to support building from snap pwsh

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
     "linux": {
         "options": {
             "shell": {
-                "executable": "/usr/bin/pwsh",
+                "executable": "pwsh",
                 "args": [ "-NoProfile", "-Command" ]
             }
         }


### PR DESCRIPTION
snap pwsh doesn't get added to `/usr/bin` so lets just use the `pwsh` on the path. I think it's a reasonable assumption.