### PR TITLE
fix change session by moving to async/await promise

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -192,12 +192,12 @@ export function load(): ISettings {
     };
 }
 
-export function change(settingName: string, newValue: any, global: boolean = false): Thenable<void> {
+export async function change(settingName: string, newValue: any, global: boolean = false): Promise<void> {
     const configuration: vscode.WorkspaceConfiguration =
         vscode.workspace.getConfiguration(
             utils.PowerShellLanguageId);
 
-    return configuration.update(settingName, newValue, global);
+    await configuration.update(settingName, newValue, global);
 }
 
 function getWorkspaceSettingsWithDefaults<TSettings>(

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -19,4 +19,14 @@ suite("Settings module", () => {
             assert.deepEqual(settings.developer.featureFlags, []);
         }
     });
+
+    test("Settings update correctly", async () => {
+        // then syntax
+        Settings.change("powerShellExePath", "dummypath1", false).then(() =>
+            assert.strictEqual(Settings.load().powerShellExePath, "dummypath1"));
+
+        // async/await syntax
+        await Settings.change("powerShellExePath", "dummypath2", false);
+        assert.strictEqual(Settings.load().powerShellExePath, "dummypath2");
+    });
 });


### PR DESCRIPTION
## PR Summary

I'll be honest... I don't really understand why this fixed the issue... 

I _think_ it's because we use to just return the Thenable where as now we're actually awaiting the settings update... but idk... in my eyes they seem equivalent.

Also, the test I've added passes in both scenarios even though the test does a good job emulating the environment...

I can only deduce that this is a race condition with vscode updating settings in the true vscode environment (instead of test harness).

With all that said... this _does_ consistently fix the issue - and async/await is better anyway.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
