### PR TITLE
Add RunCode command for CodeLens providers

### DIFF
--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as path from "path";
+import vscode = require("vscode");
+import { IFeature, LanguageClient } from "../feature";
+import { SessionManager } from "../session";
+import Settings = require("../settings");
+import utils = require("../utils");
+
+enum LaunchType {
+    Debug,
+    Run,
+}
+
+export class RunCodeFeature implements IFeature {
+
+    private command: vscode.Disposable;
+    private languageClient: LanguageClient;
+
+    constructor(private sessionManager: SessionManager) {
+        this.command = vscode.commands.registerCommand(
+            "PowerShell.RunCode",
+            (runInDebugger: boolean, scriptToRun: string, args: string[]) => {
+                this.launchTask(runInDebugger, scriptToRun, args);
+            });
+    }
+
+    public dispose() {
+        this.command.dispose();
+    }
+
+    public setLanguageClient(languageClient: LanguageClient) {
+        this.languageClient = languageClient;
+    }
+
+    private async launchTask(
+        runInDebugger: boolean,
+        scriptToRun: string,
+        args: string[]) {
+
+        const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
+        const launchConfig = this.createLaunchConfig(launchType, scriptToRun, args);
+        this.launch(launchConfig);
+    }
+
+    private createLaunchConfig(launchType: LaunchType, scriptToRun: string, args: string[]) {
+        const currentDocument = vscode.window.activeTextEditor.document;
+        const settings = Settings.load();
+
+        // Since we pass the script path to PSES in single quotes to avoid issues with PowerShell
+        // special chars like & $ @ () [], we do have to double up the interior single quotes.
+
+        const launchConfig = {
+            request: "launch",
+            type: "PowerShell",
+            name: "PowerShell Launch Pester Tests",
+            script: scriptToRun,
+            args,
+            internalConsoleOptions: "neverOpen",
+            noDebug: (launchType === LaunchType.Run),
+            createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole,
+            cwd:
+                currentDocument.isUntitled
+                    ? vscode.workspace.rootPath
+                    : path.dirname(currentDocument.fileName),
+        };
+
+        return launchConfig;
+    }
+
+    private launch(launchConfig) {
+        // Create or show the interactive console
+        // TODO #367: Check if "newSession" mode is configured
+        vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+
+        // Write out temporary debug session file
+        utils.writeSessionFile(
+            utils.getDebugSessionFilePath(),
+            this.sessionManager.getSessionDetails());
+
+        // TODO: Update to handle multiple root workspaces.
+        vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
+    }
+}

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -63,24 +63,23 @@ export class RunCodeFeature implements IFeature {
 function createLaunchConfig(launchType: LaunchType, commandToRun: string, args: string[]) {
     const settings = Settings.load();
 
-    let currentDocument: vscode.TextDocument;
-    if (vscode.window.activeTextEditor && vscode.window.activeTextEditor.document) {
-        currentDocument = vscode.window.activeTextEditor.document;
+    let cwd: string = vscode.workspace.rootPath;
+    if (vscode.window.activeTextEditor
+        && vscode.window.activeTextEditor.document
+        && !vscode.window.activeTextEditor.document.isUntitled) {
+        cwd = path.dirname(vscode.window.activeTextEditor.document.fileName);
     }
 
     const launchConfig = {
         request: "launch",
         type: "PowerShell",
         name: "PowerShell Run Code",
-        script: commandToRun,
-        args,
         internalConsoleOptions: "neverOpen",
         noDebug: (launchType === LaunchType.Run),
         createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole,
-        cwd:
-            !currentDocument || currentDocument.isUntitled
-                ? vscode.workspace.rootPath
-                : path.dirname(currentDocument.fileName),
+        script: commandToRun,
+        args,
+        cwd,
     };
 
     return launchConfig;

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { NewFileOrProjectFeature } from "./features/NewFileOrProject";
 import { OpenInISEFeature } from "./features/OpenInISE";
 import { PesterTestsFeature } from "./features/PesterTests";
 import { RemoteFilesFeature } from "./features/RemoteFiles";
+import { RunCodeFeature } from "./features/RunCode";
 import { SelectPSSARulesFeature } from "./features/SelectPSSARules";
 import { ShowHelpFeature } from "./features/ShowHelp";
 import { Logger, LogLevel } from "./logging";
@@ -149,6 +150,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new ShowHelpFeature(logger),
         new FindModuleFeature(),
         new PesterTestsFeature(sessionManager),
+        new RunCodeFeature(sessionManager),
         new ExtensionCommandsFeature(logger),
         new SelectPSSARulesFeature(logger),
         new CodeActionsFeature(logger),

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from "assert";
+import rewire = require("rewire");
+import vscode = require("vscode");
+
+// Setup function that is not exported.
+const customViews = rewire("../../src/features/RunCode");
+const createLaunchConfig = customViews.__get__("createLaunchConfig");
+
+enum LaunchType {
+    Debug,
+    Run,
+}
+
+suite("RunCode tests", () => {
+    test("Can create the launch config", () => {
+        const commandToRun: string = "Invoke-Build";
+        const args: string[] = ["Clean"];
+
+        const expected: object = {
+            request: "launch",
+            type: "PowerShell",
+            name: "PowerShell Run Code",
+            script: commandToRun,
+            args,
+            internalConsoleOptions: "neverOpen",
+            noDebug: false,
+            createTemporaryIntegratedConsole: false,
+            cwd: vscode.workspace.rootPath,
+        };
+
+        const actual: object = createLaunchConfig(LaunchType.Debug, commandToRun, args);
+
+        assert.deepEqual(actual, expected);
+    });
+});


### PR DESCRIPTION
## PR Summary

This feature adds a generic `PowerShell.RunCode` command so that CodeLens providers have a mechanism for executing whatever code is needed in the codelens...

An example:
`Invoke-Build` could offer a `Run task | Debug task` CodeLens:

![image](https://user-images.githubusercontent.com/2644648/56858928-9080f900-6937-11e9-97f3-8432000087dd.png)

This would call `PowerShell.RunCode` so that it can run:

script: `Invoke-Build`
args: `TaskName, path/to/foo.build.ps1`

With this, Invoke-Build, psake, or any other big name module could provide CodeLens without having to ship their own extension or add to PSES directly. They can take advantage of public types already available within the PSES session and use `RunCode` to run their specific scenario.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
