### PR TITLE
Fix node version detect logic to handle node v10

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -45,12 +45,17 @@ function needsVSCode () {
 
 function needsNodeJS () {
     try {
-        $nodeJSVersion = (node -v)
-
+        $nodeJSVersion = node -v
     } catch {
         return $true
     }
-    return ($nodeJSVersion.Substring(1,1) -lt 6)
+
+    if ($nodeJSVersion -notmatch 'v(\d+\.\d+\.\d+)') {
+        return $true
+    }
+
+    $nodeVer = [System.Version]$matches[1]
+    return ($nodeVer.Major -lt 6)
 }
 
 function needsPowerShellGet () {


### PR DESCRIPTION
## PR Summary

The script told me I needed nodeJS v6 or higher but I have node 10.  The script wasn't handling a two digit major version.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
