### PR TITLE
Refresh on visible

### DIFF
--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -27,12 +27,23 @@ export class GetCommandsFeature implements IFeature {
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
     private commandsExplorerProvider: CommandsExplorerProvider;
+    private commandsExplorerTreeView: vscode.TreeView<Command>;
 
     constructor(private log: Logger) {
         this.command = vscode.commands.registerCommand("PowerShell.RefreshCommandsExplorer",
             () => this.CommandExplorerRefresh());
         this.commandsExplorerProvider = new CommandsExplorerProvider();
-        vscode.window.registerTreeDataProvider("PowerShellCommands", this.commandsExplorerProvider);
+
+        this.commandsExplorerTreeView = vscode.window.createTreeView<Command>("PowerShellCommands",
+            { treeDataProvider: this.commandsExplorerProvider });
+
+        // Refresh the command explorer when the view is visible
+        this.commandsExplorerTreeView.onDidChangeVisibility( (e) => {
+            if (e.visible) {
+                this.CommandExplorerRefresh();
+            }
+        });
+
         vscode.commands.registerCommand("PowerShell.InsertCommand", (item) => this.InsertCommand(item));
     }
 
@@ -42,12 +53,14 @@ export class GetCommandsFeature implements IFeature {
 
     public setLanguageClient(languageclient: LanguageClient) {
         this.languageClient = languageclient;
-        vscode.commands.executeCommand("PowerShell.RefreshCommandsExplorer");
+        if (this.commandsExplorerTreeView.visible) {
+            vscode.commands.executeCommand("PowerShell.RefreshCommandsExplorer");
+        }
     }
 
     private CommandExplorerRefresh() {
         if (this.languageClient === undefined) {
-            this.log.writeAndShowError(`<${GetCommandsFeature.name}>: ` +
+            this.log.writeVerbose(`<${GetCommandsFeature.name}>: ` +
                 "Unable to instantiate; language client undefined.");
             return;
         }


### PR DESCRIPTION
## PR Summary

previously we were refreshing at startup every time. This change makes it so that we refresh only when the command explorer becomes visible.

cc @corbob 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [N/A] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
