### PR TITLE
Add Debug Runspace command

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "onCommand:PowerShell.ShowSessionConsole",
     "onCommand:PowerShell.ShowSessionMenu",
     "onCommand:PowerShell.RestartSession",
-    "onView:PowerShellCommands"
+    "onView:PowerShellCommands",
+    "onCommand:PowerShell.PickRunspace"
   ],
   "dependencies": {
     "vscode-languageclient": "~5.1.1"
@@ -318,6 +319,7 @@
         "runtime": "node",
         "variables": {
           "PickPSHostProcess": "PowerShell.PickPSHostProcess",
+          "PickRunspace": "PowerShell.PickRunspace",
           "SpecifyScriptArgs": "PowerShell.SpecifyScriptArgs"
         },
         "languages": [
@@ -407,6 +409,17 @@
               "request": "launch",
               "cwd": ""
             }
+          },
+          {
+            "label": "PowerShell: Debug Runspace",
+            "description": "Open runspace picker to select runspace to attach debugger to",
+            "body": {
+              "name": "PowerShell Debug Runspace",
+              "type": "PowerShell",
+              "request": "attach",
+              "processId": "current",
+              "localRunspaceId": "^\"\\${command:PickRunspace}\""
+            }
           }
         ],
         "configurationAttributes": {
@@ -451,6 +464,11 @@
                 "type": "number",
                 "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
                 "default": 1
+              },
+              "localRunspaceId": {
+                "type": "string",
+                "description": "The ID of the runspace to debug.  Defaults to 1.  Works only on PowerShell 5 and above.",
+                "default": "${command:PickRunspace}"
               }
             }
           }
@@ -495,6 +513,13 @@
             "type": "powershell",
             "request": "launch",
             "cwd": ""
+          },
+          {
+            "name": "PowerShell Debug Runspace",
+            "type": "powershell",
+            "request": "attach",
+            "processId": "current",
+            "localRunspaceId": "${command:PickRunspace}"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -416,8 +416,7 @@
               "name": "PowerShell Attach Interactive Session Runspace",
               "type": "PowerShell",
               "request": "attach",
-              "processId": "current",
-              "runspaceId": "^\"\\${command:PickRunspace}\""
+              "processId": "current"
             }
           }
         ],
@@ -460,7 +459,7 @@
                 "default": null
               },
               "runspaceId": {
-                "type": "string",
+                "type":["string","number"],
                 "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
                 "default": null
               },

--- a/package.json
+++ b/package.json
@@ -462,7 +462,7 @@
               "runspaceId": {
                 "type": "string",
                 "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
-                "default": "1"
+                "default": null
               },
               "customPipeName": {
                 "type": "string",
@@ -503,8 +503,7 @@
           {
             "name": "PowerShell Attach to Host Process",
             "type": "PowerShell",
-            "request": "attach",
-            "runspaceId": "1"
+            "request": "attach"
           },
           {
             "name": "PowerShell Interactive Session",
@@ -516,8 +515,7 @@
             "name": "PowerShell Attach Interactive Session Runspace",
             "type": "PowerShell",
             "request": "attach",
-            "processId": "current",
-            "runspaceId": "${command:PickRunspace}"
+            "processId": "current"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "onCommand:PowerShell.NewProjectFromTemplate",
     "onCommand:PowerShell.OpenExamplesFolder",
     "onCommand:PowerShell.PickPSHostProcess",
+    "onCommand:PowerShell.PickRunspace",
     "onCommand:PowerShell.SpecifyScriptArgs",
     "onCommand:PowerShell.ShowSessionConsole",
     "onCommand:PowerShell.ShowSessionMenu",
     "onCommand:PowerShell.RestartSession",
-    "onView:PowerShellCommands",
-    "onCommand:PowerShell.PickRunspace"
+    "onView:PowerShellCommands"
   ],
   "dependencies": {
     "vscode-languageclient": "~5.1.1"
@@ -411,14 +411,14 @@
             }
           },
           {
-            "label": "PowerShell: Debug Runspace",
+            "label": "PowerShell: Attach Interactive Session Runspace",
             "description": "Open runspace picker to select runspace to attach debugger to",
             "body": {
-              "name": "PowerShell Debug Runspace",
+              "name": "PowerShell Attach Interactive Session Runspace",
               "type": "PowerShell",
               "request": "attach",
               "processId": "current",
-              "localRunspaceId": "^\"\\${command:PickRunspace}\""
+              "runspaceId": "^\"\\${command:PickRunspace}\""
             }
           }
         ],
@@ -461,14 +461,9 @@
                 "default": "${command:PickPSHostProcess}"
               },
               "runspaceId": {
-                "type": "number",
-                "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
-                "default": 1
-              },
-              "localRunspaceId": {
                 "type": "string",
-                "description": "The ID of the runspace to debug.  Defaults to 1.  Works only on PowerShell 5 and above.",
-                "default": "${command:PickRunspace}"
+                "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
+                "default": "1"
               }
             }
           }
@@ -506,7 +501,7 @@
             "type": "powershell",
             "request": "attach",
             "processId": "${command:PickPSHostProcess}",
-            "runspaceId": 1
+            "runspaceId": "1"
           },
           {
             "name": "PowerShell Interactive Session",
@@ -515,11 +510,11 @@
             "cwd": ""
           },
           {
-            "name": "PowerShell Debug Runspace",
+            "name": "PowerShell Attach Interactive Session Runspace",
             "type": "powershell",
             "request": "attach",
             "processId": "current",
-            "localRunspaceId": "${command:PickRunspace}"
+            "runspaceId": "${command:PickRunspace}"
           }
         ]
       }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -392,17 +392,13 @@ interface IRunspaceItem extends vscode.QuickPickItem {
 }
 
 interface IRunspace {
-    id: string;
+    id: number;
     name: string;
     availability: string;
 }
 
 export const GetRunspaceRequestType =
-    new RequestType<any, IGetRunspaceResponseBody, string, void>("powerShell/getRunspace");
-
-interface IGetRunspaceResponseBody {
-    runspaces: IRunspace[];
-}
+    new RequestType<any, IRunspace[], string, void>("powerShell/getRunspace");
 
 export class PickRunspaceFeature implements IFeature {
 
@@ -412,7 +408,6 @@ export class PickRunspaceFeature implements IFeature {
     private getLanguageClientResolve: (value?: LanguageClient | Thenable<LanguageClient>) => void;
 
     constructor() {
-
         this.command =
             vscode.commands.registerCommand("PowerShell.PickRunspace", () => {
                 return this.getLanguageClient()
@@ -473,23 +468,20 @@ export class PickRunspaceFeature implements IFeature {
     }
 
     private pickRunspace(): Thenable<string> {
-        return this.languageClient.sendRequest(GetRunspaceRequestType, null).then((runspaces) => {
+        return this.languageClient.sendRequest(GetRunspaceRequestType, null).then((response) => {
             const items: IRunspaceItem[] = [];
 
-            for (const p in runspaces) {
-                if (runspaces.hasOwnProperty(p)) {
-
-                    // Skip default runspace
-                    if (runspaces[p].id === 1) {
-                        continue;
-                    }
-
-                    items.push({
-                        label: runspaces[p].name,
-                        description: `ID: ${runspaces[p].id} - ${runspaces[p].availability}`,
-                        id: runspaces[p].id,
-                    });
+            for (const runspace of response) {
+                // Skip default runspace
+                if (runspace.id === 1) {
+                    continue;
                 }
+
+                items.push({
+                    label: runspace.name,
+                    description: `ID: ${runspace.id} - ${runspace.availability}`,
+                    id: runspace.id.toString(),
+                });
             }
 
             const options: vscode.QuickPickOptions = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { ConsoleFeature } from "./features/Console";
 import { CustomViewsFeature } from "./features/CustomViews";
 import { DebugSessionFeature } from "./features/DebugSession";
 import { PickPSHostProcessFeature } from "./features/DebugSession";
+import { PickRunspaceFeature } from "./features/DebugSession";
 import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { DocumentFormatterFeature } from "./features/DocumentFormatter";
 import { ExamplesFeature } from "./features/Examples";
@@ -142,6 +143,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new SpecifyScriptArgsFeature(context),
         new HelpCompletionFeature(logger),
         new CustomViewsFeature(),
+        new PickRunspaceFeature(),
     ];
 
     sessionManager.setExtensionFeatures(extensionFeatures);


### PR DESCRIPTION
## PR Summary

This enables support for attaching to local runspaces. This adds a new command that allows the user to select a local runspace and attach to it. This is similar to attaching to a remote process and uses the same PSES request. 

The accompanying PR in PSES is here: https://github.com/PowerShell/PowerShellEditorServices/pull/875

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ x] PR has a meaningful title
- [ x] Summarized changes
- [ -] PR has tests
- [x ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
