### PR TITLE
include current runspace and runspace 1 if should

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -358,7 +358,12 @@ export class PickPSHostProcessFeature implements IFeature {
 
     private pickPSHostProcess(): Thenable<string> {
         return this.languageClient.sendRequest(GetPSHostProcessesRequestType, null).then((hostProcesses) => {
-            const items: IProcessItem[] = [];
+            // Start with the current PowerShell process to the list.
+            const items: IProcessItem[] = [{
+                label: "Current",
+                description: "The current PowerShell process.",
+                pid: "current",
+            }];
 
             for (const p in hostProcesses) {
                 if (hostProcesses.hasOwnProperty(p)) {
@@ -487,7 +492,8 @@ export class PickRunspaceFeature implements IFeature {
 
             for (const runspace of response) {
                 // Skip default runspace
-                if (runspace.id === 1 || runspace.name === "PSAttachRunspace") {
+                if ((runspace.id === 1 || runspace.name === "PSAttachRunspace")
+                    && processId === "current") {
                     continue;
                 }
 

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -361,7 +361,7 @@ export class PickPSHostProcessFeature implements IFeature {
             // Start with the current PowerShell process in the list.
             const items: IProcessItem[] = [{
                 label: "Current",
-                description: "The current PowerShell process.",
+                description: "The current PowerShell Integrated Console process.",
                 pid: "current",
             }];
 

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -358,7 +358,7 @@ export class PickPSHostProcessFeature implements IFeature {
 
     private pickPSHostProcess(): Thenable<string> {
         return this.languageClient.sendRequest(GetPSHostProcessesRequestType, null).then((hostProcesses) => {
-            // Start with the current PowerShell process to the list.
+            // Start with the current PowerShell process in the list.
             const items: IProcessItem[] = [{
                 label: "Current",
                 description: "The current PowerShell process.",


### PR DESCRIPTION
## PR Summary

cc @adamdriscoll 

This will allow two things:

* A current option to show up in the Pick PSHostProcess dialog
* Runspace 1 to show up if the current runspace wasn't chosen

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
