### PR TITLE
Update broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that Visual Studio Code provides.
 - **Linux** with PowerShell Core (all PowerShell-supported distributions)
 - **macOS and OS X** with PowerShell Core
 
-Read the [installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/components/vscode/using-vscode?view=powershell-6)
+Read the [installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/components/vscode/using-vscode)
 to get more details on how to use the extension on these platforms.
 
 Read the [FAQ](https://github.com/PowerShell/vscode-powershell/wiki/FAQ) for answers to common questions.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the Extensions pane, search for "PowerShell" extension and install it there. 
 get notified automatically about any future extension updates!
 
 You can also install a VSIX package from our [Releases page](https://github.com/PowerShell/vscode-powershell/releases) by following the
-[Install from a VSIX](https://code.visualstudio.com/docs/extensions/install-extension#_install-from-a-vsix)
+[Install from a VSIX](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix)
 instructions.  The easiest way is through the command line:
 
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that Visual Studio Code provides.
 - **Linux** with PowerShell Core (all PowerShell-supported distributions)
 - **macOS and OS X** with PowerShell Core
 
-Read the [installation instructions](https://github.com/PowerShell/PowerShell/blob/master/docs/learning-powershell/using-vscode.md)
+Read the [installation instructions](https://docs.microsoft.com/en-us/powershell/scripting/components/vscode/using-vscode?view=powershell-6)
 to get more details on how to use the extension on these platforms.
 
 Read the [FAQ](https://github.com/PowerShell/vscode-powershell/wiki/FAQ) for answers to common questions.


### PR DESCRIPTION
## PR Summary

The "installation instruction" and "Install from a VSIX" links in the README both pointed to outdated locations, this PR updates those locations as per the corresponding PRs in their repos:
- https://github.com/PowerShell/PowerShell/pull/8468/files#diff-650ba310f722733131d5ddbdf4f7c473R54
- https://github.com/Microsoft/vscode-docs/commit/9dca51fad2b1aefad5df9b5207f6ce7c381ff197#diff-6d89597f41a5b5e26c64f5ba1d4d468eR94

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready