### PR TITLE
add machine scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "ms-vscode",
   "description": "(Preview) Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.31.0"
+    "vscode": "^1.34.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
@@ -545,12 +545,14 @@
         "powershell.powerShellExePath": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "isExecutable": true,
           "description": "Specifies the full path to a PowerShell executable. Changes the installation of PowerShell used for language and debugging services."
         },
         "powershell.powerShellAdditionalExePaths": {
           "type": "array",
           "description": "Specifies an array of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
+          "scope": "machine",
           "isExecutable": true,
           "uniqueItems": true,
           "items": {
@@ -755,6 +757,7 @@
         "powershell.developer.powerShellExePath": {
           "type": "string",
           "default": "",
+          "scope": "machine",
           "isExecutable": true,
           "description": "Deprecated. Please use the 'powershell.powerShellExePath' setting instead"
         }

--- a/package.json
+++ b/package.json
@@ -546,14 +546,12 @@
           "type": "string",
           "default": "",
           "scope": "machine",
-          "isExecutable": true,
           "description": "Specifies the full path to a PowerShell executable. Changes the installation of PowerShell used for language and debugging services."
         },
         "powershell.powerShellAdditionalExePaths": {
           "type": "array",
           "description": "Specifies an array of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
           "scope": "machine",
-          "isExecutable": true,
           "uniqueItems": true,
           "items": {
             "type": "object",
@@ -753,13 +751,6 @@
           "type": "boolean",
           "default": false,
           "description": "Indicates that the powerShellExePath points to a developer build of Windows PowerShell and configures it for development."
-        },
-        "powershell.developer.powerShellExePath": {
-          "type": "string",
-          "default": "",
-          "scope": "machine",
-          "isExecutable": true,
-          "description": "Deprecated. Please use the 'powershell.powerShellExePath' setting instead"
         }
       }
     },

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -22,11 +22,20 @@ suite("Settings module", () => {
 
     test("Settings update correctly", async () => {
         // then syntax
-        Settings.change("powerShellExePath", "dummypath1", false).then(() =>
-            assert.strictEqual(Settings.load().powerShellExePath, "dummypath1"));
+        Settings.change("helpCompletion", "BlockComment", false).then(() =>
+            assert.strictEqual(Settings.load().helpCompletion, "BlockComment"));
 
         // async/await syntax
-        await Settings.change("powerShellExePath", "dummypath2", false);
-        assert.strictEqual(Settings.load().powerShellExePath, "dummypath2");
+        await Settings.change("helpCompletion", "LineComment", false);
+        assert.strictEqual(Settings.load().helpCompletion, "LineComment");
+    });
+
+    test("Settings that can only be user settings update correctly", async () => {
+        // set to false means it's set as a workspace-level setting so this should throw.
+        assert.rejects(async () => await Settings.change("powerShellExePath", "dummyPath", false));
+
+        // set to true means it's a user-level setting so this should not throw.
+        await Settings.change("powerShellExePath", "dummyPath", true);
+        assert.strictEqual(Settings.load().powerShellExePath, "dummyPath");
     });
 });


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/vscode-powershell/issues/2024

Per the vscode team's request, we now need to mark executables with a `scope: "machine"` to aid in remote development scenarios.

@sandy081 is there a recommended way to test this change? I couldn't use Remote - Container because it just gives me the latest release of the PowerShell extension.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] N/A PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
