### PR TITLE
Interpret null Describe TestName to mean value can't be eval'd

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -9,21 +9,28 @@ import { SessionManager } from "../session";
 import Settings = require("../settings");
 import utils = require("../utils");
 
+enum LaunchType {
+    Debug,
+    Run,
+}
+
 export class PesterTestsFeature implements IFeature {
 
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
 
     constructor(private sessionManager: SessionManager) {
+        // File context-menu command - Run Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTestsFromFile",
             () => {
-                this.launchTests(vscode.window.activeTextEditor.document.uri, false, undefined);
+                this.launchAllTestsInActiveEditor(LaunchType.Run);
             });
+        // File context-menu command - Debug Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.DebugPesterTestsFromFile",
             () => {
-                this.launchTests(vscode.window.activeTextEditor.document.uri, true, undefined);
+                this.launchAllTestsInActiveEditor(LaunchType.Debug);
             });
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
@@ -41,21 +48,37 @@ export class PesterTestsFeature implements IFeature {
         this.languageClient = languageClient;
     }
 
-    private async launchTests(uriString, runInDebugger, describeBlockName?) {
+    private launchAllTestsInActiveEditor(launchType: LaunchType) {
+        const uriString = vscode.window.activeTextEditor.document.uri.toString();
+        const launchConfig = this.createLaunchConfig(uriString, launchType);
+        this.launch(launchConfig);
+    }
+
+    private async launchTests(uriString: string, runInDebugger: boolean, describeBlockName?: string) {
         // PSES passes null for the describeBlockName to signal that it can't evaluate the TestName.
-        if (describeBlockName === null) {
+        if (!describeBlockName) {
             const answer = await vscode.window.showErrorMessage(
                 "This Describe block's TestName parameter cannot be evaluated. " +
                 `Would you like to ${runInDebugger ? "debug" : "run"} all the tests in this file?`,
                 "Yes", "No");
 
-            if (answer === "Yes") {
-                describeBlockName = undefined;
-            } else {
+            if (answer === "No") {
                 return;
             }
         }
 
+        const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
+        const launchConfig = this.createLaunchConfig(uriString, launchType);
+
+        if (describeBlockName) {
+            launchConfig.args.push("-TestName");
+            launchConfig.args.push(`'${describeBlockName}'`);
+        }
+
+        this.launch(launchConfig);
+    }
+
+    private createLaunchConfig(uriString: string, launchType: LaunchType) {
         const uri = vscode.Uri.parse(uriString);
         const currentDocument = vscode.window.activeTextEditor.document;
         const settings = Settings.load();
@@ -76,7 +99,7 @@ export class PesterTestsFeature implements IFeature {
                 "@{IncludeVSCodeMarker=$true}",
             ],
             internalConsoleOptions: "neverOpen",
-            noDebug: !runInDebugger,
+            noDebug: (launchType === LaunchType.Run),
             createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole,
             cwd:
                 currentDocument.isUntitled
@@ -84,11 +107,10 @@ export class PesterTestsFeature implements IFeature {
                     : path.dirname(currentDocument.fileName),
         };
 
-        if (describeBlockName) {
-            launchConfig.args.push("-TestName");
-            launchConfig.args.push(`'${describeBlockName}'`);
-        }
+        return launchConfig;
+    }
 
+    private launch(launchConfig) {
         // Create or show the interactive console
         // TODO #367: Check if "newSession" mode is configured
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);


### PR DESCRIPTION
## PR Summary

PSES will now return a null for `describeBlockName` to mean that this is a valid Pester Describe block but we couldn't evaluate the test name.  This will cause the extension to pop a dialog indicating this and giving the user the chance to debug or run all the tests in the file.

Two things to consider: 1) the text of the message in the dialog box and 2) should this be an error box (as it is now) or a warning box?

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
