### PR TITLE
Add ArgumentCompleter snippets

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1037,5 +1037,26 @@
             "})]"
         ],
         "description": "ArgumentCompleter parameter attribute with script block definition"
+    },
+    "IArgumentCompleter Class": {
+        "prefix": "completer-class",
+        "body": [
+            "class ${1:ArgumentCompleter} : System.Management.Automation.IArgumentCompleter {",
+            "\t[System.Collections.Generic.IEnumerable[System.Management.Automation.CompletionResult]] CompleteArgument(",
+            "\t\t[string] \\$CommandName,",
+            "\t\t[string] \\$ParameterName,",
+            "\t\t[string] \\$WordToComplete,",
+            "\t\t[System.Management.Automation.Language.CommandAst] \\$CommandAst,",
+            "\t\t[System.Collections.IDictionary] \\$FakeBoundParameters",
+            "\t) {",
+            "\t\t\\$CompletionResults = [System.Collections.Generic.List[System.Management.Automation.CompletionResult]]::new()",
+            "\t\t",
+            "\t\t${0:$TM_SELECTED_TEXT}",
+            "\t\t",
+            "\t\treturn \\$CompletionResults",
+            "\t}",
+            "}"
+        ],
+        "description": "IArgumentCompleter implementation class definition"
     }
 }

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1019,5 +1019,23 @@
             "}$0"
         ],
         "description": "Pester - It block"
+    },
+    "ArgumentCompleterAttribute with ScriptBlock": {
+        "prefix": "completer-attribute",
+        "body": [
+            "[ArgumentCompleter({",
+            "\t[OutputType([System.Management.Automation.CompletionResult])]  # zero to many",
+            "\tparam(",
+            "\t\t[string] \\$CommandName,",
+            "\t\t[string] \\$ParameterName,",
+            "\t\t[string] \\$WordToComplete,",
+            "\t\t[System.Management.Automation.Language.CommandAst] \\$CommandAst,",
+            "\t\t[System.Collections.IDictionary] \\$FakeBoundParameters",
+            "\t)",
+            "\t",
+            "\t${0:$TM_SELECTED_TEXT}",
+            "})]"
+        ],
+        "description": "ArgumentCompleter parameter attribute with script block definition"
     }
 }

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1038,6 +1038,24 @@
         ],
         "description": "ArgumentCompleter parameter attribute with script block definition"
     },
+    "ArgumentCompleterAttribute ScriptBlock": {
+        "prefix": "completer-scriptblock",
+        "body": [
+            "{",
+            "\t[OutputType([System.Management.Automation.CompletionResult])]  # zero to many",
+            "\tparam(",
+            "\t\t[string] \\$CommandName,",
+            "\t\t[string] \\$ParameterName,",
+            "\t\t[string] \\$WordToComplete,",
+            "\t\t[System.Management.Automation.Language.CommandAst] \\$CommandAst,",
+            "\t\t[System.Collections.IDictionary] \\$FakeBoundParameters",
+            "\t)",
+            "\t",
+            "\t${0:$TM_SELECTED_TEXT}",
+            "}"
+        ],
+        "description": "ArgumentCompleter parameter attribute script block definition"
+    },
     "IArgumentCompleter Class": {
         "prefix": "completer-class",
         "body": [


### PR DESCRIPTION
## PR Summary

Adds snippets to scaffold the implementation of [ArgumentCompleterAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.argumentcompleterattribute) and [IArgumentCompleter](https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.iargumentcompleter).

Adds the following three snippets (listed by name, not prefix):

- ArgumentCompleterAttribute with ScriptBlock
- ArgumentCompleterAttribute ScriptBlock
- IArgumentCompleter Class

The difference between the first two is that "ArgumentCompleterAttribute with ScriptBlock" inserts the attribute with the script block inline, whereas "ArgumentCompleterAttribute ScriptBlock" inserts just the script block without the surrounding attribute.  The former is intended for inline insertion in a parameter definition, whereas the latter is intended for assignment to a variable for reuse across parameters/functions.

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] `NA` ~PR has tests~
- [X] This PR is ready to merge and is not work in progress