### PR TITLE
Setting CommandExp ExcludeFilter to be empty array

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,7 +505,7 @@
         },
         "powershell.sideBar.CommandExplorerExcludeFilter": {
           "type":"array",
-          "default":"",
+          "default":[],
           "description": "Specify array of Modules to exclude from Command Explorer listing."
         },
         "powershell.powerShellExePath": {


### PR DESCRIPTION
Fixes https://github.com/PowerShell/vscode-powershell/issues/1737