### PR TITLE
[Ignore] Marketplace doesn't support SemVer, npm ONLY supports SemVer

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -49,7 +49,7 @@ code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
 
 To build a preview version of the extension, that is to say,
 a version of the extension named "PowerShell Preview",
-You can simply change the version in the package.json to include `-preview` at the end.
+You can simply change the `name` in the package.json to include `-Preview` at the end.
 When you build, this will:
 
 - Add a warning to the top of the README.md to warn users not to have the stable and preview version enabled at the same time

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "PowerShell-Preview",
   "displayName": "PowerShell Preview",
-  "version": "2.0.0-preview.1",
+  "version": "2.0.0",
   "preview": true,
   "publisher": "ms-vscode",
   "description": "(Preview) Develop PowerShell scripts in Visual Studio Code!",

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -32,6 +32,7 @@ task GetExtensionData -Before Package {
 
     if ($updateVersion) {
         exec { & npm version $script:ExtensionVersion --no-git-tag-version --allow-same-version }
+        $script:PackageJson.version = $script:ExtensionVersion
     }
 
     $script:ExtensionName = $script:PackageJson.name

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -111,7 +111,7 @@ task Test Build, {
     }
 }
 
-task CheckPreview -If { $script:ExtensionVersion -like "*preview*" } `
+task CheckPreview -If { $script:ExtensionName -like "*Preview*" } `
     UpdateReadme, UpdatePackageJson
 
 task UpdateReadme {


### PR DESCRIPTION
spoke to Aditya and Travis.... the plan we think is the best is:
 
do 2.0.0 as the version
Use the PATCH part of the version to rev betas
 
then the first stable version of 2 will be 2.1 so that it comes after 2.0.X

since npm only supports SemVer 2 and the marketplace only supports SemVer 1... the intersection is that is X.X.X so that's why we arrived at that