### PR TITLE
Fix README edit by using name instead of version

### DIFF
--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -11,6 +11,7 @@ param(
 
 # Grab package.json data which is used throughout the build.
 $script:PackageJson = Get-Content -Raw $PSScriptRoot/package.json | ConvertFrom-Json
+$script:IsPreviewExtension = $script:PackageJson.name -like "*preview*" -or $script:PackageJson.displayName -like "*preview*"
 Write-Host "`n### Extension Version: $($script:PackageJson.version) Extension Name: $($script:PackageJson.name)`n" -ForegroundColor Green
 
 #region Utility tasks
@@ -122,7 +123,7 @@ task TestAll TestEditorServices, Test
 
 #region Package tasks
 
-task UpdateReadme -If { $script:PackageJson.version -like "*preview*" } {
+task UpdateReadme -If { $script:IsPreviewExtension } {
     # Add the preview text
     $newReadmeTop = '# PowerShell Language Support for Visual Studio Code
 
@@ -139,7 +140,7 @@ task UpdateReadme -If { $script:PackageJson.version -like "*preview*" } {
 }
 
 task UpdatePackageJson {
-    if ($script:PackageJson.name -like "*preview*" -or $script:PackageJson.displayName -like "*preview*") {
+    if ($script:IsPreviewExtension) {
         $script:PackageJson.name = "powershell-preview"
         $script:PackageJson.displayName = "PowerShell Preview"
         $script:PackageJson.description = "(Preview) Develop PowerShell scripts in Visual Studio Code!"


### PR DESCRIPTION
I missed this in the switch to using the date as the version.