### PR TITLE
Allow passing runspace name

### DIFF
--- a/package.json
+++ b/package.json
@@ -467,6 +467,11 @@
                 "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
                 "default": null
               },
+              "runspaceName": {
+                "type": "string",
+                "description": "Optional: The Name of the runspace to debug in the attached process.  Works only on PowerShell 5 and above.",
+                "default": null
+              },
               "customPipeName": {
                 "type": "string",
                 "description": "The custom pipe name of the PowerShell host process to attach to.  Works only on PowerShell 6.2 and above.",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -87,7 +87,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                 }
             }
 
-            if (!config.runspaceId) {
+            if (!config.runspaceId && !config.runspaceName) {
                 config.runspaceId = await vscode.commands.executeCommand("PowerShell.PickRunspace", config.processId);
 
                 // No runspace selected. Cancel attach.


### PR DESCRIPTION
## PR Summary

paired with https://github.com/PowerShell/PowerShellEditorServices/pull/951

Folks will be able to specify a `runspaceName` in their `launch.json`. For example:

```json
{
    "type": "powershell",
    "request": "attach",
    "runspaceName":"PowerShellManager",
    "customPipeName":"AzureFunctionsPSWorker"
}
```

Some actually informative `launch.json`s instead of `runspaceId: 1`!

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests - debugging tests are near impossible right now :( 
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
