### PR TITLE
change version name and add docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -13,6 +13,11 @@ IMPORTANT: you can generate a bug report directly from the
 PowerShell extension in Visual Studio Code by selecting
 "PowerShell: Upload Bug Report to GitHub" from the command palette.
 
+NOTE: If you have both stable (aka "PowerShell") and preview (aka "PowerShell Preview") installed,
+you MUST DISABLE one of them for the best performance.
+Docs on how to disable an extension can be found here:
+https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension
+
 The more repro details you can provide, along with a zip
 of the log files from your session, the better the chances
 are for a quick resolution.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
       sudo apt-get install libunwind8;
     fi
 install:
-  - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
+  - git clone --single-branch -b 2.0.0 https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
   - pushd build
   - bash <(curl -s https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.sh)
   - popd

--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ how to use them.
 
 This folder can be found at the following path:
 
+```powershell
+$HOME/.vscode[-insiders]/extensions/ms-vscode.PowerShell-<version>/examples
 ```
-C:\Users\<yourusername>\.vscode\extensions\ms-vscode.PowerShell-<version>\examples
+
+or if you're using the preview version of the extension
+
+```powershell
+$HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-preview-<version>/examples
 ```
 
 To open/view the extension's examples in Visual Studio Code, run the following from your PowerShell command prompt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '1.9.1-insiders-{build}'
+version: '2.0.0-insiders-{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true        # Don't send telemetry
 
 install:
-  - git clone https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
+  - git clone --single-branch -b 2.0.0 https://github.com/PowerShell/PowerShellEditorServices.git ../PowerShellEditorServices
   - ps: Install-Product node '6.9.2'
   - ps: |
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.0.0-CI-{build}'
+version: '2.0.0-CI.{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: '2.0.0-insiders-{build}'
+version: '2.0.0-CI-{build}'
 image: Visual Studio 2017
 clone_depth: 10
 skip_tags: true

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,6 +130,12 @@ Logs provide context for what was happening when the issue occurred
   $HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-<version>/logs/
   ```
 
+  or if you're using the preview version of the extension
+
+  ```powershell
+  $HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-preview-<version>/logs/
+  ```
+
   For example:
 
   ```powershell

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,11 @@ provided by the [Editor Syntax] repository on GitHub. Please open any
 
 ## Known Issues in the Extension
 
+- If you are running the Preview version "PowerShell Preview" side-by-side with the stable version "PowerShell"
+  you will experience performance and debug issues.
+  This is expected until VSCode offers extension channels - [vscode#15756](https://github.com/Microsoft/vscode/issues/15756)
+  - You MUST [DISABLE](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension) one of them for the best performance.
+    Docs on how to disable an extension can be found [here](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension)
 - Highlighting/completions/command history don't work as I expect in the
   Integrated Console - [#535]
   - The Integrated Console implements a [custom host]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,6 @@
 {
   "name": "PowerShell",
-<<<<<<< HEAD
-  "version": "1.9.1",
-=======
   "version": "2.0.0",
->>>>>>> Update build for v2 branch
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "PowerShell",
+<<<<<<< HEAD
   "version": "1.9.1",
+=======
+  "version": "2.0.0",
+>>>>>>> Update build for v2 branch
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PowerShell",
   "displayName": "PowerShell",
-  "version": "1.9.1",
+  "version": "2.0.0",
   "publisher": "ms-vscode",
   "description": "Develop PowerShell scripts in Visual Studio Code!",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
         "category": "PowerShell"
       },
       {
-<<<<<<< HEAD
         "command": "PowerShell.RefreshCommandsExplorer",
         "title": "Refresh",
         "icon": {
@@ -132,8 +131,6 @@
         "category": "PowerShell"
       },
       {
-=======
->>>>>>> Removed ShowOnlineHelp Command (#1587)
         "command": "PowerShell.ShowHelp",
         "title": "Get Help for Command",
         "category": "PowerShell"

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
         "category": "PowerShell"
       },
       {
+<<<<<<< HEAD
         "command": "PowerShell.RefreshCommandsExplorer",
         "title": "Refresh",
         "icon": {
@@ -131,6 +132,8 @@
         "category": "PowerShell"
       },
       {
+=======
+>>>>>>> Removed ShowOnlineHelp Command (#1587)
         "command": "PowerShell.ShowHelp",
         "title": "Get Help for Command",
         "category": "PowerShell"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "PowerShell",
-  "displayName": "PowerShell",
-  "version": "2.0.0",
+  "name": "powershell-preview",
+  "displayName": "PowerShell Preview",
+  "version": "2.0.0-preview.1",
   "publisher": "ms-vscode",
-  "description": "Develop PowerShell scripts in Visual Studio Code!",
+  "description": "(PREVIEW) Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
     "vscode": "^1.25.0"
   },

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -36,12 +36,6 @@ export class ShowHelpFeature implements IFeature {
                 this.languageClient.sendRequest(ShowHelpRequestType, item.Name);
             }
         });
-
-        this.deprecatedCommand = vscode.commands.registerCommand("PowerShell.OnlineHelp", () => {
-            const warnText = "PowerShell.OnlineHelp is being deprecated. Use PowerShell.ShowHelp instead.";
-            vscode.window.showWarningMessage(warnText);
-            vscode.commands.executeCommand("PowerShell.ShowHelp");
-        });
     }
 
     public dispose() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,7 @@ import utils = require("./utils");
 
 // NOTE: We will need to find a better way to deal with the required
 //       PS Editor Services version...
-const requiredEditorServicesVersion = "1.9.1";
+const requiredEditorServicesVersion = "2.0.0";
 
 let logger: Logger;
 let sessionManager: SessionManager;

--- a/tools/releaseBuild/Image/DockerFile
+++ b/tools/releaseBuild/Image/DockerFile
@@ -23,7 +23,7 @@ COPY build.ps1 containerFiles/build.ps1
 
 # Add an environment variable for build versioning
 ENV VSTS_BUILD=1
-ENV VSTS_BUILD_VERSION=1.9.1
+ENV VSTS_BUILD_VERSION=2.0.0
 
 # Uncomment to debug locally
 # RUN Import-Module ./containerFiles/dockerInstall.psm1; `

--- a/tools/releaseBuild/Image/build.ps1
+++ b/tools/releaseBuild/Image/build.ps1
@@ -10,4 +10,4 @@ else {
 }
 push-location C:/vscode-powershell
 Invoke-Build GetExtensionVersion,Clean,Build,Test,Package
-Copy-Item -Verbose -Recurse "C:/vscode-powershell/PowerShell-insiders.vsix" "${target}/PowerShell-insiders.vsix"
+Copy-Item -Verbose -Recurse "C:/vscode-powershell/PowerShell-CI.vsix" "${target}/PowerShell-CI.vsix"

--- a/tools/releaseBuild/setVstsVariables.ps1
+++ b/tools/releaseBuild/setVstsVariables.ps1
@@ -1,5 +1,5 @@
 $vstsVariables = @{
-    PSES_BRANCH = 'master'
+    PSES_BRANCH = '2.0.0'
 }
 
 # Use VSTS's API to set an env vars

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <SignConfigXML>
   <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="vscode powershell" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\release\out\PowerShell-insiders.vsix" signType="Vsix"
-      dest="__OUTPATHROOT__\PowerShell-insiders.vsix" />
+    <file src="__INPATHROOT__\release\out\PowerShell-CI.vsix" signType="Vsix"
+      dest="__OUTPATHROOT__\PowerShell-CI.vsix" />
   </job>
 </SignConfigXML>

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -109,6 +109,19 @@ task Test Build, {
     }
 }
 
+task UpdateReadme If { $env:PSES_BRANCH -contains "preview" } {
+    $newReadmeTop = '# PowerShell Language Support for Visual Studio Code
+
+> ## ATTENTION: This is the PREVIEW version of the PowerShell extension for VSCode which contains features that are being evaluated for stable
+> ### If you are looking for the stable version, please [go here](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) or install the extension called "PowerShell" (not "PowerShell Preview")
+> ## NOTE: If you have both stable (aka "PowerShell") and preview (aka "PowerShell Preview") installed, you MUST [DISABLE](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension) one of them for the best performance. Docs on how to disable an extension can be found [here](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension)'
+    $readmePath = (Join-Path $PSScriptRoot README.md)
+
+    $readmeContent = Get-Content -Path $readmePath
+    $readmeContent[0] = $newReadmeTop
+    $readmeContent > $readmePath
+}
+
 task Package {
 
     if ($script:psesBuildScriptPath) {
@@ -134,4 +147,4 @@ task UploadArtifacts -If { $env:AppVeyor } {
 }
 
 # The default task is to run the entire CI build
-task . GetExtensionVersion, CleanAll, BuildAll, Test, Package, UploadArtifacts
+task . GetExtensionVersion, CleanAll, BuildAll, Test, UpdateReadme, Package, UploadArtifacts

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -36,7 +36,7 @@ task GetExtensionVersion -Before Package {
     }
 }
 
-task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices {
+task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices, Package {
 
     $script:psesRepoPath = `
         if ($EditorServicesRepoPath) {

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -135,15 +135,15 @@ task Package {
         throw "Unable to find PowerShell EditorServices"
     }
 
-    Write-Host "`n### Packaging PowerShell-insiders.vsix`n" -ForegroundColor Green
+    Write-Host "`n### Packaging PowerShell-CI.vsix`n" -ForegroundColor Green
     exec { & node ./node_modules/vsce/out/vsce package }
 
     # Change the package to have a static name for automation purposes
-    Move-Item -Force .\PowerShell-$($script:ExtensionVersion).vsix .\PowerShell-insiders.vsix
+    Move-Item -Force .\powershell-preview-$($script:ExtensionVersion).vsix .\PowerShell-CI.vsix
 }
 
 task UploadArtifacts -If { $env:AppVeyor } {
-    Push-AppveyorArtifact .\PowerShell-insiders.vsix
+    Push-AppveyorArtifact .\PowerShell-CI.vsix
 }
 
 # The default task is to run the entire CI build

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -109,7 +109,7 @@ task Test Build, {
     }
 }
 
-task UpdateReadme If { $env:PSES_BRANCH -contains "preview" } {
+task UpdateReadme -If { $env:PSES_BRANCH -like "*preview*" } {
     $newReadmeTop = '# PowerShell Language Support for Visual Studio Code
 
 > ## ATTENTION: This is the PREVIEW version of the PowerShell extension for VSCode which contains features that are being evaluated for stable


### PR DESCRIPTION
This PR contains:

* the update of the name from "PowerShell" to "PowerShell Preview" so that we can ship a preview in the extension marketplace
* docs to tell users to disable either "stable or preview" for better performance. We can do better once vscode gives us [Extension-level release channels](https://github.com/Microsoft/vscode/issues/15756)
* the README is updated at build time for the preview releases so that the warning doesn't pollute GitHub