### PR TITLE
Set Default PowerShell Version on Windows to Latest Available

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -73,7 +73,7 @@ export function getDefaultPowerShellPath(
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         if (use32Bit) {
             psCoreInstallPath =
-            (platformDetails.isProcess64Bit ? process.env['ProgramFiles(x86)'] : process.env.ProgramFiles)
+            (platformDetails.isProcess64Bit ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles)
             + "\\PowerShell";
         } else {
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -98,7 +98,7 @@ export function getDefaultPowerShellPath(
                 return powerShellExePath = psCorePaths[0].exePath;
             }
         }
-        
+
         if (use32Bit) {
                 powerShellExePath =
                     platformDetails.isOS64Bit && platformDetails.isProcess64Bit

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -99,6 +99,7 @@ export function getDefaultPowerShellPath(
             }
         }
 
+        // No PowerShell 6+ detected so use Windows PowerShell.
         if (use32Bit) {
                 return platformDetails.isOS64Bit && platformDetails.isProcess64Bit
                         ? SysWow64PowerShellPath

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -109,7 +109,7 @@ export function getDefaultPowerShellPath(
                     !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                         ? System32PowerShellPath
                         : SysnativePowerShellPath;
-            }
+        }
     } else if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,7 +108,7 @@ export function getDefaultPowerShellPath(
         return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                  ? System32PowerShellPath
                  : SysnativePowerShellPath;
-    }   if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
+    } if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;
         if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -76,10 +76,10 @@ export function getDefaultPowerShellPath(
                 (platformDetails.isProcess64Bit ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles)
             + "\\PowerShell";
         } else {
-
             psCoreInstallPath =
                 (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
         }
+        
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
             const psCorePaths =
@@ -98,6 +98,7 @@ export function getDefaultPowerShellPath(
                 return powerShellExePath = psCorePaths[0].exePath;
             }
         }
+        
         if (use32Bit) {
                 powerShellExePath =
                     platformDetails.isOS64Bit && platformDetails.isProcess64Bit

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -229,7 +229,7 @@ export function getAvailablePowerShellExes(
         exePaths.forEach((exePath) => {
             if (fs.existsSync(exePath)) {
                 paths.push({
-                    versionName: "PowerShell " + (/-preview/.test(exePath) ? " Preview" : ""),
+                    versionName: "PowerShell" + (/-preview/.test(exePath) ? " Preview" : ""),
                     exePath,
                 });
             }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -79,7 +79,7 @@ export function getDefaultPowerShellPath(
             psCoreInstallPath =
                 (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
         }
-        
+
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
             const psCorePaths =

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -90,7 +90,7 @@ export function getDefaultPowerShellPath(
                     return fs.lstatSync(item).isDirectory() && fs.existsSync(exePath);
                 })
                 .map((item) => ({
-                    versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
+                    versionName: `PowerShell ${path.parse(item).base} ${arch}`,
                     exePath: path.join(item, "pwsh.exe"),
                 }));
 
@@ -208,7 +208,7 @@ export function getAvailablePowerShellExes(
                     return fs.lstatSync(item).isDirectory() && fs.existsSync(exePath);
                 })
                 .map((item) => ({
-                    versionName: `PowerShell Core ${path.parse(item).base} ${arch}`,
+                    versionName: `PowerShell ${path.parse(item).base} ${arch}`,
                     exePath: path.join(item, "pwsh.exe"),
                 }));
 
@@ -229,7 +229,7 @@ export function getAvailablePowerShellExes(
         exePaths.forEach((exePath) => {
             if (fs.existsSync(exePath)) {
                 paths.push({
-                    versionName: "PowerShell Core" + (/-preview/.test(exePath) ? " Preview" : ""),
+                    versionName: "PowerShell " + (/-preview/.test(exePath) ? " Preview" : ""),
                     exePath,
                 });
             }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -100,12 +100,10 @@ export function getDefaultPowerShellPath(
         }
 
         if (use32Bit) {
-                powerShellExePath =
                 return platformDetails.isOS64Bit && platformDetails.isProcess64Bit
                         ? SysWow64PowerShellPath
                         : System32PowerShellPath;
         } else {
-                powerShellExePath =
                 return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                         ? System32PowerShellPath
                         : SysnativePowerShellPath;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -71,7 +71,7 @@ export function getDefaultPowerShellPath(
     // and the user's desire to run the x86 version of PowerShell
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         const psCoreInstallPath =
-        (!platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
+        (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
             const psCorePaths =

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,11 +108,11 @@ export function getDefaultPowerShellPath(
         return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                  ? System32PowerShellPath
                  : SysnativePowerShellPath;
-    } if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
+    }   if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
-        powerShellExePath = macOSExePath;
-        if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
-            powerShellExePath = macOSPreviewExePath;
+            powerShellExePath = macOSExePath;
+            if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
+                powerShellExePath = macOSPreviewExePath;
         }
     } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -69,7 +69,7 @@ export function getDefaultPowerShellPath(
 
     // Find the path to powershell.exe based on the current platform
     // and the user's desire to run the x86 version of PowerShell
-        if (platformDetails.operatingSystem === OperatingSystem.Windows) {
+    if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         const psCoreInstallPath =
         (!platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
         if (fs.existsSync(psCoreInstallPath)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -68,7 +68,7 @@ export function getDefaultPowerShellPath(
     let powerShellExePath;
     let psCoreInstallPath;
 
-    // Find the path to powershell.exe based on the current platform
+     // Find the path to the powershell executable based on the current platform
     // and the user's desire to run the x86 version of PowerShell
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         if (use32Bit) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -73,10 +73,12 @@ export function getDefaultPowerShellPath(
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         if (use32Bit) {
             psCoreInstallPath =
-            (platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
+            (platformDetails.isProcess64Bit ? process.env['ProgramFiles(x86)'] : process.env.ProgramFiles)
+            + "\\PowerShell";
         } else {
 
-            psCoreInstallPath = psCoreInstallPath = process.env.ProgramFiles + "\\PowerShell";
+            psCoreInstallPath =
+            (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
         }
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -73,12 +73,12 @@ export function getDefaultPowerShellPath(
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
         if (use32Bit) {
             psCoreInstallPath =
-            (platformDetails.isProcess64Bit ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles)
+                (platformDetails.isProcess64Bit ? process.env["ProgramFiles(x86)"] : process.env.ProgramFiles)
             + "\\PowerShell";
         } else {
 
             psCoreInstallPath =
-            (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
+                (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
         }
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,12 +108,13 @@ export function getDefaultPowerShellPath(
         return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                  ? System32PowerShellPath
                  : SysnativePowerShellPath;
-    }   if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
+    } 
+    if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
-            powerShellExePath = macOSExePath;
-            if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
-                powerShellExePath = macOSPreviewExePath;
-        }
+        powerShellExePath = macOSExePath;
+        if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {
+            powerShellExePath = macOSPreviewExePath;
+    }
     } else if (platformDetails.operatingSystem === OperatingSystem.Linux) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         // as well as the Snaps case - https://snapcraft.io/

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -105,10 +105,10 @@ export function getDefaultPowerShellPath(
                         ? SysWow64PowerShellPath
                         : System32PowerShellPath;
         }
-                return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
-                        ? System32PowerShellPath
-                        : SysnativePowerShellPath;
-    } if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
+        return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
+                 ? System32PowerShellPath
+                 : SysnativePowerShellPath;
+    }   if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;
         if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -66,12 +66,18 @@ export function getDefaultPowerShellPath(
     use32Bit: boolean = false): string | null {
 
     let powerShellExePath;
+    let psCoreInstallPath;
 
     // Find the path to powershell.exe based on the current platform
     // and the user's desire to run the x86 version of PowerShell
     if (platformDetails.operatingSystem === OperatingSystem.Windows) {
-        const psCoreInstallPath =
-        (platformDetails.isProcess64Bit ? process.env.ProgramFiles : process.env.ProgramW6432) + "\\PowerShell";
+        if (use32Bit) {
+            psCoreInstallPath =
+            (platformDetails.isProcess64Bit ? process.env.ProgramW6432 : process.env.ProgramFiles) + "\\PowerShell";
+        } else {
+
+            psCoreInstallPath = psCoreInstallPath = process.env.ProgramFiles + "\\PowerShell";
+        }
         if (fs.existsSync(psCoreInstallPath)) {
             const arch = platformDetails.isProcess64Bit ? "(x64)" : "(x86)";
             const psCorePaths =
@@ -87,22 +93,20 @@ export function getDefaultPowerShellPath(
                 }));
 
             if (psCorePaths) {
-                powerShellExePath = psCorePaths[0].exePath;
+                return powerShellExePath = psCorePaths[0].exePath;
             }
-
-        } else {
-            if (use32Bit) {
+        }
+        if (use32Bit) {
                 powerShellExePath =
                     platformDetails.isOS64Bit && platformDetails.isProcess64Bit
                         ? SysWow64PowerShellPath
                         : System32PowerShellPath;
-            } else {
+        } else {
                 powerShellExePath =
                     !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                         ? System32PowerShellPath
                         : SysnativePowerShellPath;
             }
-        }
     } else if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -106,7 +106,7 @@ export function getDefaultPowerShellPath(
                         : System32PowerShellPath;
         } else {
                 powerShellExePath =
-                    !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
+                return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                         ? System32PowerShellPath
                         : SysnativePowerShellPath;
         }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -108,7 +108,7 @@ export function getDefaultPowerShellPath(
         return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                  ? System32PowerShellPath
                  : SysnativePowerShellPath;
-    } 
+    }
     if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -101,7 +101,7 @@ export function getDefaultPowerShellPath(
 
         if (use32Bit) {
                 powerShellExePath =
-                    platformDetails.isOS64Bit && platformDetails.isProcess64Bit
+                return platformDetails.isOS64Bit && platformDetails.isProcess64Bit
                         ? SysWow64PowerShellPath
                         : System32PowerShellPath;
         } else {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -104,12 +104,11 @@ export function getDefaultPowerShellPath(
                 return platformDetails.isOS64Bit && platformDetails.isProcess64Bit
                         ? SysWow64PowerShellPath
                         : System32PowerShellPath;
-        } else {
+        }
                 return !platformDetails.isOS64Bit || platformDetails.isProcess64Bit
                         ? System32PowerShellPath
                         : SysnativePowerShellPath;
-        }
-    } else if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
+    } if (platformDetails.operatingSystem === OperatingSystem.MacOS) {
         // Always default to the stable version of PowerShell (if installed) but handle case of only Preview installed
         powerShellExePath = macOSExePath;
         if (!fs.existsSync(macOSExePath) && fs.existsSync(macOSPreviewExePath)) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -113,34 +113,6 @@ export class SessionManager implements Middleware {
 
         this.powerShellExePath = this.getPowerShellExePath();
 
-        // Check for OpenSSL dependency on macOS when running PowerShell Core alpha. Look for the default
-        // Homebrew installation path and if that fails check the system-wide library path.
-        if (os.platform() === "darwin" && this.getPowerShellVersionLabel() === "alpha") {
-            if (!(utils.checkIfFileExists("/usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib") &&
-                    utils.checkIfFileExists("/usr/local/opt/openssl/lib/libssl.1.0.0.dylib")) &&
-                !(utils.checkIfFileExists("/usr/local/lib/libcrypto.1.0.0.dylib") &&
-                    utils.checkIfFileExists("/usr/local/lib/libssl.1.0.0.dylib"))) {
-                    const thenable =
-                        vscode.window.showWarningMessage(
-                            "The PowerShell extension will not work without OpenSSL on macOS and OS X when using " +
-                            "PowerShell Core alpha",
-                            "Show Documentation");
-
-                    thenable.then(
-                        (s) => {
-                            if (s === "Show Documentation") {
-                                cp.exec("open https://github.com/PowerShell/vscode-powershell/blob/master/docs/" +
-                                    "troubleshooting.md#1-powershell-intellisense-does-not-work-cant-debug-scripts");
-                            }
-                        });
-
-                    // Don't continue initializing since Editor Services will not load successfully
-                    this.setSessionFailure(
-                        "Cannot start PowerShell Editor Services due to missing OpenSSL dependency.");
-                    return;
-            }
-        }
-
         this.suppressRestartPrompt = false;
 
         if (this.powerShellExePath) {

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].versionName);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[2].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[2].versionName);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].versionName);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].versionName);
+                platform.getAvailablePowerShellExes(platformDetails, undefined));
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[2].versionName);
+                platform.getAvailablePowerShellExes(platformDetails, undefined));
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].versionName);
+                platform.getAvailablePowerShellExes(platformDetails, undefined));
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -77,7 +77,7 @@ suite("Platform module", () => {
             checkDefaultPowerShellPath(
                 platformDetails,
                 platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6"));
+                === "PowerShell Core 6")[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -76,7 +76,8 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
+                platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
+                === "PowerShell Core 6"));
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -108,7 +108,7 @@ suite("Platform module", () => {
             checkDefaultPowerShellPath(
                 platformDetails,
                 platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6")[0].exePath);
+                === "PowerShell Core 6 (x86)")[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.System32PowerShellPath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.SysnativePowerShellPath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.System32PowerShellPath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined));
+                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined));
+                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined));
+                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -77,7 +77,7 @@ suite("Platform module", () => {
             checkDefaultPowerShellPath(
                 platformDetails,
                 platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6 (x86)"));
+                === "PowerShell Core 6 (x86)")[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -107,7 +107,8 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
+                platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
+                === "PowerShell Core 6")[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -106,7 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0]);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[2].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -76,7 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined)[0].exePath);
+                platform.getAvailablePowerShellExes(platformDetails, undefined)[1].exePath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -77,7 +77,7 @@ suite("Platform module", () => {
             checkDefaultPowerShellPath(
                 platformDetails,
                 platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6")[0]);
+                === "PowerShell Core 6 (x86)"));
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
+                platform.SysWow64PowerShellPath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -46,7 +46,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.SysWow64PowerShellPath);
+                platform.System32PowerShellPath);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -76,8 +76,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6 (x86)")[0].exePath);
+                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,
@@ -107,8 +106,7 @@ suite("Platform module", () => {
 
             checkDefaultPowerShellPath(
                 platformDetails,
-                platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6 (x86)")[0].exePath);
+                "C:\\Program Files\\PowerShell\\6\\pwsh.exe");
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -77,7 +77,7 @@ suite("Platform module", () => {
             checkDefaultPowerShellPath(
                 platformDetails,
                 platform.getAvailablePowerShellExes(platformDetails, undefined).filter((psPath) => (psPath.versionName)
-                === "PowerShell Core 6")[0].exePath);
+                === "PowerShell Core 6")[0]);
 
             checkAvailableWindowsPowerShellPaths(
                 platformDetails,


### PR DESCRIPTION
## PR Summary

Updated the default PowerShell path on Windows to check for the latest version (previous behavior defaulted to Windows PowerShell). Also removed an SSL check that is no longer necessary. 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [x] PR has tests
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
