### PR TITLE
Update to official TSLint ext in extensions.json, old version deprecated

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,7 @@
   "recommendations": [
     "msjsdiag.debugger-for-chrome",
     "ms-vscode.PowerShell",
-    "eg2.tslint",
+    "ms-vscode.vscode-typescript-tslint-plugin",
     "DavidAnson.vscode-markdownlint"
   ]
 }


### PR DESCRIPTION
## PR Summary

The old Erich Gamma version of TSLint has been deprecrated and replaced by a "Microsoft" version of the same extension.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
