### PR TITLE
Add powershell.codeFormatting.autoCorrectAliases setting to add for optionally correcting aliases as well (setting disabled by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -540,6 +540,11 @@
           "default": true,
           "description": "Shows the last line of a folded section similar to the default VSCode folding style. When disabled, the entire folded region is hidden."
         },
+        "powershell.codeFormatting.autoCorrectAliases": {
+          "type": "boolean",
+          "default": false,
+          "description": "Replaces aliases with their aliased name."
+        },
         "powershell.codeFormatting.preset": {
           "type": "string",
           "enum": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,6 +41,7 @@ export interface ICodeFoldingSettings {
 }
 
 export interface ICodeFormattingSettings {
+    autoCorrectAliases: boolean;
     preset: CodeFormattingPreset;
     openBraceOnSameLine: boolean;
     newLineAfterOpenBrace: boolean;
@@ -137,6 +138,7 @@ export function load(): ISettings {
     };
 
     const defaultCodeFormattingSettings: ICodeFormattingSettings = {
+        autoCorrectAliases: false,
         preset: CodeFormattingPreset.Custom,
         openBraceOnSameLine: true,
         newLineAfterOpenBrace: true,


### PR DESCRIPTION
## PR Summary

Add powershell.codeFormatting.autoCorrectAliases setting to add support for optionally correcting aliases as well (added in PSSA 1.18.2). Disabled by default.
Requires the following PSES PR to be merged first: https://github.com/PowerShell/PowerShellEditorServices/pull/1021

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
