### PR TITLE
Added functionality to install the User variant of Stable Edition

### DIFF
--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.4.1
+.VERSION 1.4
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -134,8 +134,8 @@ param(
     [string]$Architecture = "64-bit",
 
     [parameter()]
-    [ValidateSet("Stable","Stable-User", "Insider-System", "Insider-User")]
-    [string]$BuildEdition = "Stable",
+    [ValidateSet("Stable-System","Stable-User", "Insider-System", "Insider-User")]
+    [string]$BuildEdition = "Stable-System",
 
     [Parameter()]
     [ValidateNotNull()]
@@ -201,7 +201,7 @@ function Get-CodePlatformInformation {
         $Bitness,
 
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Stable', 'Stable-User', 'Insider-System', 'Insider-User')]
+        [ValidateSet('Stable-System', 'Stable-User', 'Insider-System', 'Insider-User')]
         [string]
         $BuildEdition
     )
@@ -228,7 +228,7 @@ function Get-CodePlatformInformation {
     }
 
     switch ($BuildEdition) {
-        'Stable' {
+        'Stable-System' {
             $appName = "Visual Studio Code ($Bitness)"
             break
         }
@@ -325,7 +325,7 @@ function Get-CodePlatformInformation {
             }
 
             switch ($BuildEdition) {
-                'Stable' {
+                'Stable-System' {
                     $exePath = "$installBase\Microsoft VS Code\bin\code.cmd"
                 }
                 'Stable-User' {
@@ -344,7 +344,7 @@ function Get-CodePlatformInformation {
     }
 
     switch ($BuildEdition) {
-        'Stable' {
+        'Stable-System' {
             $channel = 'stable'
             break
         }
@@ -455,7 +455,7 @@ function Install-VSCodeFromTar {
 
 # We need to be running as elevated on *nix
 if (($IsLinux -or $IsMacOS) -and (id -u) -ne 0) {
-    throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable"
+    throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable-System"
 }
 
 try {
@@ -522,7 +522,7 @@ try {
             }
 
             switch ($BuildEdition) {
-                'Stable' {
+                'Stable-System' {
                     & $pacMan install -y code
                 }
 
@@ -566,7 +566,7 @@ try {
                 break
             }
 
-            Install-VSCodeFromTar -TarPath $installerPath -Insiders:($BuildEdition -ne 'Stable')
+            Install-VSCodeFromTar -TarPath $installerPath -Insiders:($BuildEdition -ne 'Stable-System')
             break
         }
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.3.1
+.VERSION 1.4.0
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.3
+.VERSION 1.3.1
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 
@@ -25,6 +25,8 @@
 .EXTERNALSCRIPTDEPENDENCIES
 
 .RELEASENOTES
+    30/08/2019 - added functionality to install the "User Install" variant of Stable Edition.
+    --
     07/11/2018 - added support for PowerShell Core and macOS/Linux platforms.
     --
     15/08/2018 - added functionality to install the new "User Install" variant of Insiders Edition.
@@ -132,7 +134,7 @@ param(
     [string]$Architecture = "64-bit",
 
     [parameter()]
-    [ValidateSet("Stable", "Insider-System", "Insider-User")]
+    [ValidateSet("Stable","Stable-User", "Insider-System", "Insider-User")]
     [string]$BuildEdition = "Stable",
 
     [Parameter()]
@@ -199,7 +201,7 @@ function Get-CodePlatformInformation {
         $Bitness,
 
         [Parameter(Mandatory=$true)]
-        [ValidateSet('Stable', 'Insider-System', 'Insider-User')]
+        [ValidateSet('Stable', 'Stable-User', 'Insider-System', 'Insider-User')]
         [string]
         $BuildEdition
     )
@@ -228,6 +230,11 @@ function Get-CodePlatformInformation {
     switch ($BuildEdition) {
         'Stable' {
             $appName = "Visual Studio Code ($Bitness)"
+            break
+        }
+
+        'Stable-User' {
+            $appName = "Visual Studio Code ($($Architecture) - User)"
             break
         }
 
@@ -321,6 +328,9 @@ function Get-CodePlatformInformation {
                 'Stable' {
                     $exePath = "$installBase\Microsoft VS Code\bin\code.cmd"
                 }
+                'Stable-User' {
+                    $exePath = "${env:LocalAppData}\Programs\Microsoft VS Code\bin\code.cmd"
+                }
 
                 'Insider-System' {
                     $exePath = "$installBase\Microsoft VS Code Insiders\bin\code-insiders.cmd"
@@ -336,6 +346,12 @@ function Get-CodePlatformInformation {
     switch ($BuildEdition) {
         'Stable' {
             $channel = 'stable'
+            break
+        }
+
+        'Stable-User' {
+            $channel = 'stable'
+            $platform += '-user'
             break
         }
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.4.0
+.VERSION 1.4.1
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 
@@ -130,11 +130,11 @@
 [CmdletBinding(SupportsShouldProcess=$true)]
 param(
     [parameter()]
-    [ValidateSet(, "64-bit", "32-bit")]
-    [string]$Architecture = "64-bit",
+    [ValidateSet('64-bit', '32-bit')]
+    [string]$Architecture = '64-bit',
 
     [parameter()]
-    [ValidateSet("Stable-System","Stable-User", "Insider-System", "Insider-User")]
+    [ValidateSet('Stable-System', 'Stable-User', 'Insider-System', 'Insider-User')]
     [string]$BuildEdition = "Stable-System",
 
     [Parameter()]
@@ -168,7 +168,7 @@ gpgkey=https://packages.microsoft.com/keys/microsoft.asc
 
 function Test-IsOsArchX64 {
     if ($PSVersionTable.PSVersion.Major -lt 6) {
-        return (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture -eq "64-bit"
+        return (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture -eq '64-bit'
     }
 
     return [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::X64
@@ -404,19 +404,19 @@ function Save-WithBitsTransfer {
 
     $bitsDl = Start-BitsTransfer $FileUri -Destination $Destination -Asynchronous
 
-    while (($bitsDL.JobState -eq "Transferring") -or ($bitsDL.JobState -eq "Connecting")) {
+    while (($bitsDL.JobState -eq 'Transferring') -or ($bitsDL.JobState -eq 'Connecting')) {
         Write-Progress -Activity "Downloading: $AppName" -Status "$([math]::round($bitsDl.BytesTransferred / 1mb))mb / $([math]::round($bitsDl.BytesTotal / 1mb))mb" -PercentComplete ($($bitsDl.BytesTransferred) / $($bitsDl.BytesTotal) * 100 )
     }
 
     switch ($bitsDl.JobState) {
 
-        "Transferred" {
+        'Transferred' {
             Complete-BitsTransfer -BitsJob $bitsDl
             break
         }
 
-        "Error" {
-            throw "Error downloading installation media."
+        'Error' {
+            throw 'Error downloading installation media.'
         }
     }
 }
@@ -433,7 +433,7 @@ function Install-VSCodeFromTar {
     )
 
     $tarDir = Join-Path ([System.IO.Path]::GetTempPath()) 'VSCodeTar'
-    $destDir = "/opt/VSCode-linux-x64"
+    $destDir = '/opt/VSCode-linux-x64'
 
     New-Item -ItemType Directory -Force -Path $tarDir
     try {

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -458,6 +458,11 @@ if (($IsLinux -or $IsMacOS) -and (id -u) -ne 0) {
     throw "Must be running as root to install VSCode.`nInvoke this script with (for example):`n`tsudo pwsh -f Install-VSCode.ps1 -BuildEdition Stable-System"
 }
 
+# User builds can only be installed on Windows systems
+if ($BuildEdition.EndsWith('User') -and -not ($IsWindows -or $PSVersionTable.PSVersion.Major -lt 5)) {
+    throw 'User builds are not available for non-Windows systems'
+}
+
 try {
     $prevProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -328,6 +328,7 @@ function Get-CodePlatformInformation {
                 'Stable-System' {
                     $exePath = "$installBase\Microsoft VS Code\bin\code.cmd"
                 }
+
                 'Stable-User' {
                     $exePath = "${env:LocalAppData}\Programs\Microsoft VS Code\bin\code.cmd"
                 }


### PR DESCRIPTION
## PR Summary

Added functionality to install the "User Install" variant of Stable Edition in the *Install-VSCode.ps1* script. It works in the same way the Insiders Edition "User Install" does (see PR https://github.com/PowerShell/vscode-powershell/pull/1477). The deployement website already provides the installers.
Resolves Issue https://github.com/PowerShell/vscode-powershell/issues/2048

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] PR has tests `NA`
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
