### PR TITLE
Prompt to update PowerShell version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,10 +44,25 @@
       "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.0.tgz",
+      "integrity": "sha512-TLFRywthBgL68auWj+ziWu+vnmmcHCDFC/sqCOQf1xTz4hRq8cu79z8CtHU9lncExGBsB8fXA4TiLDLt6xvMzw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/rewire": {
       "version": "2.5.28",
       "resolved": "https://registry.npmjs.org/@types/rewire/-/rewire-2.5.28.tgz",
       "integrity": "sha512-uD0j/AQOa5le7afuK+u+woi8jNKF1vf3DN0H7LCJhft/lNNibUr7VcAesdgtWfEKveZol3ZG1CJqwx2Bhrnl8w==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.0.1.tgz",
+      "integrity": "sha512-ffCdcrEE5h8DqVxinQjo+2d1q+FV5z7iNtPofw3JsrltSoSVlOGaW0rY8XxtO9XukdTn8TaCGWmk2VFGhI70mg==",
       "dev": true
     },
     "acorn": {
@@ -168,6 +183,13 @@
       "requires": {
         "semver": "^5.3.0",
         "shimmer": "^1.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "asynckit": {
@@ -400,6 +422,13 @@
         "async-hook-jl": "^1.7.6",
         "emitter-listener": "^1.0.1",
         "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "co": {
@@ -548,6 +577,13 @@
       "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
       "requires": {
         "semver": "^5.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "diagnostic-channel-publishers": {
@@ -700,6 +736,14 @@
         "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
         "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "eslint-scope": {
@@ -1396,6 +1440,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "nth-check": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
@@ -1484,6 +1533,14 @@
       "dev": true,
       "requires": {
         "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "parse5": {
@@ -1749,9 +1806,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -1953,6 +2010,14 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "tsutils": {
@@ -2104,6 +2169,12 @@
         "yazl": "^2.2.2"
       },
       "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        },
         "tmp": {
           "version": "0.0.29",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
@@ -2128,6 +2199,14 @@
         "source-map-support": "^0.5.0",
         "url-parse": "^1.4.4",
         "vscode-test": "^0.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+          "dev": true
+        }
       }
     },
     "vscode-extension-telemetry": {
@@ -2150,6 +2229,13 @@
       "requires": {
         "semver": "^5.5.0",
         "vscode-languageserver-protocol": "3.14.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+        }
       }
     },
     "vscode-languageserver-protocol": {

--- a/package.json
+++ b/package.json
@@ -40,13 +40,17 @@
     "onView:PowerShellCommands"
   ],
   "dependencies": {
+    "node-fetch": "^2.6.0",
+    "semver": "^6.3.0",
     "vscode-extension-telemetry": "~0.1.2",
     "vscode-languageclient": "~5.2.1"
   },
   "devDependencies": {
     "@types/mocha": "~5.2.7",
     "@types/node": "~10.11.0",
+    "@types/node-fetch": "^2.5.0",
     "@types/rewire": "^2.5.28",
+    "@types/semver": "^6.0.1",
     "mocha": "~5.2.0",
     "mocha-junit-reporter": "~1.23.1",
     "mocha-multi-reporters": "~1.1.7",
@@ -574,6 +578,11 @@
         "powershell.powerShellDefaultVersion": {
           "type": "string",
           "description": "Specifies the PowerShell version name, as displayed by the 'PowerShell: Show Session Menu' command, used when the extension loads e.g \"Windows PowerShell (x86)\" or \"PowerShell Core 6 (x64)\"."
+        },
+        "powershell.promptToUpdatePowerShell": {
+          "type": "boolean",
+          "description": "Specifies whether you should be prompted to update your version of PowerShell.",
+          "default": true
         },
         "powershell.startAutomatically": {
           "type": "boolean",

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import fetch from "node-fetch";
+import { compare, parse, prerelease, SemVer } from "semver";
+import { MessageItem, window } from "vscode";
+import Settings = require("../settings");
+import { EvaluateRequestType } from "./Console";
+
+const PowerShellGitHubReleasesUrl =
+        "https://api.github.com/repos/PowerShell/PowerShell/releases/latest";
+const PowerShellGitHubRPrereleasesUrl =
+    "https://api.github.com/repos/PowerShell/PowerShell/releases";
+
+export class GitHubReleaseInformation {
+    public static async FetchLatestRelease(preview: boolean): Promise<GitHubReleaseInformation> {
+        // Fetch the latest PowerShell releases from GitHub.
+        let releaseJson: any;
+        if (preview) {
+            // This gets all releases and the first one is the latest prerelease if
+            // there is a prerelease version.
+            releaseJson = (await fetch(PowerShellGitHubRPrereleasesUrl)
+                .then((res) => res.json()))[0];
+        } else {
+            releaseJson = await fetch(PowerShellGitHubReleasesUrl)
+                .then((res) => res.json());
+        }
+
+        return new GitHubReleaseInformation(
+            releaseJson.tag_name, releaseJson.assets);
+    }
+
+    public version: SemVer;
+    public isPreview: boolean = false;
+    public assets: any[];
+
+    public constructor(version: string | SemVer, assets: any[] = []) {
+        this.version = parse(version);
+
+        if (prerelease(this.version)) {
+            this.isPreview = true;
+        }
+
+        this.assets = assets;
+    }
+}
+
+interface IUpdateMessageItem extends MessageItem {
+    id: number;
+}
+
+export async function InvokePowerShellUpdateCheck(
+    localVersion: SemVer, arch: string, release: GitHubReleaseInformation) {
+    const options: IUpdateMessageItem[] = [
+        {
+            id: 0,
+            title: "Yes!",
+        },
+        {
+            id: 1,
+            title: "Not now.",
+        },
+        {
+            id: 2,
+            title: "Never...",
+        },
+    ];
+
+    if (compare(release.version, localVersion) > 0) {
+        const result = await window.showInformationMessage(
+            `You have an old version of PowerShell (${
+            localVersion.raw
+        }). The current latest release is ${
+            release.version.raw
+        }. Would you like to update the version?`, ...options);
+
+        // Yes choice.
+        if (result.id === 0) {
+            let script: string;
+            if (process.platform === "win32") {
+                const msiMatcher = arch === "x86" ?
+                    "win-x86.msi" : "win-x64.msi";
+
+                const assetUrl = release.assets.filter((asset: any) =>
+                    asset.name.indexOf(msiMatcher) >= 0)[0].url;
+
+                // Grab MSI and run it.
+                // tslint:disable-next-line: max-line-length
+                script = `$tmpMsiPath = Microsoft.PowerShell.Management\\Join-Path ([System.IO.Path]::GetTempPath()) "pwsh.msi";
+Microsoft.PowerShell.Utility\\Invoke-RestMethod -Uri ${assetUrl} -OutFile $tmpMsiPath;
+Microsoft.PowerShell.Management\\Invoke-Item $tmpMsiPath;`;
+
+            } else if (process.platform === "darwin") {
+                script = "brew cask upgrade powershell";
+                if (release.isPreview) {
+                    script = "brew cask upgrade powershell-preview";
+                }
+            } else if (process.platform === "linux") {
+                window.showWarningMessage(
+                    "Update through VS Code not supported on Linux.");
+                return;
+            }
+            await this.languageServerClient.sendRequest(EvaluateRequestType, {
+                expression: script,
+            });
+        // Never choice.
+        } else if (result.id === 2) {
+            await Settings.change("promptToUpdatePowerShell", false, true);
+        }
+    }
+}

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -3,10 +3,10 @@
  *--------------------------------------------------------*/
 
 import fetch from "node-fetch";
-import { compare, parse, prerelease, SemVer } from "semver";
+import * as semver from "semver";
 import { MessageItem, window } from "vscode";
 import { LanguageClient } from "vscode-languageclient";
-import Settings = require("../settings");
+import * as Settings from "../settings";
 import { EvaluateRequestType } from "./Console";
 
 const PowerShellGitHubReleasesUrl =
@@ -32,14 +32,14 @@ export class GitHubReleaseInformation {
             releaseJson.tag_name, releaseJson.assets);
     }
 
-    public version: SemVer;
+    public version: semver.SemVer;
     public isPreview: boolean = false;
     public assets: any[];
 
-    public constructor(version: string | SemVer, assets: any[] = []) {
-        this.version = parse(version);
+    public constructor(version: string | semver.SemVer, assets: any[] = []) {
+        this.version = semver.parse(version);
 
-        if (prerelease(this.version)) {
+        if (semver.prerelease(this.version)) {
             this.isPreview = true;
         }
 
@@ -53,7 +53,7 @@ interface IUpdateMessageItem extends MessageItem {
 
 export async function InvokePowerShellUpdateCheck(
     languageServerClient: LanguageClient,
-    localVersion: SemVer,
+    localVersion: semver.SemVer,
     arch: string,
     release: GitHubReleaseInformation) {
     const options: IUpdateMessageItem[] = [
@@ -72,7 +72,7 @@ export async function InvokePowerShellUpdateCheck(
     ];
 
     // If our local version is up-to-date, we can return early.
-    if (compare(localVersion, release.version) >= 0) {
+    if (semver.compare(localVersion, release.version) >= 0) {
         return;
     }
 

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -107,7 +107,7 @@ export async function InvokePowerShellUpdateCheck(
                     "win-x86.msi" : "win-x64.msi";
 
                 const assetUrl = release.assets.filter((asset: any) =>
-                    asset.name.indexOf(msiMatcher) >= 0)[0].url;
+                    asset.name.indexOf(msiMatcher) >= 0)[0].browser_download_url;
 
                 // Grab MSI and run it.
                 // tslint:disable-next-line: max-line-length

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -67,7 +67,7 @@ export async function InvokePowerShellUpdateCheck(
         },
         {
             id: 2,
-            title: "Never...",
+            title: "Don't show me this notification again...",
         },
     ];
 
@@ -88,8 +88,11 @@ export async function InvokePowerShellUpdateCheck(
         return;
     }
 
+    const isMacOS: boolean = process.platform === "darwin";
     const result = await window.showInformationMessage(
-        `${commonText} Would you like to update the version?`, ...options);
+        `${commonText} Would you like to update the version? ${
+            isMacOS ? "(Homebrew is required on macOS)" : ""
+        }`, ...options);
 
     // If the user cancels the notification.
     if (!result) { return; }
@@ -121,7 +124,7 @@ finally
     Microsoft.PowerShell.Management\\Remove-Item $tmpMsiPath
 }`;
 
-            } else if (process.platform === "darwin") {
+            } else if (isMacOS) {
                 script = "brew cask upgrade powershell";
                 if (release.isPreview) {
                     script = "brew cask upgrade powershell-preview";

--- a/src/session.ts
+++ b/src/session.ts
@@ -37,10 +37,6 @@ export enum SessionStatus {
 }
 
 export class SessionManager implements Middleware {
-    private static PowerShellGitHubReleasesUrl =
-        "https://api.github.com/repos/PowerShell/PowerShell/releases/latest";
-    private static PowerShellGitHubRPrereleasesUrl =
-        "https://api.github.com/repos/PowerShell/PowerShell/releases";
     public HostVersion: string;
     private ShowSessionMenuCommandName = "PowerShell.ShowSessionMenu";
     private editorServicesArgs: string;
@@ -614,18 +610,16 @@ export class SessionManager implements Middleware {
                                     }
 
                                     // Fetch the latest PowerShell releases from GitHub.
-                                    let release: GitHubReleaseInformation;
-                                    if (semver.prerelease(localVersion)) {
-                                        // This gets all releases and the first one is the latest prerelease if
-                                        // there is a prerelease version.
-                                        release = await GitHubReleaseInformation.FetchLatestRelease(true);
-                                    } else {
-                                        release = await GitHubReleaseInformation.FetchLatestRelease(false);
-                                    }
+                                    const isPreRelease = !!semver.prerelease(localVersion);
+                                    const release: GitHubReleaseInformation =
+                                        await GitHubReleaseInformation.FetchLatestRelease(isPreRelease);
 
                                     await InvokePowerShellUpdateCheck(
-                                        localVersion, this.versionDetails.architecture, release);
-                                } catch (e) {
+                                        this.languageServerClient,
+                                        localVersion,
+                                        this.versionDetails.architecture,
+                                        release);
+                                } catch {
                                     // best effort. This probably failed to fetch the data from GitHub.
                                 }
                             });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -79,6 +79,7 @@ export interface ISettings {
     powerShellAdditionalExePaths?: IPowerShellAdditionalExePathSettings[];
     powerShellDefaultVersion?: string;
     powerShellExePath?: string;
+    promptToUpdatePowerShell?: boolean;
     bundledModulesPath?: string;
     startAutomatically?: boolean;
     useX86Host?: boolean;
@@ -167,6 +168,8 @@ export function load(): ISettings {
             configuration.get<string>("powerShellDefaultVersion", undefined),
         powerShellExePath:
             configuration.get<string>("powerShellExePath", undefined),
+        promptToUpdatePowerShell:
+            configuration.get<boolean>("promptToUpdatePowerShell", true),
         bundledModulesPath:
             "../../modules",
         useX86Host:

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from "assert";
+import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";
+
+suite("UpdatePowerShell tests", () => {
+    test("Can get the latest version", async () => {
+        const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
+        assert.strictEqual(release.isPreview, false, "expected to not be preview.");
+        assert.strictEqual(release.version.prerelease.length === 0, true, "expected to not have preview in version.");
+        assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
+    });
+
+    test("Can get the latest preview version", async () => {
+        const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(true);
+        assert.strictEqual(release.isPreview, true, "expected to be preview.");
+        assert.strictEqual(release.version.prerelease.length > 0, true, "expected to have preview in version.");
+        assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
+    });
+});


### PR DESCRIPTION
## PR Summary

This adds a little dialog that informs you that you can update your version of PowerShell.

It will update:

6.0 - 6.2.1 -> 6.2.2
any preview version -> 7.0.0-preview.2

here's an example:
![image](https://user-images.githubusercontent.com/2644648/61987567-95a02380-afcc-11e9-8b68-3c2ec846bfb7.png)

It updates via homebrew on macOS and through the MSI (interactively) on Windows.

Linux is not supported.

This won't "update" Windows PowerShell to PowerShell 6+ yet as it's a trickier situation.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
