### PR TITLE
Update '.vscode/settings.json' to identify snippet files as 'JSON with Comments'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,11 @@
     // Add a visual ruler for the typescript linting line length
     "editor.rulers": [120],
 
+    "files.associations": {
+        // Use JSONC instead of JSON because (1) that's how VS Code interprets snippet files, and (2) it enables better source documentation.
+        "**/snippets/*.json": "jsonc"
+    },
+
     "search.exclude": {
         "**/node_modules": true,
         "**/bower_components": true,


### PR DESCRIPTION
## PR Summary

Updates the folder VS Code settings (i.e. .vscode/settings.json) to add

```json
"files.associations": {
    "**/snippets/*.json": "jsonc"
}
```

This addition causes the developer's VS Code editor to associate snippets files with the "JSON with Comments" language, rather than "JSON".

This addition is motivated by the need for better source documentation of snippets (e.g. whether a particular prefix should be preserved for ISE compatibility). Obversely, this addition is justified by the fact that VS Code associates (known) snippet files with the "JSON with Comments" language anyway.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] ~~PR has tests~~
- [x] This PR is ready to merge and is not work in progress