### PR TITLE
Support -CustomPipeName

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,7 +394,6 @@
               "name": "PowerShell Attach to Host Process",
               "type": "PowerShell",
               "request": "attach",
-              "processId": "^\"\\${command:PickPSHostProcess}\"",
               "runspaceId": 1
             }
           },
@@ -445,12 +444,17 @@
               "processId": {
                 "type": "string",
                 "description": "The process id of the PowerShell host process to attach to.  Works only on PowerShell 5 and above.",
-                "default": "${command:PickPSHostProcess}"
+                "default": null
               },
               "runspaceId": {
                 "type": "number",
                 "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
                 "default": 1
+              },
+              "customPipeName": {
+                "type": "string",
+                "description": "The custom pipe name of the PowerShell host process to attach to.  Works only on PowerShell 6.2 and above.",
+                "default": null
               }
             }
           }
@@ -487,7 +491,6 @@
             "name": "PowerShell Attach to Host Process",
             "type": "powershell",
             "request": "attach",
-            "processId": "${command:PickPSHostProcess}",
             "runspaceId": 1
           },
           {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -43,10 +43,10 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
     }
 
     // DebugConfigurationProvider method
-    public resolveDebugConfiguration(
+    public async resolveDebugConfiguration(
         folder: WorkspaceFolder | undefined,
         config: DebugConfiguration,
-        token?: CancellationToken): ProviderResult<DebugConfiguration> {
+        token?: CancellationToken): Promise<DebugConfiguration> {
 
         // Make sure there is a session running before attempting to debug/run a program
         if (this.sessionManager.getSessionStatus() !== SessionStatus.Running) {
@@ -75,6 +75,11 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                 return vscode.window.showErrorMessage(msg).then((_) => {
                     return undefined;
                 });
+            }
+
+            // if nothing is set, prompt for the processId
+            if (!config.customPipeName && !config.processId) {
+                config.processId = await vscode.commands.executeCommand("PowerShell.PickPSHostProcess");
             }
         }
 


### PR DESCRIPTION
## PR Summary

In PowerShell 6.2 RC we will introduce `-CustomPipeName`. The work is in this PR:
https://github.com/PowerShell/PowerShell/pull/8889

This, along with https://github.com/PowerShell/PowerShellEditorServices/pull/871 will add support for this parameter in the debug config that is passed to 

```powershell
Enter-PSHostProcess -CustomPipeName $foo
```

marking this as a Draft PR until RC is released.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
