### PR TITLE
Legacy/node types v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powershell",
-  "version": "1.12.1",
+  "version": "2019.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -39,9 +39,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.2.tgz",
-      "integrity": "sha512-5tabW/i+9mhrfEOUcLDu2xBPsHJ+X5Orqy9FKpale3SjDA17j5AEpYq5vfy3oAeAHGcvANRCO3NV3d2D6q3NiA==",
+      "version": "10.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
+      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
       "dev": true
     },
     "@types/rewire": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "@types/mocha": "~5.2.6",
-    "@types/node": "~12.0.2",
+    "@types/node": "~10.11.0",
     "@types/rewire": "^2.5.28",
     "mocha": "~5.2.0",
     "mocha-junit-reporter": "~1.22.0",


### PR DESCRIPTION
Brings the node types back to VSCode's version in legacy