### PR TITLE
Update recommended NodeJS version to 8.x since 6.x will go out of support in April 2019 and is already in maintenance mode

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ to before you can proceed.
     Insiders means the extension can be developed ready for new features
     and changes in the next VSCode release.
 
-5. Install [Node.js](https://nodejs.org/en/) 6.0.0 or higher.
+5. Install [Node.js](https://nodejs.org/en/) 8.x or higher.
 
 ## Building the Code
 


### PR DESCRIPTION
## PR Summary

As per title, for more details see [here](https://github.com/nodejs/Release#release-schedule). 6.x is not active any more and only in maintenance mode, therefore bump the minimum to 8.x, which will be supported at least until December 31, 2019.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
