### PR TITLE
Update build to clear node modules directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -508,8 +508,8 @@
           "description": "Specifies the visibility of the Command Explorer in the PowerShell Side Bar."
         },
         "powershell.sideBar.CommandExplorerExcludeFilter": {
-          "type":"array",
-          "default":[],
+          "type": "array",
+          "default": [],
           "description": "Specify array of Modules to exclude from Command Explorer listing."
         },
         "powershell.powerShellExePath": {

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -75,8 +75,8 @@ task RestoreNodeModules {
 task Clean {
     Write-Host "`n### Cleaning vscode-powershell`n" -ForegroundColor Green
     Remove-Item .\modules\* -Exclude "README.md" -Recurse -Force -ErrorAction Ignore
-    Remove-Item .\node_modules -Recurse -Force -ErrorAction Ignore
     Remove-Item .\out -Recurse -Force -ErrorAction Ignore
+    exec { & npm prune }
 }
 
 task CleanEditorServices {

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -60,9 +60,9 @@ task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices,
     }
 }
 
-task Restore RestoreNodeModules -Before Build
+task Restore RestoreNodeModules -Before Build -If { -not (Test-Path "$PSScriptRoot/node_modules") }
 
-task RestoreNodeModules -If { -not (Test-Path "$PSScriptRoot/node_modules") } {
+task RestoreNodeModules {
 
     Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
 
@@ -75,6 +75,7 @@ task RestoreNodeModules -If { -not (Test-Path "$PSScriptRoot/node_modules") } {
 task Clean {
     Write-Host "`n### Cleaning vscode-powershell`n" -ForegroundColor Green
     Remove-Item .\modules\* -Exclude "README.md" -Recurse -Force -ErrorAction Ignore
+    Remove-Item .\node_modules -Recurse -Force -ErrorAction Ignore
     Remove-Item .\out -Recurse -Force -ErrorAction Ignore
 }
 


### PR DESCRIPTION
## PR Summary

* Add removal of the node_modules directory on Clean task.
* Move condition for restore to the build prerequisite.
  * This allows the restoring of node modules even if the folder exists.

The main benefit of this is it keeps the build process in invoke-build when new node modules are added as they were recently.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
