### PR TITLE
Remove redundant snippets

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -513,7 +513,10 @@
         "description": "Enum definition snippet"
     },
     "Function-Advanced": {
-        "prefix": "function-advanced",
+        "prefix": [
+            "function-advanced",
+            "cmdlet"
+        ],
         "body": [
             "function ${1:Verb-Noun} {",
             "\t[CmdletBinding()]",

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -539,7 +539,7 @@
         ],
         "description": "Script advanced function definition snippet"
     },
-    "Cmdlet-Comment-Help": {
+    "Comment-Help": {
         "prefix": "comment-help",
         "body": [
             "<#",
@@ -558,7 +558,7 @@
             "\tGeneral notes",
             "#>"
         ],
-        "description": "Comment-based help snippet"
+        "description": "Comment-based help for an advanced function snippet"
     },
     "Parameter": {
         "prefix": "parameter",

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -512,30 +512,6 @@
         ],
         "description": "Enum definition snippet"
     },
-    "Cmdlet": {
-        "prefix": "cmdlet",
-        "body": [
-            "function ${1:Verb-Noun} {",
-            "\t[CmdletBinding()]",
-            "\tparam (",
-            "\t\t$0",
-            "\t)",
-            "\t",
-            "\tbegin {",
-            "\t\t",
-            "\t}",
-            "\t",
-            "\tprocess {",
-            "\t\t$TM_SELECTED_TEXT",
-            "\t}",
-            "\t",
-            "\tend {",
-            "\t\t",
-            "\t}",
-            "}"
-        ],
-        "description": "Script cmdlet definition snippet"
-    },
     "Function-Advanced": {
         "prefix": "function-advanced",
         "body": [
@@ -931,7 +907,7 @@
 		"body": [
 			"[Diagnostics.CodeAnalysis.SuppressMessageAttribute('${1:PSProvideDefaultParameterValue}', '', Scope='Function', Target='${2:*}')]"
 		]
-	},
+    },
     "PSCustomObject": {
         "prefix": "PSCustomObject",
         "body": [


### PR DESCRIPTION
Remove the following snippets (listed by name, not prefix):

- `Cmdlet`

The *removed-redundant-snippet* to *kept-redundantee-snippet* mappings are as follows (listed by name, not prefix):

- `Cmdlet` : `Function-Advanced`  
  The decision to remove `Cmdlet` instead of `Function-Advanced` is because a function defined in PowerShell with the `CmdletBinding` attribute is technically an advanced function rather than a cmdlet, which would be defined in C# with the `Cmdlet` attribute.  

  However, the `cmdlet` prefix has also been added to the `Function-Advanced` snippet (whose other prefix is `function-advanced`), because `cmdlet` is an ISE snippet prefix for an advanced function and so should be preserved for compatibility.