### PR TITLE
Match Install-VSCode.ps1 script url with the one from master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ the `Install-Script` command.
 
 **Alternatively** you can download and execute the script directly from the web
 without the use of `Install-Script`.  However we **highly recommend** that you
-[read the script](https://git.io/vbxjj)
+[read the script](https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/scripts/Install-VSCode.ps1)
 first before running it in this way!
 
 ```powershell
-iex (iwr https://git.io/vbxjj)
+iex (iwr https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/scripts/Install-VSCode.ps1)
 ```
 
 ## Reporting Problems

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can also install a VSIX package from our [Releases page](https://github.com/
 [Install from a VSIX](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix)
 instructions.  The easiest way is through the command line:
 
-```
+```bash
 code --install-extension PowerShell-<version>.vsix
 ```
 
@@ -63,7 +63,7 @@ the `Install-Script` command.
 
 **Alternatively** you can download and execute the script directly from the web
 without the use of `Install-Script`.  However we **highly recommend** that you
-[read the script](https://github.com/PowerShell/vscode-powershell/blob/develop/scripts/Install-VSCode.ps1)
+[read the script](https://git.io/vbxjj)
 first before running it in this way!
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can also install a VSIX package from our [Releases page](https://github.com/
 [Install from a VSIX](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix)
 instructions.  The easiest way is through the command line:
 
-```bash
+```powershell
 code --install-extension PowerShell-<version>.vsix
 ```
 


### PR DESCRIPTION
## PR Summary

Install-VSCode.ps1 has been changed many times and default 'develop' branch has become stale. In README.md there is installation link which provides to Install-VSCode.ps1 from master branch. The text above recommends to check content of the script before launching, but redirects to old Install-VSCode.ps1 from develop branch. This small PR is changing this behaviour. Additionally setting language to command line.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
