### PR TITLE
#1019: Get format settings from document editor instead of global.

### DIFF
--- a/src/features/DocumentFormatter.ts
+++ b/src/features/DocumentFormatter.ts
@@ -246,7 +246,7 @@ class PSDocumentFormattingEditProvider implements
         const requestParams: DocumentRangeFormattingParams = {
             textDocument: TextDocumentIdentifier.create(document.uri.toString()),
             range: rangeParam,
-            options: this.getEditorSettings(),
+            options: this.getEditorSettings(editor),
         };
 
         const formattingStartTime = new Date().valueOf();
@@ -309,11 +309,12 @@ class PSDocumentFormattingEditProvider implements
         PSDocumentFormattingEditProvider.documentLocker.lock(document, unlockWhenDone);
     }
 
-    private getEditorSettings(): { insertSpaces: boolean, tabSize: number } {
-        const editorConfiguration = vscode.workspace.getConfiguration("editor");
+    private getEditorSettings(editor: TextEditor): { insertSpaces: boolean, tabSize: number } {
+        // Writing the editor options allows string or strong types going in, but always
+        // resolves to an appropriate value on read.
         return {
-            insertSpaces: editorConfiguration.get<boolean>("insertSpaces"),
-            tabSize: editorConfiguration.get<number>("tabSize"),
+            insertSpaces: editor.options.insertSpaces as boolean,
+            tabSize: editor.options.tabSize as number,
         };
     }
 }


### PR DESCRIPTION
## PR Summary

Change the document formatter so indent settings come from the document-specific editor rather than global configuration. This allows language-specific overrides and other things like EditorConfig to modify the settings and the document formatter will obey.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [NA] PR has tests
- [X] This PR is ready to merge and is not work in progress
