### PR TITLE
Do not run pester tests when user cancels questions using the x button (bugfix)

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -62,7 +62,7 @@ export class PesterTestsFeature implements IFeature {
                 `Would you like to ${runInDebugger ? "debug" : "run"} all the tests in this file?`,
                 "Yes", "No");
 
-            if (answer === "No") {
+            if (answer !== "Yes") {
                 return;
             }
         }


### PR DESCRIPTION
## PR Summary

@rkeithhill added a dialog in #1701 to ask the user whether he/she wants to run the whole Pester test file when there is an interpolated describe block string. However, when the user does not answer yes or no but cancels via the x button, the answer string will be `undefined` and the extension will run the test as if the user said yes. Therefore invert the logic to avoid running the test despite the user cancelling
![image](https://user-images.githubusercontent.com/9250262/51571011-b8744280-1e98-11e9-883b-ac687f88c464.png)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests -> Manually tested the 3 test scenarios
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
