### PR TITLE
Workaround PSSA #1187 by defaulting to NoIndentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -652,7 +652,7 @@
             "IncreaseIndentationAfterEveryPipeline",
             "NoIndentation"
           ],
-          "default": "IncreaseIndentationForFirstPipeline",
+          "default": "NoIndentation",
           "description": "Multi-line pipeline style settings."
         },
         "powershell.codeFormatting.whitespaceBeforeOpenBrace": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -141,7 +141,7 @@ export function load(): ISettings {
         openBraceOnSameLine: true,
         newLineAfterOpenBrace: true,
         newLineAfterCloseBrace: true,
-        pipelineIndentationStyle: PipelineIndentationStyle.IncreaseIndentationForFirstPipeline,
+        pipelineIndentationStyle: PipelineIndentationStyle.NoIndentation,
         whitespaceBeforeOpenBrace: true,
         whitespaceBeforeOpenParen: true,
         whitespaceAroundOperator: true,


### PR DESCRIPTION
## PR Summary

cc @bergmeister See https://github.com/PowerShell/PSScriptAnalyzer/issues/1187 for more information.

v1.18.0 of PSSA introduced a regression. This changes the default behavior back to what v1.17 did while that is being addressed.

I will cherry pick this back to legacy once this is merged in.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
