### PR TITLE
Add 'Run/Debug Pester tests' command and file tab menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
       ],
       "editor/title/context": [
         {
-          "when": "resourceFilename =~ /\\.[Tt]ests\\.ps1$/",
+          "when": "resourceFilename =~ /\\.tests\\.ps1$/i",
           "command": "PowerShell.RunPesterTests"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -240,7 +240,7 @@
       ],
       "editor/title/context": [
         {
-          "when": "resourceExtname  == .ps1",
+          "when": "resourceFilename =~ /\\.[Tt]ests\\.ps1$/",
           "command": "PowerShell.RunPesterTests"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -205,6 +205,11 @@
         "category": "PowerShell"
       },
       {
+        "command": "PowerShell.RunPesterTests",
+        "title": "Run Pester tests",
+        "category": "PowerShell"
+      },
+      {
         "command": "PowerShell.OpenExamplesFolder",
         "title": "Open Examples Folder",
         "category": "PowerShell"
@@ -231,6 +236,12 @@
           "when": "editorLangId == powershell",
           "command": "PowerShell.ShowHelp",
           "group": "2_powershell"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "when": "resourceExtname  == .ps1",
+          "command": "PowerShell.RunPesterTests"
         }
       ],
       "view/title": [

--- a/package.json
+++ b/package.json
@@ -205,8 +205,13 @@
         "category": "PowerShell"
       },
       {
-        "command": "PowerShell.RunPesterTests",
+        "command": "PowerShell.RunPesterTestsFromFile",
         "title": "Run Pester tests",
+        "category": "PowerShell"
+      },
+      {
+        "command": "PowerShell.DebugPesterTestsFromFile",
+        "title": "Debug Pester tests",
         "category": "PowerShell"
       },
       {
@@ -241,7 +246,11 @@
       "editor/title/context": [
         {
           "when": "resourceFilename =~ /\\.tests\\.ps1$/i",
-          "command": "PowerShell.RunPesterTests"
+          "command": "PowerShell.RunPesterTestsFromFile"
+        },
+        {
+          "when": "resourceFilename =~ /\\.tests\\.ps1$/i",
+          "command": "PowerShell.DebugPesterTestsFromFile"
         }
       ],
       "view/title": [

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -1,4 +1,4 @@
- /*---------------------------------------------------------
+/*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
@@ -17,13 +17,13 @@ export class PesterTestsFeature implements IFeature {
     constructor(private sessionManager: SessionManager) {
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTestsFromFile",
-            (uriString, runInDebugger, describeBlockName?) => {
-                this.launchTests(vscode.window.activeTextEditor.document.uri, false, describeBlockName);
+            () => {
+                this.launchTests(vscode.window.activeTextEditor.document.uri, false);
             });
         this.command = vscode.commands.registerCommand(
             "PowerShell.DebugPesterTestsFromFile",
-            (uriString, runInDebugger, describeBlockName?) => {
-                this.launchTests(vscode.window.activeTextEditor.document.uri, true, describeBlockName);
+            () => {
+                this.launchTests(vscode.window.activeTextEditor.document.uri, true);
             });
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -1,4 +1,4 @@
-/*---------------------------------------------------------
+ /*---------------------------------------------------------
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
@@ -15,6 +15,17 @@ export class PesterTestsFeature implements IFeature {
     private languageClient: LanguageClient;
 
     constructor(private sessionManager: SessionManager) {
+        this.command = vscode.commands.registerCommand(
+            "PowerShell.RunPesterTestsFromFile",
+            (uriString, runInDebugger, describeBlockName?) => {
+                this.launchTests(vscode.window.activeTextEditor.document.uri, false, describeBlockName);
+            });
+        this.command = vscode.commands.registerCommand(
+            "PowerShell.DebugPesterTestsFromFile",
+            (uriString, runInDebugger, describeBlockName?) => {
+                this.launchTests(vscode.window.activeTextEditor.document.uri, true, describeBlockName);
+            });
+        // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTests",
             (uriString, runInDebugger, describeBlockName?) => {


### PR DESCRIPTION
## PR Summary

Implements #1667 by adding a command and file tab menu to run all Pester tests on a file. The file tab menu will only appear for `.tests.ps1` files (using a case insensitive comparison).
I tested this on Windows 1809 using vscode and the latest vscode-insiders when using Windows PowerShell 5.1. I also made sure that the code lens being used by PSES does not get broken, hence why new commands were added rather than trying to adapt for the different kind of uri in the `launchTests` function. Here is a zip of my locally built vsix for testing:  [PowerShell-insiders.zip](https://github.com/PowerShell/vscode-powershell/files/2765727/PowerShell-insiders.zip)



New file tab menu entries:
![image](https://user-images.githubusercontent.com/9250262/51268237-89049800-19b7-11e9-81b0-f26058eab305.png)
Commands:
![image](https://user-images.githubusercontent.com/9250262/51268265-9d489500-19b7-11e9-82ce-589acfddd57f.png)

*
## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
