### PR TITLE
Implement #1611 - provide dynamic debug config

### DIFF
--- a/package.json
+++ b/package.json
@@ -340,20 +340,6 @@
             }
           },
           {
-            "label": "PowerShell: Launch Current File w/Args Prompt",
-            "description": "Launch and debug the file in the currently active editor window, prompting first for arguments",
-            "body": {
-              "name": "PowerShell Launch Current File w/Args Prompt",
-              "type": "PowerShell",
-              "request": "launch",
-              "script": "^\"\\${file}\"",
-              "args": [
-                "^\"\\${command:SpecifyScriptArgs}\""
-              ],
-              "cwd": "^\"\\${file}\""
-            }
-          },
-          {
             "label": "PowerShell: Launch Script",
             "description": "Launch and debug the specified file or command",
             "body": {

--- a/package.json
+++ b/package.json
@@ -330,19 +330,18 @@
         "configurationSnippets": [
           {
             "label": "PowerShell: Launch Current File",
-            "description": "Launch current file (in active editor window) under debugger",
+            "description": "Launch and debug the file in the currently active editor window",
             "body": {
               "name": "PowerShell Launch Current File",
               "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
-              "args": [],
               "cwd": "^\"\\${file}\""
             }
           },
           {
             "label": "PowerShell: Launch Current File w/Args Prompt",
-            "description": "Launch current file (in active editor window) under debugger, prompting first for script arguments",
+            "description": "Launch and debug the file in the currently active editor window, prompting first for arguments",
             "body": {
               "name": "PowerShell Launch Current File w/Args Prompt",
               "type": "PowerShell",
@@ -356,46 +355,33 @@
           },
           {
             "label": "PowerShell: Launch Script",
-            "description": "Launch specified script or path to script under debugger",
+            "description": "Launch and debug the specified file or command",
             "body": {
-              "name": "PowerShell Launch ${Script}",
+              "name": "PowerShell Launch Script",
               "type": "PowerShell",
               "request": "launch",
-              "script": "^\"\\${workspaceFolder}/${Script}\"",
-              "args": [],
+              "script": "^\"enter path or command to execute e.g.: \\${workspaceFolder}/src/foo.ps1 or Invoke-Pester\"",
               "cwd": "^\"\\${workspaceFolder}\""
-            }
-          },
-          {
-            "label": "PowerShell: Pester Tests",
-            "description": "Invokes Pester tests under debugger",
-            "body": {
-              "name": "PowerShell Pester Tests",
-              "type": "PowerShell",
-              "request": "launch",
-              "script": "Invoke-Pester",
-              "args": [],
-              "cwd": "^\"\\${workspaceFolder}\""
-            }
-          },
-          {
-            "label": "PowerShell: Attach to PowerShell Host Process",
-            "description": "Open host process picker to select process to attach debugger to",
-            "body": {
-              "name": "PowerShell Attach to Host Process",
-              "type": "PowerShell",
-              "request": "attach",
-              "runspaceId": 1
             }
           },
           {
             "label": "PowerShell: Interactive Session",
-            "description": "Start interactive session (Debug Console) under debugger",
+            "description": "Debug commands executed from the Integrated Console",
             "body": {
               "name": "PowerShell Interactive Session",
               "type": "PowerShell",
               "request": "launch",
               "cwd": ""
+            }
+          },
+          {
+            "label": "PowerShell: Attach to PowerShell Host Process",
+            "description": "Attach the debugger to a running PowerShell Host Process",
+            "body": {
+              "name": "PowerShell Attach to Host Process",
+              "type": "PowerShell",
+              "request": "attach",
+              "runspaceId": 1
             }
           },
           {
@@ -418,7 +404,7 @@
               },
               "args": {
                 "type": "array",
-                "description": "Command line arguments to pass to the PowerShell script. Specify ${command:SpecifyScriptArgs} if you want to be prompted for the args.",
+                "description": "Command line arguments to pass to the PowerShell script. Specify \"${command:SpecifyScriptArgs}\" if you want to be prompted for the args.",
                 "items": {
                   "type": "string"
                 },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "main": "./out/src/main",
   "activationEvents": [
+    "onDebugInitialConfigurations",
     "onDebugResolve:powershell",
     "onLanguage:powershell",
     "onCommand:PowerShell.NewProjectFromTemplate",
@@ -66,6 +67,11 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "contributes": {
+    "breakpoints": [
+      {
+        "language": "powershell"
+      }
+    ],
     "viewsContainers": {
       "activitybar": [
         {
@@ -311,11 +317,6 @@
       {
         "type": "PowerShell",
         "label": "PowerShell",
-        "enableBreakpointsFor": {
-          "languageIds": [
-            "powershell"
-          ]
-        },
         "program": "./out/src/debugAdapter.js",
         "runtime": "node",
         "variables": {
@@ -337,19 +338,6 @@
               "script": "^\"\\${file}\"",
               "args": [],
               "cwd": "^\"\\${file}\""
-            }
-          },
-          {
-            "label": "PowerShell: Launch Current File in Temporary Console",
-            "description": "Launch current file (in active editor window) under debugger in a temporary Integrated Console.",
-            "body": {
-              "name": "PowerShell Launch Current File in Temporary Console",
-              "type": "PowerShell",
-              "request": "launch",
-              "script": "^\"\\${file}\"",
-              "args": [],
-              "cwd": "^\"\\${file}\"",
-              "createTemporaryIntegratedConsole": true
             }
           },
           {
@@ -430,7 +418,7 @@
               },
               "args": {
                 "type": "array",
-                "description": "Command line arguments to pass to the PowerShell script.",
+                "description": "Command line arguments to pass to the PowerShell script. Specify ${command:SpecifyScriptArgs} if you want to be prompted for the args.",
                 "items": {
                   "type": "string"
                 },
@@ -480,52 +468,7 @@
             }
           }
         },
-        "initialConfigurations": [
-          {
-            "name": "PowerShell Launch Current File",
-            "type": "PowerShell",
-            "request": "launch",
-            "script": "${file}",
-            "args": [],
-            "cwd": "${file}"
-          },
-          {
-            "name": "PowerShell Launch Current File in Temporary Console",
-            "type": "PowerShell",
-            "request": "launch",
-            "script": "${file}",
-            "args": [],
-            "cwd": "${file}",
-            "createTemporaryIntegratedConsole": true
-          },
-          {
-            "name": "PowerShell Launch Current File w/Args Prompt",
-            "type": "PowerShell",
-            "request": "launch",
-            "script": "${file}",
-            "args": [
-              "${command:SpecifyScriptArgs}"
-            ],
-            "cwd": "${file}"
-          },
-          {
-            "name": "PowerShell Attach to Host Process",
-            "type": "PowerShell",
-            "request": "attach"
-          },
-          {
-            "name": "PowerShell Interactive Session",
-            "type": "PowerShell",
-            "request": "launch",
-            "cwd": ""
-          },
-          {
-            "name": "PowerShell Attach Interactive Session Runspace",
-            "type": "PowerShell",
-            "request": "attach",
-            "processId": "current"
-          }
-        ]
+        "initialConfigurations": []
       }
     ],
     "configuration": {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import path = require("path");
 import vscode = require("vscode");
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider,
     ExtensionContext, WorkspaceFolder } from "vscode";
@@ -90,7 +89,9 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     cwd: "${file}",
                 },
             ];
-        } else if (launchSelection.id === launchScriptId) {
+        }
+
+        if (launchSelection.id === launchScriptId) {
             return [
                 {
                     name: "PowerShell: Launch Script",
@@ -100,7 +101,9 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     cwd: "${workspaceFolder}",
                 },
             ];
-        } else if (launchSelection.id === interactiveSessionId) {
+        }
+
+        if (launchSelection.id === interactiveSessionId) {
             return [
                 {
                     name: "PowerShell: Interactive Session",
@@ -111,7 +114,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
             ];
         }
 
-        // Return the "Attach to PowerShell Host Process" debug configuration
+        // Last remaining possibility is attach to host process
         return [
             {
                 name: "PowerShell: Attach to PowerShell Host Process",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -47,82 +47,74 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
         folder: WorkspaceFolder | undefined,
         token?: CancellationToken): Promise<DebugConfiguration[]> {
 
-        const launchAttachItems = [
-            { label: "Launch",
-              description: "Launch the debugger with a specified script or for the interactive session" },
-            { label: "Attach",
-              description: "Attach the debugger to a running PowerShell Host Process" },
+        const launchCurrentFileLabel  = "Launch Current File";
+        const launchScriptLabel       = "Launch Script";
+        const interactiveSessionLabel = "Interactive Session";
+
+        const debugConfigPickItems = [
+            {
+                label: launchCurrentFileLabel,
+                description: "Launch and debug the file in the currently active editor window",
+            },
+            {
+                label: launchScriptLabel,
+                description: "Launch and debug the specified file or command",
+            },
+            {
+                label: interactiveSessionLabel,
+                description: "Debug commands executed from the Integrated Console",
+            },
+            {
+                label: "Attach",
+                description: "Attach the debugger to a running PowerShell Host Process",
+            },
         ];
 
-        const debugTypeSelection =
+        const launchSelection =
             await vscode.window.showQuickPick(
-                launchAttachItems,
-                { placeHolder: "Would you like to launch or attach the PowerShell debugger?" });
+                debugConfigPickItems,
+                { placeHolder: "Select a PowerShell debug configuration" });
 
-        let debugConfiguration = [];
-
-        if (debugTypeSelection.label === "Launch") {
-            const launchCurrentFileLabel = "Launch Current File";
-            const launchScriptLabel = "Launch Script";
-            const interactiveSessionLabel = "Interactive Session";
-
-            const launchItems = [
-                { label: launchCurrentFileLabel,
-                  description: "Debugs whichever script is in the active editor window" },
-                { label: launchScriptLabel,
-                  description: "Debugs the specified script" },
-                { label: interactiveSessionLabel,
-                  description: "Debugs scripts or modules executed from the Integrated Console" },
-            ];
-
-            const launchSelection =
-                await vscode.window.showQuickPick(
-                    launchItems,
-                    { placeHolder: "Select a launch option" });
-
-            if (launchSelection.label === launchCurrentFileLabel) {
-                debugConfiguration = [
-                    {
-                        name: "PowerShell: Launch Current File",
-                        type: "PowerShell",
-                        request: "launch",
-                        script: "${file}",
-                        cwd: "${file}",
-                    },
-                ];
-            } else if (launchSelection.label === launchScriptLabel) {
-                debugConfiguration = [
-                    {
-                        name: "PowerShell: Launch Script",
-                        type: "PowerShell",
-                        request: "launch",
-                        script: "enter path or script to execute e.g.: ${workspaceFolder}/src/foo.ps1 or Invoke-Pester",
-                        cwd: "${workspaceFolder}",
-                    },
-                ];
-            } else {
-                debugConfiguration = [
-                    {
-                        name: "PowerShell: Interactive Session",
-                        type: "PowerShell",
-                        request: "launch",
-                        cwd: "",
-                    },
-                ];
-            }
-        } else {
-            // Return the "Attach to PowerShell Host Process" debug configuration
-            debugConfiguration =  [
+        if (launchSelection.label === launchCurrentFileLabel) {
+            return [
                 {
-                    name: "PowerShell: Attach to PowerShell Host Process",
+                    name: "PowerShell: Launch Current File",
                     type: "PowerShell",
-                    request: "attach",
-                    runspaceId: 1,
+                    request: "launch",
+                    script: "${file}",
+                    cwd: "${file}",
+                },
+            ];
+        } else if (launchSelection.label === launchScriptLabel) {
+            return [
+                {
+                    name: "PowerShell: Launch Script",
+                    type: "PowerShell",
+                    request: "launch",
+                    script: "enter path or command to execute e.g.: ${workspaceFolder}/src/foo.ps1 or Invoke-Pester",
+                    cwd: "${workspaceFolder}",
+                },
+            ];
+        } else if (launchSelection.label === interactiveSessionLabel) {
+            return [
+                {
+                    name: "PowerShell: Interactive Session",
+                    type: "PowerShell",
+                    request: "launch",
+                    cwd: "",
                 },
             ];
         }
 
-        return debugConfiguration;
+        // Return the "Attach to PowerShell Host Process" debug configuration
+        return [
+            {
+                name: "PowerShell: Attach to PowerShell Host Process",
+                type: "PowerShell",
+                request: "attach",
+                runspaceId: 1,
+            },
+        ];
     }
 
     // DebugConfigurationProvider method

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -2,9 +2,10 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
+import path = require("path");
 import vscode = require("vscode");
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider,
-    ExtensionContext, ProviderResult, WorkspaceFolder } from "vscode";
+    ExtensionContext, WorkspaceFolder } from "vscode";
 import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
 import { getPlatformDetails, OperatingSystem } from "../platform";
@@ -40,6 +41,88 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     type: "PowerShell",
                     name: "PowerShell Interactive Session",
         }));
+    }
+
+    public async provideDebugConfigurations(
+        folder: WorkspaceFolder | undefined,
+        token?: CancellationToken): Promise<DebugConfiguration[]> {
+
+        const launchAttachItems = [
+            { label: "Launch",
+              description: "Launch the debugger with a specified script or for the interactive session" },
+            { label: "Attach",
+              description: "Attach the debugger to a running PowerShell Host Process" },
+        ];
+
+        const debugTypeSelection =
+            await vscode.window.showQuickPick(
+                launchAttachItems,
+                { placeHolder: "Would you like to launch or attach the PowerShell debugger?" });
+
+        let debugConfiguration = [];
+
+        if (debugTypeSelection.label === "Launch") {
+            const launchCurrentFileLabel = "Launch Current File";
+            const launchScriptLabel = "Launch Script";
+            const interactiveSessionLabel = "Interactive Session";
+
+            const launchItems = [
+                { label: launchCurrentFileLabel,
+                  description: "Debugs whichever script is in the active editor window" },
+                { label: launchScriptLabel,
+                  description: "Debugs the specified script" },
+                { label: interactiveSessionLabel,
+                  description: "Debugs scripts or modules executed from the Integrated Console" },
+            ];
+
+            const launchSelection =
+                await vscode.window.showQuickPick(
+                    launchItems,
+                    { placeHolder: "Select a launch option" });
+
+            if (launchSelection.label === launchCurrentFileLabel) {
+                debugConfiguration = [
+                    {
+                        name: "PowerShell: Launch Current File",
+                        type: "PowerShell",
+                        request: "launch",
+                        script: "${file}",
+                        cwd: "${file}",
+                    },
+                ];
+            } else if (launchSelection.label === launchScriptLabel) {
+                debugConfiguration = [
+                    {
+                        name: "PowerShell: Launch Script",
+                        type: "PowerShell",
+                        request: "launch",
+                        script: "enter path or script to execute e.g.: ${workspaceFolder}/src/foo.ps1 or Invoke-Pester",
+                        cwd: "${workspaceFolder}",
+                    },
+                ];
+            } else {
+                debugConfiguration = [
+                    {
+                        name: "PowerShell: Interactive Session",
+                        type: "PowerShell",
+                        request: "launch",
+                        cwd: "",
+                    },
+                ];
+            }
+        } else {
+            // Return the "Attach to PowerShell Host Process" debug configuration
+            debugConfiguration =  [
+                {
+                    name: "PowerShell: Attach to PowerShell Host Process",
+                    type: "PowerShell",
+                    request: "attach",
+                    runspaceId: 1,
+                },
+            ];
+        }
+
+        return debugConfiguration;
     }
 
     // DebugConfigurationProvider method
@@ -161,13 +244,13 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     }
 
                     if ((currentDocument.languageId !== "powershell") || !isValidExtension) {
-                        let path = currentDocument.fileName;
+                        let docPath = currentDocument.fileName;
                         const workspaceRootPath = vscode.workspace.rootPath;
                         if (currentDocument.fileName.startsWith(workspaceRootPath)) {
-                            path = currentDocument.fileName.substring(vscode.workspace.rootPath.length + 1);
+                            docPath = currentDocument.fileName.substring(vscode.workspace.rootPath.length + 1);
                         }
 
-                        const msg = "PowerShell does not support debugging this file type: '" + path + "'.";
+                        const msg = "PowerShell does not support debugging this file type: '" + docPath + "'.";
                         vscode.window.showErrorMessage(msg);
                         return;
                     }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -47,24 +47,29 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
         folder: WorkspaceFolder | undefined,
         token?: CancellationToken): Promise<DebugConfiguration[]> {
 
-        const launchCurrentFileLabel  = "Launch Current File";
-        const launchScriptLabel       = "Launch Script";
-        const interactiveSessionLabel = "Interactive Session";
+        const launchCurrentFileId  = 0;
+        const launchScriptId       = 1;
+        const interactiveSessionId = 2;
+        const attachHostProcessId  = 3;
 
         const debugConfigPickItems = [
             {
-                label: launchCurrentFileLabel,
+                id: launchCurrentFileId,
+                label: "Launch Current File",
                 description: "Launch and debug the file in the currently active editor window",
             },
             {
-                label: launchScriptLabel,
+                id: launchScriptId,
+                label: "Launch Script",
                 description: "Launch and debug the specified file or command",
             },
             {
-                label: interactiveSessionLabel,
+                id: interactiveSessionId,
+                label: "Interactive Session",
                 description: "Debug commands executed from the Integrated Console",
             },
             {
+                id: attachHostProcessId,
                 label: "Attach",
                 description: "Attach the debugger to a running PowerShell Host Process",
             },
@@ -75,7 +80,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                 debugConfigPickItems,
                 { placeHolder: "Select a PowerShell debug configuration" });
 
-        if (launchSelection.label === launchCurrentFileLabel) {
+        if (launchSelection.id === launchCurrentFileId) {
             return [
                 {
                     name: "PowerShell: Launch Current File",
@@ -85,7 +90,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     cwd: "${file}",
                 },
             ];
-        } else if (launchSelection.label === launchScriptLabel) {
+        } else if (launchSelection.id === launchScriptId) {
             return [
                 {
                     name: "PowerShell: Launch Script",
@@ -95,7 +100,7 @@ export class DebugSessionFeature implements IFeature, DebugConfigurationProvider
                     cwd: "${workspaceFolder}",
                 },
             ];
-        } else if (launchSelection.label === interactiveSessionLabel) {
+        } else if (launchSelection.id === interactiveSessionId) {
             return [
                 {
                     name: "PowerShell: Interactive Session",


### PR DESCRIPTION
## PR Summary

This an overdue, first-pass attempt at implementing dynamic debug configurations as suggested by @isidorn in #1611.  I'm completely open to changing the text that appears in the various prompts.  I'm also open to the idea that "Attach to PowerShell Host Process" is rare enough that we could eliminate one level of prompting and only allow dynamic debug config for "Launch".  Or maybe we make the second level quick pick a multi-select option and then create the debug configs the user selects?  Then we could remove the first quick pick prompt.

BTW this functionality **only** comes into play when you don't have a launch.json file. The first time you configure launch.json is where you will see this.  Once launch.json exists, you are always choosing from the list of debug config snippets we provide in our package.json file.  One benefit of this approach is that when a user goes through this process now, they get just one debug config added to their new launch.json as opposed to everything we used to define in our package.json's initialDebugConfigurations - which was a lot of stuff.  

@isidorn I tried all the other debuggers on my system in this mode and none of them prompt (node, chrome, C++ gdb/Windows, .NET Core).  Are you sure this is OK for PowerShell to do?  Also, would you mind reviewing this PR?

Here is what this process looks like:

![DebugLaunchConfig1](https://user-images.githubusercontent.com/5177512/61177955-30493d00-a59f-11e9-8969-f57f84ca0d4b.gif)

![DebugLaunchConfig2](https://user-images.githubusercontent.com/5177512/61177957-33442d80-a59f-11e9-80d5-df8ac4209679.gif)

![DebugLaunchConfig3](https://user-images.githubusercontent.com/5177512/61177958-35a68780-a59f-11e9-9bbb-2f7071645423.gif)

![DebugAttachConfig1](https://user-images.githubusercontent.com/5177512/61177959-38a17800-a59f-11e9-9033-5add41730b44.gif)

Finally, I removed the `temp integrated console debug` config snippet.  That will still continue to work but I think we should remove this for now as its a bug factory.  Also, looking at this list of snippets, I wonder if we could cull it further:

![image](https://user-images.githubusercontent.com/5177512/61177974-80280400-a59f-11e9-9fe4-fea5a9923eae.png)

I'm fuzzy on what the difference is between `PowerShell: Interactive Session` and `PowerShell: Attach Interactive Session`.  Also, not sure the `w/Args` is worth having as a snippet. I did add to the docs on `args` that you could specify `${command:SpecifyScriptArgs}` to be prompted for args.  Thoughts?

Also, one last thing.  We had the breakpoints configuration in a part of package.json that isn't valid anymore / deprecated.  So, I moved it to where the VSCode debug docs say it should go.  That said, I'm not sure when that switchover happened.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
