### PR TITLE
Set featureFlag default to null so that it can be resolved by settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -738,7 +738,7 @@
         },
         "powershell.developer.featureFlags": {
           "type": "array",
-          "default": [],
+          "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
         },
         "powershell.developer.powerShellExeIsWindowsDevBuild": {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from "assert";
+import Settings = require("../src/settings");
+
+suite("Settings module", () => {
+    test("Settings load without error", () => {
+        assert.doesNotThrow(Settings.load);
+    });
+
+    // TODO: Remove this test when PSReadLine is in stable
+    test("PSReadLine featureFlag set correctly", () => {
+        const settings: Settings.ISettings = Settings.load();
+        if (process.platform === "win32") {
+            assert.deepEqual(settings.developer.featureFlags, ["PSReadLine"]);
+        } else {
+            assert.deepEqual(settings.developer.featureFlags, []);
+        }
+    });
+});


### PR DESCRIPTION
## PR Summary

This will _properly_ enable PSReadLine by default because the setting will be resolved by the [extension here](https://github.com/PowerShell/vscode-powershell/blob/master/src/settings.ts#L182). Something tells me I had this set, but didn't actually commit it... 😅

fixes https://github.com/PowerShell/vscode-powershell/issues/1822

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
