### PR TITLE
null check on activeTerminal to workaround vscode behavior

### DIFF
--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -211,7 +211,8 @@ export class ConsoleFeature implements IFeature {
                     return;
                 }
 
-                if (vscode.window.activeTerminal && vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
+                if (vscode.window.activeTerminal &&
+                    vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
                     this.log.write("PSIC is not active terminal. Running in active terminal using 'runSelectedText'");
                     await vscode.commands.executeCommand("workbench.action.terminal.runSelectedText");
 

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -211,7 +211,7 @@ export class ConsoleFeature implements IFeature {
                     return;
                 }
 
-                if (vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
+                if (vscode.window.activeTerminal && vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
                     this.log.write("PSIC is not active terminal. Running in active terminal using 'runSelectedText'");
                     await vscode.commands.executeCommand("workbench.action.terminal.runSelectedText");
 


### PR DESCRIPTION
## PR Summary

fixes #2137 

For some reason, there is no active terminal until you click inside of the terminal so this protects against `vscode.window.activeTerminal` not being defined and will default to running the code in the PSIC

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
