### PR TITLE
Fix error in HtmlContentView.ShowContent when no JS/CSS provided

### DIFF
--- a/src/features/CustomViews.ts
+++ b/src/features/CustomViews.ts
@@ -207,12 +207,18 @@ class HtmlContentView extends CustomView {
             this.webviewPanel.dispose();
         }
 
-        let localResourceRoots: vscode.Uri[] = this.htmlContent.javaScriptPaths.map((p) => {
-            return vscode.Uri.parse(path.dirname(p));
-        });
-        localResourceRoots = localResourceRoots.concat(this.htmlContent.styleSheetPaths.map((p) => {
-            return vscode.Uri.parse(path.dirname(p));
-        }));
+        let localResourceRoots: vscode.Uri[] = [];
+        if (this.htmlContent.javaScriptPaths) {
+            localResourceRoots = localResourceRoots.concat(this.htmlContent.javaScriptPaths.map((p) => {
+                return vscode.Uri.parse(path.dirname(p));
+            }));
+        }
+
+        if (this.htmlContent.styleSheetPaths) {
+            localResourceRoots = localResourceRoots.concat(this.htmlContent.styleSheetPaths.map((p) => {
+                return vscode.Uri.parse(path.dirname(p));
+            }));
+        }
 
         this.webviewPanel = vscode.window.createWebviewPanel(
             this.id,


### PR DESCRIPTION
## PR Summary

Fix undefined reference issue with the showContent method when the Set-VSCodeHtmlContentView command is not passed any JavaScript or CSS files. 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
