### PR TITLE
Added Pester, ShouldProcess and Calculated Property PS Snippets

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -956,11 +956,11 @@
     "IfShouldProcess": {
         "prefix": "IfShouldProcess",
         "body": [
-            "if ($$PSCmdlet.ShouldProcess(\"${1:The Item}\" , \"${2:The Change}\")) {",
-            "\t# Place Code here",
+            "if (\\$PSCmdlet.ShouldProcess(\"${1:Target}\", \"${2:Operation}\")) {",
+                "\t$0",
             "}"
         ],
-        "description": "Creates an if should process"
+        "description": "Adds ShouldProcess block"
     },
     "CalculatedProperty": {
         "prefix": "Calculated-Property",

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -968,5 +968,56 @@
             "@{name='${1:PropertyName}';expression={\\$_.${2:PropertyValue}}}$0"
         ],
         "description": "Creates a PSCustomObject"
+    },
+    "PesterDescribeContextIt": {
+        "prefix": "Describe-Context-It-Pester",
+        "body": [
+            "Describe \"${1:DescribeName}\" {",
+                "\tContext \"${2:ContextName}\" {",
+                    "\t\tIt \"${3:ItName}\" {",
+                        "\t\t\t${4:Assertion}",
+                    "\t\t}$0",
+                "\t}",
+            "}"
+        ],
+        "description": "Pester Describe block with nested Context & It blocks"
+    },
+    "PesterDescribeBlock": {
+        "prefix": "Describe-Pester",
+        "body": [
+            "Describe \"${1:DescribeName}\" {",
+                "\t$0",
+            "}"
+        ],
+        "description": "Pester Describe block"
+    },
+    "PesterContextIt": {
+        "prefix": "Context-It-Pester",
+        "body": [
+            "Context \"${1:ContextName}\" {",
+                "\tIt \"${2:ItName}\" {",
+                    "\t\t${3:Assertion}",
+                "\t}$0",
+            "}"
+        ],
+        "description": "Pester - Context block with nested It block"
+    },
+    "PesterContext": {
+        "prefix": "Context-Pester",
+        "body": [
+            "Context \"${1:ContextName}\" {",
+                "\t$0",
+            "}"
+        ],
+        "description": "Pester - Context block"
+    },
+    "PesterIt": {
+        "prefix": "It-Pester",
+        "body": [
+            "It \"${1:ItName}\" {",
+                "\t${2:Assertion}",
+            "}$0"
+        ],
+        "description": "Pester - It block"
     }
 }

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -952,5 +952,21 @@
             "#endregion"
         ],
         "description": "Region Block for organizing and folding of your code"
+    },
+    "IfShouldProcess": {
+        "prefix": "IfShouldProcess",
+        "body": [
+            "if ($$PSCmdlet.ShouldProcess(\"${1:The Item}\" , \"${2:The Change}\")) {",
+            "\t# Place Code here",
+            "}"
+        ],
+        "description": "Creates an if should process"
+    },
+    "CalculatedProperty": {
+        "prefix": "Calculated-Property",
+        "body": [
+            "@{name='${1:PropertyName}';expression={\\$_.${2:PropertyValue}}}$0"
+        ],
+        "description": "Creates a PSCustomObject"
     }
 }

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -965,7 +965,7 @@
     "CalculatedProperty": {
         "prefix": "Calculated-Property",
         "body": [
-            "@{name='${1:PropertyName}';expression={\\$_.${2:PropertyValue}}}$0"
+            "@{name='${1:PropertyName}';expression={${2:\\$_.PropertyValue}}}$0"
         ],
         "description": "Creates a Calculated Property"
     },

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -960,14 +960,14 @@
                 "\t$0",
             "}"
         ],
-        "description": "Adds ShouldProcess block"
+        "description": "Creates ShouldProcess block"
     },
     "CalculatedProperty": {
         "prefix": "Calculated-Property",
         "body": [
             "@{name='${1:PropertyName}';expression={\\$_.${2:PropertyValue}}}$0"
         ],
-        "description": "Creates a PSCustomObject"
+        "description": "Creates a Calculated Property"
     },
     "PesterDescribeContextIt": {
         "prefix": "Describe-Context-It-Pester",


### PR DESCRIPTION
## PR Summary
Added snippets for the following:
* Calculated Property for use with `Select-Object -Property`
* `If Should Process` for quickly adding `if ($PSCmdlet.ShouldProcess("Target", "Operation")) {...}`
* Pester:
    * Describe Block
    * Describe with nested context & It block
    * Context Block
    * Context with nested It Block
    * It Block

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
