### PR TITLE
Don't use -EncodedCommand on Windows

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -69,14 +69,20 @@ export class PowerShellProcess {
                         powerShellArgs.push("-ExecutionPolicy", "Bypass");
                     }
 
-                    const stringToEncode = "& '" +
+                    const startEditorServices = "& '" +
                         PowerShellProcess.escapeSingleQuotes(startScriptPath) +
                         "' " + this.startArgs;
 
-                    // Use -EncodedCommand because the command is complex and has quotes in it that need to work xplat.
-                    powerShellArgs.push(
-                        "-EncodedCommand",
-                        Buffer.from(stringToEncode, "utf16le").toString("base64"));
+                    if (utils.isWindowsOS()) {
+                        powerShellArgs.push(
+                            "-Command",
+                            startEditorServices);
+                    } else {
+                        // Use -EncodedCommand for better quote support on non-Windows
+                        powerShellArgs.push(
+                            "-EncodedCommand",
+                            Buffer.from(startEditorServices, "utf16le").toString("base64"));
+                    }
 
                     let powerShellExePath = this.exePath;
 


### PR DESCRIPTION
## PR Summary

Fixes #1831 

Conditionally uses EncodedCommand for only non-Windows

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
