### PR TITLE
Handle Pester Describe block strings with single quotes inside it

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -72,9 +72,9 @@ export class PesterTestsFeature implements IFeature {
 
         if (describeBlockName) {
             launchConfig.args.push("-TestName");
-            // Escape single quotes inside double quotes
+            // Escape single quotes inside double quotes by doubling them up
             if (describeBlockName.includes("'")) {
-                describeBlockName = describeBlockName.replace("'", "''");
+                describeBlockName = describeBlockName.replace(/'/g, "''");
             }
             launchConfig.args.push(`'${describeBlockName}'`);
         }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -72,6 +72,10 @@ export class PesterTestsFeature implements IFeature {
 
         if (describeBlockName) {
             launchConfig.args.push("-TestName");
+            // Escape single quotes inside double quotes
+            if (describeBlockName.includes("'")) {
+                describeBlockName = describeBlockName.replace("'", "''");
+            }
             launchConfig.args.push(`'${describeBlockName}'`);
         }
 


### PR DESCRIPTION
## PR Summary

Fixes #1725

Although PR #1713 will fix any problems of running Pester tests with special describe block strings when the latest version of Pester (>4.6.0) is used, this PR fixes the behaviour when an older version of Pester is installed to allow running tests with describe blocks that contain a single quote inside them. I also checked that this does not break running describe blocks with single quotes strings or single quotes inside single quotes. I also tested multiple single quotes inside the string.
![image](https://user-images.githubusercontent.com/9250262/51791687-5704ea00-219e-11e9-9a8b-b7d191ea6348.png)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
