### PR TITLE
Moved docs

### DIFF
--- a/docs/ise_compatibility.md
+++ b/docs/ise_compatibility.md
@@ -1,5 +1,13 @@
 # ISE Compatibility
 
+# ATTENTION! THIS DOC HAS MOVED
+
+[THIS DOC IS NOW HOSTED ON DOCS.MICROSOFT.COM.](https://docs.microsoft.com/en-us/powershell/scripting/components/vscode/how-to-replicate-the-ise-experience-in-vscode)
+
+PLEASE REFER TO THE DOC THERE FOR FUTURE REFERENCE AS ANY CHANGES WILL BE MADE TO THAT DOC.
+
+## Summary
+
 While the PowerShell extension for VSCode does not seek
 complete feature parity with the PowerShell ISE,
 there are features in place to make the VSCode experience more natural

--- a/docs/remoting.md
+++ b/docs/remoting.md
@@ -1,5 +1,13 @@
 # PowerShell Remote Editing and Debugging in VSCode
 
+# ATTENTION! THIS DOC HAS MOVED
+
+[THIS DOC IS NOW HOSTED ON DOCS.MICROSOFT.COM.](https://docs.microsoft.com/en-us/powershell/scripting/components/vscode/using-vscode-for-remote-editing-and-debugging)
+
+PLEASE REFER TO THE DOC THERE FOR FUTURE REFERENCE AS ANY CHANGES WILL BE MADE TO THAT DOC.
+
+## Summary
+
 For those of you that were familiar with the ISE, you may recall that you were able to use run `psedit file.ps1` from the integrated console to open files - local or remote - right in the ISE.
 
 As it turns out, this feature is also availible out of the box in the PowerShell extension for VSCode. This guide will show you how to do it.


### PR DESCRIPTION
This let's people know these docs have moved. After some time, we can delete these files and rely on git history for any other folks that still have the old urls.

However, I don't think _that_ many people depend on these docs today. I think the ones on docs.microsoft.com will have more traction. 