### PR TITLE
turn off non-windows gate for attach to process

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -70,7 +70,8 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
 
             // Cross-platform attach to process was added in 6.2.0-preview.4
             if (versionDetails.version < "6.2.0" && platformDetails.operatingSystem !== OperatingSystem.Windows) {
-                const msg = "Attaching to a PowerShell Host Process is supported only on Windows.";
+                const msg = `Attaching to a PowerShell Host Process on '${
+                    OperatingSystem[platformDetails.operatingSystem] }' requires PowerShell 6.2 or higher.`;
                 return vscode.window.showErrorMessage(msg).then((_) => {
                     return undefined;
                 });

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -70,8 +70,8 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
 
             // Cross-platform attach to process was added in 6.2.0-preview.4
             if (versionDetails.version < "6.2.0" && platformDetails.operatingSystem !== OperatingSystem.Windows) {
-                const msg = `Attaching to a PowerShell Host Process on '${
-                    OperatingSystem[platformDetails.operatingSystem] }' requires PowerShell 6.2 or higher.`;
+                const msg = `Attaching to a PowerShell Host Process on ${
+                    OperatingSystem[platformDetails.operatingSystem] } requires PowerShell 6.2 or higher.`;
                 return vscode.window.showErrorMessage(msg).then((_) => {
                     return undefined;
                 });

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -68,7 +68,8 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
             const platformDetails = getPlatformDetails();
             const versionDetails = this.sessionManager.getPowerShellVersionDetails();
 
-            if (platformDetails.operatingSystem !== OperatingSystem.Windows) {
+            // Cross-platform attach to process was added in 6.2.0-preview.4
+            if (versionDetails.version < "6.2.0" && platformDetails.operatingSystem !== OperatingSystem.Windows) {
                 const msg = "Attaching to a PowerShell Host Process is supported only on Windows.";
                 return vscode.window.showErrorMessage(msg).then((_) => {
                     return undefined;


### PR DESCRIPTION
## PR Summary

As of 6.2.0-preview.4 `Enter-PSHostProcess` and `Get-PSHostProcessInfo` both work on Non-Windows so I've modified the check to allow folks with 6.2.0 and higher to use the Attach to process debug config.

We try to only support the latest preview of PowerShell since it gets hairy to maintain all of the previews... if you feel like I should make the check more robust, let me know! However, I don't know the % of people who would be on preview.X and try using Enter-PSHostProcess.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
