### PR TITLE
Escape "-Command" arguments to prevent Terminal API failure

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -69,9 +69,10 @@ export class PowerShellProcess {
                         powerShellArgs.push("-ExecutionPolicy", "Bypass");
                     }
 
+                    this.startArgs = this.startArgs.replace(/'/g, '"');
                     powerShellArgs.push(
                         "-Command",
-                        "& '" + PowerShellProcess.escapeSingleQuotes(startScriptPath) + "' " + this.startArgs);
+                        "'& \"" + PowerShellProcess.escapeSingleQuotes(startScriptPath) + "\" " + this.startArgs + "'");
 
                     let powerShellExePath = this.exePath;
 


### PR DESCRIPTION
Fixes: https://github.com/codercom/bugs/issues/270.

## PR Summary

On Ubuntu 16.04 containers, the Terminal API fails to start the pwsh executable with any "-Command" arguments. This appears to be due to unescaped single quotes within the argument list.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] ~PR has tests~ (NA)
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
