### PR TITLE
Speed up travis builds by skipping the .net core initialisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: cpp
 git:
   depth: 1000
 
+env:
+  # Avoid expensive initialization of dotnet cli, see: https://donovanbrown.com/post/Stop-wasting-time-during-NET-Core-builds
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
 os:
   - linux
   - osx


### PR DESCRIPTION
## PR Summary

This makes the build nearly 1 minute faster. It is a trick that I already added to the PowerShell build [here](https://github.com/PowerShell/PowerShell/blob/master/.vsts-ci/windows.yml) last year

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- x ] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
