### PR TITLE
Add Configuration to suppress initial refresh of Command Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -482,6 +482,11 @@
           "default":true,
           "description": "Specifies the visibility of the Command Explorer in the PowerShell Side Bar."
         },
+        "powershell.sideBar.CommandExplorerInitialRefresh": {
+          "type":"boolean",
+          "default":true,
+          "description": "Toggle the initial refresh of the command explorer."
+        },
         "powershell.powerShellExePath": {
           "type": "string",
           "default": "",

--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -42,7 +42,10 @@ export class GetCommandsFeature implements IFeature {
 
     public setLanguageClient(languageclient: LanguageClient) {
         this.languageClient = languageclient;
-        vscode.commands.executeCommand("PowerShell.RefreshCommandsExplorer");
+        const SideBarConfiguration = vscode.workspace.getConfiguration("powershell.sideBar");
+        if (SideBarConfiguration.CommandExplorerInitialRefresh) {
+            vscode.commands.executeCommand("PowerShell.RefreshCommandsExplorer");
+        }
     }
 
     private CommandExplorerRefresh() {


### PR DESCRIPTION
## PR Summary

Add a configuration option to disable the initial refresh of the Command Explorer.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
