### PR TITLE
Add snippet 'foreach-indexed'

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -766,6 +766,17 @@
         ],
         "description": "foreach loop snippet"
     },
+    "foreach-indexed": {
+        "prefix": "foreach-indexed",
+        "body": [
+            "\\$private:_index = 0",
+            "foreach ($${1:item} in $${2:collection}) {",
+            "\t\\$index = (\\$_index++)",  // Instead of incrementing the index at the end of the loop body, incrementing it at the beginning (and therefore also assigning a proxy variable) defends against naive invocations of the `continue` statement in the middle of the loop body.
+            "\t${0:$TM_SELECTED_TEXT}",
+            "}"
+        ],
+        "description": "indexed foreach loop snippet"
+    },
     "function": {
         "prefix": "function",
         "body": [


### PR DESCRIPTION
<!-- markdownlint-disable  -->

## PR Summary

Adds a snippet named `foreach-indexed`.

The `foreach-indexed` snippet enumerates a collection using a `foreach` loop, but also tracks the index of the current item in the process. Regarding *motivation*, the use cases of the `foreach-indexed` construct (which enumerates element-to-index) are somewhat the opposite of the `for` construct (which enumerates index-to-element): synthetically indexing an unordered collection (e.g. a `HashSet`), relatively indexing a live enumerator (vs. an absolutely-indexed enumerable), etc. Regarding *justification*, the logic sequencing required by the `foreach-indexed` construct to defend against naive uses of the `continue` keyword in the middle of the loop body (i.e. continuing without also incrementing the index) is both unconventional as well as more verbose than the conventional pattern (i.e. of incrementing the index at the end of the loop body).

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] `NA` ~~PR has tests~~
- [x] This PR is ready to merge and is not work in progress
