### PR TITLE
Update version only in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "powershell-preview",
   "displayName": "PowerShell Preview",
-  "version": "2.0.0-preview.3",
+  "version": "2019.5.0",
   "preview": true,
   "publisher": "ms-vscode",
   "description": "(Preview) Develop PowerShell scripts in Visual Studio Code!",

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -162,6 +162,10 @@ task UpdatePackageJson {
 
     $script:PackageJson.version = "$($currentDate.ToString('yyyy.M')).$revision"
 
+    if ($env:TF_BUILD) {
+        $script:PackageJson.version += "-CI.$env:BUILD_BUILDID"
+    }
+
     $Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllLines(
         (Resolve-Path "$PSScriptRoot/package.json").Path,

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -139,7 +139,7 @@ task UpdateReadme -If { $script:PackageJson.version -like "*preview*" } {
 }
 
 task UpdatePackageJson {
-    if ($script:PackageJson.version -like "*preview*") {
+    if ($script:PackageJson.name -like "*preview*" -or $script:PackageJson.displayName -like "*preview*") {
         $script:PackageJson.name = "powershell-preview"
         $script:PackageJson.displayName = "PowerShell Preview"
         $script:PackageJson.description = "(Preview) Develop PowerShell scripts in Visual Studio Code!"
@@ -151,8 +151,16 @@ task UpdatePackageJson {
         $script:PackageJson.preview = $false
     }
 
-    $revision = if ($env:BUILD_BUILDID) { $env:BUILD_BUILDID } else { 9999 }
-    $script:PackageJson.version = "$(Get-Date -Format 'yyyy.M').$revision"
+    $currentVersion = [version](($script:PackageJson.version -split "-")[0])
+    $currentDate = Get-Date
+
+    $revision = if ($currentDate.Month -eq $currentVersion.Minor) {
+        $currentVersion.Build + 1
+    } else {
+        0
+    }
+
+    $script:PackageJson.version = "$($currentDate.ToString('yyyy.M')).$revision"
 
     $Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($false)
     [System.IO.File]::WriteAllLines(
@@ -161,7 +169,7 @@ task UpdatePackageJson {
         $Utf8NoBomEncoding)
 }
 
-task Package UpdateReadme, UpdatePackageJson, {
+task Package UpdateReadme, {
 
     if ($script:psesBuildScriptPath) {
         Write-Host "`n### Copying PowerShellEditorServices module files" -ForegroundColor Green
@@ -186,4 +194,4 @@ task Package UpdateReadme, UpdatePackageJson, {
 # The set of tasks for a release
 task Release Clean, Build, Test, Package
 # The default task is to run the entire CI build
-task . CleanAll, BuildAll, Test, Package, UploadArtifacts
+task . CleanAll, BuildAll, Test, UpdatePackageJson, Package, UploadArtifacts


### PR DESCRIPTION
I think we've finally settled on a version scheme and when to set it... This will set the version only in CI and not in releases. Releases will depend on the version that's already there.