### PR TITLE
Fix spacing inside package.json to not end up with local changes after execution of Invoke-Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -479,7 +479,7 @@
       "properties": {
         "powershell.sideBar.CommandExplorerVisibility": {
           "type": "boolean",
-          "default":true,
+          "default": true,
           "description": "Specifies the visibility of the Command Explorer in the PowerShell Side Bar."
         },
         "powershell.powerShellExePath": {


### PR DESCRIPTION
## PR Summary

Fix spacing of `package.json` after running `Invoke-Build` to not end up with local changes.
This has been introduced in PR #1638

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
