### PR TITLE
Update PSSA docs Url to point to master branch because master is now the default branch

### DIFF
--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -42,7 +42,7 @@ export class CodeActionsFeature implements IFeature {
     }
 
     public showRuleDocumentation(ruleId: string) {
-        const pssaDocBaseURL = "https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation";
+        const pssaDocBaseURL = "https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation";
 
         if (!ruleId) {
             this.log.writeWarning("Cannot show documentation for code action, no ruleName was supplied.");


### PR DESCRIPTION
## PR Summary

Update PSSA docs Url to point to master branch because master is now the default branch. We will keep the `development` branch for legacy purposes but new development happens now on master.
This change needs to be backported to 1.x

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
