### PR TITLE
Backport: Turn powershell.codeformatting.useCorrectCasing setting off by default until PSSA issues are fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -692,7 +692,7 @@
         },
         "powershell.codeFormatting.useCorrectCasing": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Use correct casing for cmdlets."
         },
         "powershell.integratedConsole.showOnStartup": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -144,7 +144,7 @@ export function load(): ISettings {
         WhitespaceAroundPipe: true,
         ignoreOneLineBlock: true,
         alignPropertyValuePairs: true,
-        useCorrectCasing: true,
+        useCorrectCasing: false,
     };
 
     const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {


### PR DESCRIPTION
Backport of #1852 