### PR TITLE
Turn powershell.codeformatting.useCorrectCasing setting off by default until PSSA issues are fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -697,7 +697,7 @@
         },
         "powershell.codeFormatting.useCorrectCasing": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Use correct casing for cmdlets."
         },
         "powershell.integratedConsole.showOnStartup": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -150,7 +150,7 @@ export function load(): ISettings {
         WhitespaceAroundPipe: true,
         ignoreOneLineBlock: true,
         alignPropertyValuePairs: true,
-        useCorrectCasing: true,
+        useCorrectCasing: false,
     };
 
     const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {


### PR DESCRIPTION
## PR Summary

Due to the following formattig PSSA issues it's probably better to not enable the setting by default until a patch of PSSA is available (we could also do this only for version 1 of the extension but I am currently targeting master, it is up to you and the preferred timeline of next extension or PSSA release)
- `Alias "?" is changed to "%" by Invoke-Formatter`: https://github.com/PowerShell/PSScriptAnalyzer/issues/1209
- `Cmdlet aliases are expanded automatically when formatting document`: https://github.com/PowerShell/vscode-powershell/issues/1842
- Applications such as e.g. `git` get corrected to `git.exe` (which would make a script not cross-platform any more): https://github.com/PowerShell/vscode-powershell/issues/1849

Note that this requires the following PSES PR because the vscode extension setting was not actually used by PSES: https://github.com/PowerShell/PowerShellEditorServices/pull/910

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
