### PR TITLE
Fix small typo in Function-Inline description

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -779,7 +779,7 @@
             "\t$0",
             "}"
         ],
-        "description": "Function definition snippet that does not contain a param block, but defines parameters inline. This syntax is commonly used in other lanaguages"
+        "description": "Function definition snippet that does not contain a param block, but defines parameters inline. This syntax is commonly used in other languages"
     },
     "if": {
         "prefix": "if",


### PR DESCRIPTION
lanaguages -> languages

## PR Summary

This PR, as the title suggests, fixes a small typo in the Function-Inline snippet's description.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests _**NA**_
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
