### PR TITLE
Remove Region Block snippet

### DIFF
--- a/docs/community_snippets.md
+++ b/docs/community_snippets.md
@@ -33,7 +33,6 @@ _To contribute, check out our [guide here](#contributing)._
 | [PesterTestForMandatoryParameter](#pestertestformandatoryparameter) | _Create Pester test for a mandatory parameter_ |
 | [PesterTestForParameter](#pestertestforparameter) | _Create Pester test for parameter_ |
 | [PSCustomObject](#pscustomobject) | _A simple PSCustomObject by @brettmillerb_ |
-| [Region Block](#region-block) | _Region Block for organizing and folding of your code_ |
 | [Send-MailMessage](#send-mailmessage) | _Send an mail message with the most common parameters by @fullenw1_ |
 
 ## Snippets
@@ -365,24 +364,6 @@ A simple PSCustomObject by @brettmillerb. It has 4 properties that you can tab t
         "}"
     ],
     "description": "Creates a PSCustomObject"
-}
-```
-
-### Region Block
-
-Use the `#region` for organizing your code (including good code folding).
-
-#### Snippet
-
-```json
-"Region Block": {
-    "prefix": "#region",
-    "body": [
-        "#region ${1}",
-        "$0",
-        "#endregion"
-    ],
-    "description": "Region Block for organizing and folding of your code"
 }
 ```
 


### PR DESCRIPTION
## PR Summary

The Region Block snippet has been added to the built-in snippets and doesn't need to be added to the user's snippets anymore.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] PR has tests
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
