### PR TITLE
Change debugger type field back to "PowerShell" from powershell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "PowerShell",
+  "name": "powershell",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     ],
     "debuggers": [
       {
-        "type": "powershell",
+        "type": "PowerShell",
         "label": "PowerShell",
         "enableBreakpointsFor": {
           "languageIds": [
@@ -329,7 +329,7 @@
             "description": "Launch current file (in active editor window) under debugger",
             "body": {
               "name": "PowerShell Launch Current File",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
               "args": [],
@@ -341,7 +341,7 @@
             "description": "Launch current file (in active editor window) under debugger in a temporary Integrated Console.",
             "body": {
               "name": "PowerShell Launch Current File in Temporary Console",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
               "args": [],
@@ -354,7 +354,7 @@
             "description": "Launch current file (in active editor window) under debugger, prompting first for script arguments",
             "body": {
               "name": "PowerShell Launch Current File w/Args Prompt",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
               "args": [
@@ -368,7 +368,7 @@
             "description": "Launch specified script or path to script under debugger",
             "body": {
               "name": "PowerShell Launch ${Script}",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${workspaceFolder}/${Script}\"",
               "args": [],
@@ -380,7 +380,7 @@
             "description": "Invokes Pester tests under debugger",
             "body": {
               "name": "PowerShell Pester Tests",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "script": "Invoke-Pester",
               "args": [],
@@ -392,7 +392,7 @@
             "description": "Open host process picker to select process to attach debugger to",
             "body": {
               "name": "PowerShell Attach to Host Process",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "attach",
               "processId": "^\"\\${command:PickPSHostProcess}\"",
               "runspaceId": 1
@@ -403,7 +403,7 @@
             "description": "Start interactive session (Debug Console) under debugger",
             "body": {
               "name": "PowerShell Interactive Session",
-              "type": "powershell",
+              "type": "PowerShell",
               "request": "launch",
               "cwd": ""
             }

--- a/src/session.ts
+++ b/src/session.ts
@@ -411,8 +411,9 @@ export class SessionManager implements Middleware {
         if (!this.suppressRestartPrompt &&
             (settings.useX86Host !== this.sessionSettings.useX86Host ||
              settings.powerShellExePath.toLowerCase() !== this.sessionSettings.powerShellExePath.toLowerCase() ||
-             settings.developer.powerShellExePath.toLowerCase() !==
-                this.sessionSettings.developer.powerShellExePath.toLowerCase() ||
+             (settings.developer.powerShellExePath ? settings.developer.powerShellExePath.toLowerCase() : null) !==
+                (this.sessionSettings.developer.powerShellExePath
+                    ? this.sessionSettings.developer.powerShellExePath.toLowerCase() : null) ||
              settings.developer.editorServicesLogLevel.toLowerCase() !==
                 this.sessionSettings.developer.editorServicesLogLevel.toLowerCase() ||
              settings.developer.bundledModulesPath.toLowerCase() !==


### PR DESCRIPTION
## PR Summary

This allows the debugger to start but not sure why (lower-case) "powershell" doesn't
work. That said, the previous change meant that users would have to
update their launch.json to change the type to "powershell".  But
even when I do that, the debugger still doesn't launch. So I'm a bit
puzzled.  But this gets the debugger working again on master.

Also fixed some warnings in session.ts.

Fix #1768


<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
