### PR TITLE
Add param-block snippet

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -571,6 +571,17 @@
         ],
         "description": "Parameter declaration snippet"
     },
+    "Parameter_Block" : {
+        "prefix": "param-block",
+        "body": ["[CmdletBinding()]",
+            "param (",
+            "    [parameter()]",
+            "    [${1:TypeName}]",
+            "    $${2:ParameterName}$0",
+            ")"
+	],
+        "description": "A Parameter block to get you started."
+    },
     "Parameter-Path": {
         "prefix": "parameter-path",
         "body": [

--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -575,7 +575,7 @@
         "prefix": "param-block",
         "body": ["[CmdletBinding()]",
             "param (",
-            "    [parameter()]",
+            "    [Parameter()]",
             "    [${1:TypeName}]",
             "    $${2:ParameterName}$0",
             ")"


### PR DESCRIPTION

## PR Summary

Added a basic parameter block (At line 574 of powershell.json) that includes the cmdletbinding attribute.

As a user I would like a snippet to make it easier to add a param() section with one parameter declaration to help me get started with a script or function.
  
The cursor is deposited to the right of the parameter variable.  If the user would like to add more parameters, they can type the comma, and proceed to use the "param" snippet to add another parameter.

This addresses issue #2080


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
