### PR TITLE
Add #Requires snippets

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1105,13 +1105,13 @@
     },
     "Requires Module RequiredVersion": {
         "prefix": "requires-module-required-version",
-        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; ModuleVersion = '${2:minimum-acceptable-version}' }",
-        "description": "Requires a module (by name and minimum version) in order to execute the containing script file."
+        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; RequiredVersion = '${2:exact-required-version}' }",
+        "description": "Requires a module (by name and exact version) in order to execute the containing script file."
     },
     "Requires Module Version": {
         "prefix": "requires-module-version",
-        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; RequiredVersion = '${2:exact-required-version}' }",
-        "description": "Requires a module (by name and exact version) in order to execute the containing script file."
+        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; ModuleVersion = '${2:minimum-acceptable-version}' }",
+        "description": "Requires a module (by name and minimum version) in order to execute the containing script file."
     },
     "Requires PSEdition": {
         "prefix": "requires-ps-edition",

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1082,5 +1082,65 @@
             "}"
         ],
         "description": "IArgumentCompleter implementation class definition"
+    },
+    "Requires Assembly": {
+        "prefix": "requires-assembly",
+        "body": "#Requires -Assembly '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'",
+        "description": "Requires an assembly (by name) in order to execute the containing script file."
+    },
+    "Requires Assembly Path": {
+        "prefix": "requires-assembly-path",
+        "body": "#Requires -Assembly ${0:${TM_SELECTED_TEXT:path/to/assembly.dll}}",
+        "description": "Requires an assembly (by relative or absolute path) in order to execute the containing script file."
+    },
+    "Requires Assembly Version": {
+        "prefix": "requires-assembly-version",
+        "body": "#Requires -Assembly '${1:${TM_SELECTED_TEXT:fully-qualified-name}}, Version=${2:1.0.0.0}'",
+        "description": "Requires an assembly (by name and minimum version) in order to execute the containing script file."
+    },
+    "Requires Module": {
+        "prefix": "requires-module",
+        "body": "#Requires -Module ${0:${TM_SELECTED_TEXT:fully-qualified-name}}",
+        "description": "Requires a module (by name) in order to execute the containing script file."
+    },
+    "Requires Module RequiredVersion": {
+        "prefix": "requires-module-required-version",
+        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; ModuleVersion = '${2:minimum-acceptable-version}' }",
+        "description": "Requires a module (by name and minimum version) in order to execute the containing script file."
+    },
+    "Requires Module Version": {
+        "prefix": "requires-module-version",
+        "body": "#Requires -Module @{ ModuleName = '${1:${TM_SELECTED_TEXT:fully-qualified-name}}'; RequiredVersion = '${2:exact-required-version}' }",
+        "description": "Requires a module (by name and exact version) in order to execute the containing script file."
+    },
+    "Requires PSEdition": {
+        "prefix": "requires-ps-edition",
+        "body": "#Requires -PSEdition ${1|Core,Desktop|}",
+        "description": "Requires a specific edition of PowerShell in order to execute the containing script file."
+    },
+    "Requires PSSnapin": {
+        "prefix": "requires-ps-snapin",
+        "body": "#Requires -PSSnapin ${0:${TM_SELECTED_TEXT:fully-qualified-name}}",
+        "description": "Requires a PowerShell snap-in (by name) in order to execute the containing script file."
+    },
+    "Requires PSSnapin Version": {
+        "prefix": "requires-ps-snapin-version",
+        "body": "#Requires -PSSnapin ${1:${TM_SELECTED_TEXT:fully-qualified-name}} -Version ${2:minimum-acceptable-version}",
+        "description": "Requires a PowerShell snap-in (by name and minimum version) in order to execute the containing script file."
+    },
+    "Requires RunAsAdministrator": {
+        "prefix": "requires-run-as-administrator",
+        "body": "#Requires -RunAsAdministrator",
+        "description": "Requires elevated user rights in order to execute the containing script file. Ignored on non-Windows systems. On Windows systems, it requires that the PowerShell session in which the containing script file is run must have been started with elevated user rights (\"Run as Administrator\")."
+    },
+    "Requires ShellId": {
+        "prefix": "requires-shell-id",
+        "body": "#Requires -ShellId ${0:${TM_SELECTED_TEXT:shell-id}}",
+        "description": "Requires a specific shell id in order to execute the containing script file. The current shell id may be determined by querying the $ShellId automatic variable."
+    },
+    "Requires Version": {
+        "prefix": "requires-version",
+        "body": "#Requires -Version ${0:${TM_SELECTED_TEXT:minimum-acceptable-version}}",
+        "description": "Requires a minimum version of PowerShell in order to execute the containing script file."
     }
 }

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -1,3 +1,4 @@
+// The "Requires *" snippets should be removed if-and-when intellisense is implemented for the script requirement directive syntax.
 {
     "ModuleManifest": {
         "prefix": "manifest",


### PR DESCRIPTION
## PR Summary

Adds snippets for the various [script requirement directive parameterizations](about-requires). Also includes convenience snippets for some of the more specific common-but-verbose parameter sets.

Adds the following snippets (listed by name, not prefix):

- "Requires Assembly"
- "Requires Assembly Path"
- "Requires Assembly Version"
- "Requires Module"
- "Requires Module RequiredVersion"
- "Requires Module Version"
- "Requires PSEdition"
- "Requires PSSnapin"
- "Requires PSSnapin Version"
- "Requires RunAsAdministrator"
- "Requires ShellId"
- "Requires Version"

### Notes:

- The [About Requires] help documents the `-Modules` parameter only in the plural, but the [`ScriptRequirements` Class] API documentation demonstrates that that parameter can also be used in the singular (i.e. `-Module`), as these snippets use it.

- The `-Assembly` parameter is not documented in the [About Requires] help, but is supported as demonstrated by the [`ScriptRequirements` Class] API documentation.

## PR Checklist

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] `NA` ~~PR has tests~~
- [X] This PR is ready to merge and is not work in progress

[About Requires]:
<https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires>
'About Requires Help'

[`ScriptRequirements` Class]:
<https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.language.scriptrequirements>
'ScriptRequirements Class'
