### PR TITLE
Migrate Pester version detection into an InovkePester stub script

### DIFF
--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -52,7 +52,7 @@ param(
 
 $pesterModule = Microsoft.PowerShell.Core\Get-Module Pester
 if (!$pesterModule) {
-    Write-Host "Importing Pester module..."
+    Write-Output "Importing Pester module..."
     $pesterModule = Microsoft.PowerShell.Core\Import-Module Pester -ErrorAction Ignore -PassThru
     if (!$pesterModule) {
         # If we still don't have an imported Pester module, that is (most likely) because Pester is not installed.

--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -1,0 +1,62 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+    Stub around Invoke-Pester command used by VSCode PowerShell extension.
+.DESCRIPTION
+    Stub around Invoke-Pester command used by VSCode PowerShell extension.
+    The stub checks the version of Pester and if >= 4.6.0, invokes Pester
+    using the LineNumber parameter (if specified). Otherwise, it invokes
+    using the TestName parameter (if specified).
+.EXAMPLE
+    PS C:\> .\InvokePesterStub.ps1 ~\project\test\foo.tests.ps1 -LineNumber 14
+    Invokes a specific test by line number in the specified file.
+.EXAMPLE
+    PS C:\> .\InvokePesterStub.ps1 ~\project\test\foo.tests.ps1 -TestName 'Foo Tests'
+    Invokes a specific test by test name in the specified file.
+.EXAMPLE
+    PS C:\> .\InvokePesterStub.ps1 ~\project\test\foo.tests.ps1
+    Invokes all tests in the specified file.
+.INPUTS
+    None
+.OUTPUTS
+    None
+#>
+param(
+    # Specifies the path to the test script.
+    [Parameter(Position=0, Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $ScriptPath,
+
+    # Specifies the name of the test taken from the Describe block's name.
+    [Parameter()]
+    [string]
+    $TestName,
+
+    # Specifies the starting line number of the DescribeBlock.  This feature requires
+    # Pester 4.6.0 or higher.
+    [Parameter()]
+    [ValidatePattern('\d*')]
+    [string]
+    $LineNumber
+)
+
+try {
+    $pesterVersion = (Microsoft.PowerShell.Core\Get-Command Invoke-Pester -ErrorAction Stop).Version
+    if (($pesterVersion -ge '4.6.0') -and ($LineNumber -match '\d+')) {
+        $pesterOption = New-PesterOption -ScriptBlockFilter @(
+            @{ IncludeVSCodeMarker=$true; Line=$LineNumber; Path=$ScriptPath } )
+        Invoke-Pester -Script $ScriptPath -PesterOption $pesterOption
+    }
+    elseif ($TestName) {
+        Invoke-Pester -Script $ScriptPath -PesterOption @{ IncludeVSCodeMarker=$true } -TestName $TestName
+    }
+    else {
+        Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true}
+    }
+}
+catch [System.Management.Automation.CommandNotFoundException] {
+    Write-Warning "You must install Pester to run or debug Pester Tests. You can install Pester by executing:"
+    Write-Warning "Install-Module Pester -Scope CurrentUser -Force"
+}

--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -65,12 +65,12 @@ if (!$pesterModule) {
 if ($All) {
     Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true}
 }
+elseif ($TestName) {
+    Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -TestName $TestName
+}
 elseif (($LineNumber -match '\d+') -and ($pesterModule.Version -ge '4.6.0')) {
     Pester\Invoke-Pester -Script $ScriptPath -PesterOption (New-PesterOption -ScriptBlockFilter @{
         IncludeVSCodeMarker=$true; Line=$LineNumber; Path=$ScriptPath})
-}
-elseif ($TestName) {
-    Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -TestName $TestName
 }
 else {
     # We get here when the TestName expression is of type ExpandableStringExpressionAst.

--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -76,8 +76,7 @@ else {
     # We get here when the TestName expression is of type ExpandableStringExpressionAst.
     # PSES will not attempt to "evaluate" the expression so it returns null for the TestName.
     Write-Warning "The Describe block's TestName cannot be evaluated. EXECUTING ALL TESTS instead."
-    Write-Warning "To avoid this, either install Pester 4.6.0 or higher, or remove any variables or"
-    Write-Warning "sub-expressions in the Describe block's TestName."
+    Write-Warning "To avoid this, install Pester >= 4.6.0 or remove any expressions in the TestName."
 
     Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true}
 }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -54,24 +54,18 @@ export class PesterTestsFeature implements IFeature {
     private launchAllTestsInActiveEditor(launchType: LaunchType) {
         const uriString = vscode.window.activeTextEditor.document.uri.toString();
         const launchConfig = this.createLaunchConfig(uriString, launchType);
+        launchConfig.args.push("-All");
         this.launch(launchConfig);
     }
 
-    private async launchTests(uriString: string, runInDebugger: boolean, describeBlockName?: string, lineNum?: number) {
-        // PSES passes null for the describeBlockName to signal that it can't evaluate the TestName.
-        if (!describeBlockName) {
-            const answer = await vscode.window.showErrorMessage(
-                "This Describe block's TestName parameter cannot be evaluated. " +
-                `Would you like to ${runInDebugger ? "debug" : "run"} all the tests in this file?`,
-                "Yes", "No");
-
-            if (answer !== "Yes") {
-                return;
-            }
-        }
+    private async launchTests(
+        uriString: string,
+        runInDebugger: boolean,
+        describeBlockName?: string,
+        describeBlockLineNumber?: number) {
 
         const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
-        const launchConfig = this.createLaunchConfig(uriString, launchType, describeBlockName, lineNum);
+        const launchConfig = this.createLaunchConfig(uriString, launchType, describeBlockName, describeBlockLineNumber);
         this.launch(launchConfig);
     }
 

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -18,8 +18,11 @@ export class PesterTestsFeature implements IFeature {
 
     private command: vscode.Disposable;
     private languageClient: LanguageClient;
+    private invokePesterStubScriptPath: string;
 
     constructor(private sessionManager: SessionManager) {
+        this.invokePesterStubScriptPath = path.resolve(__dirname, "../../../InvokePesterStub.ps1");
+
         // File context-menu command - Run Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTestsFromFile",
@@ -35,8 +38,8 @@ export class PesterTestsFeature implements IFeature {
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTests",
-            (uriString, runInDebugger, describeBlockName?) => {
-                this.launchTests(uriString, runInDebugger, describeBlockName);
+            (uriString, runInDebugger, describeBlockName?, describeBlockLineNumber?) => {
+                this.launchTests(uriString, runInDebugger, describeBlockName, describeBlockLineNumber);
             });
     }
 
@@ -54,7 +57,7 @@ export class PesterTestsFeature implements IFeature {
         this.launch(launchConfig);
     }
 
-    private async launchTests(uriString: string, runInDebugger: boolean, describeBlockName?: string) {
+    private async launchTests(uriString: string, runInDebugger: boolean, describeBlockName?: string, lineNum?: number) {
         // PSES passes null for the describeBlockName to signal that it can't evaluate the TestName.
         if (!describeBlockName) {
             const answer = await vscode.window.showErrorMessage(
@@ -68,21 +71,11 @@ export class PesterTestsFeature implements IFeature {
         }
 
         const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
-        const launchConfig = this.createLaunchConfig(uriString, launchType);
-
-        if (describeBlockName) {
-            launchConfig.args.push("-TestName");
-            // Escape single quotes inside double quotes by doubling them up
-            if (describeBlockName.includes("'")) {
-                describeBlockName = describeBlockName.replace(/'/g, "''");
-            }
-            launchConfig.args.push(`'${describeBlockName}'`);
-        }
-
+        const launchConfig = this.createLaunchConfig(uriString, launchType, describeBlockName, lineNum);
         this.launch(launchConfig);
     }
 
-    private createLaunchConfig(uriString: string, launchType: LaunchType) {
+    private createLaunchConfig(uriString: string, launchType: LaunchType, testName?: string, lineNum?: number) {
         const uri = vscode.Uri.parse(uriString);
         const currentDocument = vscode.window.activeTextEditor.document;
         const settings = Settings.load();
@@ -95,12 +88,10 @@ export class PesterTestsFeature implements IFeature {
             request: "launch",
             type: "PowerShell",
             name: "PowerShell Launch Pester Tests",
-            script: "Invoke-Pester",
+            script: this.invokePesterStubScriptPath,
             args: [
-                "-Script",
+                "-ScriptPath",
                 `'${scriptPath}'`,
-                "-PesterOption",
-                "@{IncludeVSCodeMarker=$true}",
             ],
             internalConsoleOptions: "neverOpen",
             noDebug: (launchType === LaunchType.Run),
@@ -110,6 +101,19 @@ export class PesterTestsFeature implements IFeature {
                     ? vscode.workspace.rootPath
                     : path.dirname(currentDocument.fileName),
         };
+
+        if (lineNum) {
+            launchConfig.args.push("-LineNumber", `${lineNum}`);
+        }
+
+        if (testName) {
+            // Escape single quotes inside double quotes by doubling them up
+            if (testName.includes("'")) {
+                testName = testName.replace(/'/g, "''");
+            }
+
+            launchConfig.args.push("-TestName", `'${testName}'`);
+        }
 
         return launchConfig;
     }


### PR DESCRIPTION
## PR Summary

Alternate implementation of invoking pester tests by line number. See PR #1713

This PR requires the changes that @bergmeister is working on in the [PSES PR 856](https://github.com/PowerShell/PowerShellEditorServices/pull/856)  That PR can now be simplified since it does not need to determine the Pester version number.  It just always returns the line number.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
