### PR TITLE
Execute interpolated Pester describe blocks if PSES signals that it is possible

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -35,9 +35,8 @@ export class PesterTestsFeature implements IFeature {
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTests",
-            (uriString, runInDebugger, describeBlockName?, describeBlockLineNumber?, pesterSupportsLineNumber?) => {
-                this.launchTests(uriString, runInDebugger, describeBlockName,
-                                 describeBlockLineNumber, pesterSupportsLineNumber);
+            (uriString, runInDebugger, describeBlockName?, describeBlockLineNumber?) => {
+                this.launchTests(uriString, runInDebugger, describeBlockName, describeBlockLineNumber);
             });
     }
 
@@ -56,11 +55,11 @@ export class PesterTestsFeature implements IFeature {
     }
 
     private async launchTests(uriString: string, runInDebugger: boolean, describeBlockName?: string,
-                              describeBlockLineNumber?: number, pesterSupportsLineNumber = false) {
+                              describeBlockLineNumber?: number) {
         // PSES passes null for the describeBlockName to signal that it can't evaluate the TestName.
-        if (!describeBlockName && !pesterSupportsLineNumber) {
+        if (!describeBlockName && !describeBlockLineNumber) {
             const answer = await vscode.window.showErrorMessage(
-                "This Describe block's TestName parameter cannot be evaluated in versions of Pester before 4.6.0." +
+                "This Describe block's TestName parameter cannot be evaluated in versions of Pester before 4.6.0. " +
                 `Would you like to ${runInDebugger ? "debug" : "run"} all the tests in this file?`,
                 "Yes", "No");
 
@@ -70,10 +69,9 @@ export class PesterTestsFeature implements IFeature {
         }
 
         const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
-        const launchConfig = this.createLaunchConfig(uriString, launchType,
-                                                     describeBlockLineNumber, pesterSupportsLineNumber);
+        const launchConfig = this.createLaunchConfig(uriString, launchType, describeBlockLineNumber);
 
-        if (describeBlockName && !pesterSupportsLineNumber) {
+        if (describeBlockName && !describeBlockLineNumber) {
             launchConfig.args.push("-TestName");
             launchConfig.args.push(`'${describeBlockName}'`);
         }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -79,8 +79,7 @@ export class PesterTestsFeature implements IFeature {
         this.launch(launchConfig);
     }
 
-    private createLaunchConfig(uriString: string, launchType: LaunchType,
-                               describeBlockLineNumber?: number, pesterSupportsLineNumber = false) {
+    private createLaunchConfig(uriString: string, launchType: LaunchType, describeBlockLineNumber?: number) {
         const uri = vscode.Uri.parse(uriString);
         const currentDocument = vscode.window.activeTextEditor.document;
         const settings = Settings.load();
@@ -90,7 +89,7 @@ export class PesterTestsFeature implements IFeature {
         const scriptPath = uri.fsPath.replace(/'/g, "''");
 
         let pesterOption: string;
-        if (pesterSupportsLineNumber) {
+        if (describeBlockLineNumber) {
             pesterOption = "(New-PesterOption -ScriptBlockFilter " +
                 `@( @{ IncludeVSCodeMarker=$true; Line=${describeBlockLineNumber}; Path='${scriptPath}' } ) )`;
         } else {

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -60,7 +60,7 @@ export class PesterTestsFeature implements IFeature {
         // PSES passes null for the describeBlockName to signal that it can't evaluate the TestName.
         if (!describeBlockName && !pesterSupportsLineNumber) {
             const answer = await vscode.window.showErrorMessage(
-                "This Describe block's TestName parameter cannot be evaluated. " +
+                "This Describe block's TestName parameter cannot be evaluated in versions of Pester before 4.6.0." +
                 `Would you like to ${runInDebugger ? "debug" : "run"} all the tests in this file?`,
                 "Yes", "No");
 


### PR DESCRIPTION
## PR Summary

Fixes #1710
This PR requires [this](https://github.com/PowerShell/PowerShellEditorServices/pull/856) PSES to be merged as a pre-requisite as PSES sends us info if the installed Pester version supports this.
In the future it would be nice to enhance the prompt to ask the user to install the latest version of Pester for them if they are on an old version, for the moment, I only added some info to make them aware.

![image](https://user-images.githubusercontent.com/9250262/51565067-d89c0580-1e88-11e9-866d-14f0aab5e89c.png)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests - Tested manually (various scenarios: 4.6.0 is installed or not, check that it does not break the file tab menus and commands and check that run/debug works as expected)
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
