### PR TITLE
Support Preview mechanism

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -13,6 +13,11 @@ IMPORTANT: you can generate a bug report directly from the
 PowerShell extension in Visual Studio Code by selecting
 "PowerShell: Upload Bug Report to GitHub" from the command palette.
 
+NOTE: If you have both stable (aka "PowerShell") and preview (aka "PowerShell Preview") installed,
+you MUST DISABLE one of them for the best performance.
+Docs on how to disable an extension can be found here:
+https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension
+
 The more repro details you can provide, along with a zip
 of the log files from your session, the better the chances
 are for a quick resolution.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,14 @@ how to use them.
 
 This folder can be found at the following path:
 
+```powershell
+$HOME/.vscode[-insiders]/extensions/ms-vscode.PowerShell-<version>/examples
 ```
-C:\Users\<yourusername>\.vscode\extensions\ms-vscode.PowerShell-<version>\examples
+
+or if you're using the preview version of the extension
+
+ ```powershell
+$HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-preview-<version>/examples
 ```
 
 To open/view the extension's examples in Visual Studio Code, run the following from your PowerShell command prompt:

--- a/docs/development.md
+++ b/docs/development.md
@@ -44,3 +44,15 @@ press <kbd>Ctrl</kbd>+<kbd>F5</kbd> or <kbd>Cmd</kbd>+<kbd>F5</kbd> on macOS.
 ```
 code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
 ```
+
+## Building a "Preview" version
+
+To build a preview version of the extension, that is to say,
+a version of the extension named "PowerShell Preview",
+You can simply change the version in the package.json to include `-preview` at the end.
+When you build, this will:
+
+- Add a warning to the top of the README.md to warn users not to have the stable and preview version enabled at the same time
+- Adds "Preview" in a few places in the package.json
+
+This mechanism is mostly used for releases.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,11 @@ and you can ask for new features [in their repository](https://github.com/Micros
 
 ## Known Issues in the Extension
 
+- If you are running the Preview version "PowerShell Preview" side-by-side with the stable version "PowerShell"
+  you will experience performance and debug issues.
+  This is expected until VSCode offers extension channels - [vscode#15756](https://github.com/Microsoft/vscode/issues/15756)
+  - You MUST [DISABLE](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension) one of them for the best performance.
+    Docs on how to disable an extension can be found [here](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension)
 - Highlighting/completions/command history don't work as I expect in the
   Integrated Console - [#535]
   - The Integrated Console implements a [custom host]
@@ -155,6 +160,12 @@ Logs provide context for what was happening when the issue occurred
 
   ```powershell
   $HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-<version>/logs/
+  ```
+
+  or if you're using the preview version of the extension
+
+  ```powershell
+  $HOME/.vscode[-insiders]/extensions/ms-vscode.powershell-preview-<version>/logs/
   ```
 
   For example:

--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -9,8 +9,6 @@ import { IFeature, LanguageClient } from "../feature";
 import { SessionManager } from "../session";
 import Settings = require("../settings");
 
-const extensionId: string = "ms-vscode.PowerShell";
-const extensionVersion: string = vscode.extensions.getExtension(extensionId).packageJSON.version;
 const queryStringPrefix: string = "?";
 
 const settings = Settings.load();
@@ -54,7 +52,7 @@ capturing and sending logs.
 | --- | --- |
 | Operating System | ${os.type()} ${os.arch()} ${os.release()} |
 | VSCode | ${vscode.version}|
-| PowerShell Extension Version | ${extensionVersion} |
+| PowerShell Extension Version | ${sessionManager.HostVersion} |
 
 ### PowerShell Information ###
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -157,6 +157,12 @@ function checkForUpdatedVersion(context: vscode.ExtensionContext) {
     const extensionName = context.storagePath.toLowerCase().includes("ms-vscode.powershell-preview") ?
         "ms-vscode.PowerShell-Preview" : "ms-vscode.PowerShell";
 
+    if (extensionName === "ms-vscode.PowerShell-Preview"
+        && vscode.extensions.getExtension("ms-vscode.PowerShell")) {
+        vscode.window.showWarningMessage(
+            "'PowerShell' and 'PowerShell Preview' are both enabled. Please disable one for best performance.");
+    }
+
     const extensionVersion: string =
         vscode
             .extensions

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,7 +114,9 @@ export function activate(context: vscode.ExtensionContext): void {
     sessionManager =
         new SessionManager(
             requiredEditorServicesVersion,
-            logger, documentSelector);
+            logger,
+            documentSelector,
+            context);
 
     // Create features
     extensionFeatures = [
@@ -152,10 +154,13 @@ function checkForUpdatedVersion(context: vscode.ExtensionContext) {
     const showReleaseNotes = "Show Release Notes";
     const powerShellExtensionVersionKey = "powerShellExtensionVersion";
 
+    const extensionName = context.storagePath.toLowerCase().includes("ms-vscode.powershell-preview") ?
+        "ms-vscode.PowerShell-Preview" : "ms-vscode.PowerShell";
+
     const extensionVersion: string =
         vscode
             .extensions
-            .getExtension("ms-vscode.PowerShell")
+            .getExtension(extensionName)
             .packageJSON
             .version;
 

--- a/tools/releaseBuild/Image/build.ps1
+++ b/tools/releaseBuild/Image/build.ps1
@@ -9,5 +9,5 @@ else {
     }
 }
 push-location C:/vscode-powershell
-Invoke-Build GetExtensionVersion,Clean,Build,Test,Package
+Invoke-Build GetExtensionData,Clean,Build,Test,CheckPreview,Package
 Copy-Item -Verbose -Recurse "C:/vscode-powershell/PowerShell-insiders.vsix" "${target}/PowerShell-insiders.vsix"

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -117,14 +117,16 @@ task CheckPreview -If { $script:ExtensionVersion -like "*preview*" } `
 task UpdateReadme {
     $newReadmeTop = '# PowerShell Language Support for Visual Studio Code
 
-> ## ATTENTION: This is the PREVIEW version of the PowerShell extension for VSCode which contains features that are being evaluated for stable
+> ## ATTENTION: This is the PREVIEW version of the PowerShell extension for VSCode which contains features that are being evaluated for stable. It works with PowerShell 5.1 and up.
 > ### If you are looking for the stable version, please [go here](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) or install the extension called "PowerShell" (not "PowerShell Preview")
 > ## NOTE: If you have both stable (aka "PowerShell") and preview (aka "PowerShell Preview") installed, you MUST [DISABLE](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension) one of them for the best performance. Docs on how to disable an extension can be found [here](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension)'
     $readmePath = (Join-Path $PSScriptRoot README.md)
 
     $readmeContent = Get-Content -Path $readmePath
-    $readmeContent[0] = $newReadmeTop
-    $readmeContent > $readmePath
+    if (!($readmeContent -match "This is the PREVIEW version of the PowerShell extension")) {
+        $readmeContent[0] = $newReadmeTop
+        $readmeContent > $readmePath
+    }
 }
 
 task UpdatePackageJson {


### PR DESCRIPTION
## PR Summary

This removes the dependency on the name of the extension being "ms-vscode.PowerShell". It's a bit of a workaround until [this is resolved](https://github.com/Microsoft/vscode/issues/66515).

Also, this allows you to build preview versions the extension that have the name "PowerShell Preview". To build a preview version of the extension, that is to say,
a version of the extension named "PowerShell Preview",
You can simply change the version in the package.json to include `-preview` at the end.

When you build, this will:

 - Add a warning to the top of the README.md to warn users not to have the stable and preview version enabled at the same time
- Adds "Preview" in a few places in the package.json

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
