### PR TITLE
Fix Right Click Help lookup not always working.

### DIFF
--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -22,7 +22,7 @@ export class ShowHelpFeature implements IFeature {
                     "Unable to instantiate; language client undefined.");
                 return;
             }
-            if (item === undefined) {
+            if (item === undefined || !item.hasOwnProperty("Name")) {
 
                 const editor = vscode.window.activeTextEditor;
 

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -22,7 +22,7 @@ export class ShowHelpFeature implements IFeature {
                     "Unable to instantiate; language client undefined.");
                 return;
             }
-            if (item === undefined || !item.hasOwnProperty("Name")) {
+            if (!item || !item.Name) {
 
                 const editor = vscode.window.activeTextEditor;
 


### PR DESCRIPTION
## PR Summary
Fixes #1740

When selecting Show Help from right click menu, vscode is sending the editor information through the item parameter. The editor doesn't have a Name property, so we should check that the item being passed has a Name property as well.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- NA PR has tests
- [x] This PR is ready to merge and is not work in progress