### PR TITLE
Switch to current lowercase names for powershell and mdlint exts

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,8 +3,8 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "msjsdiag.debugger-for-chrome",
-    "ms-vscode.PowerShell",
+    "ms-vscode.powershell",
     "ms-vscode.vscode-typescript-tslint-plugin",
-    "DavidAnson.vscode-markdownlint"
+    "davidanson.vscode-markdownlint"
   ]
 }


### PR DESCRIPTION
## PR Summary

A couple of our recommended extensions are now listed on the marketplace with all lowercase names. Switch to the official name casing as currently displayed in the marketplace.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
