### PR TITLE
Provide Run Selection button in Editor Title Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,15 @@
         "category": "PowerShell"
       },
       {
+        "command": "workbench.action.debug.start",
+        "title": "Run",
+        "category": "PowerShell",
+        "icon": {
+          "light": "resources/light/run.svg",
+          "dark": "resources/dark/run.svg"
+        }
+      },
+      {
         "command": "PowerShell.RunSelection",
         "title": "Run Selection",
         "category": "PowerShell",
@@ -267,8 +276,13 @@
       "editor/title": [
         {
           "when": "resourceLangId == powershell",
-          "command": "PowerShell.RunSelection",
+          "command": "workbench.action.debug.start",
           "group": "navigation@100"
+        },
+        {
+          "when": "resourceLangId == powershell",
+          "command": "PowerShell.RunSelection",
+          "group": "navigation@101"
         }
       ],
       "editor/title/context": [

--- a/package.json
+++ b/package.json
@@ -164,7 +164,11 @@
       {
         "command": "PowerShell.RunSelection",
         "title": "Run Selection",
-        "category": "PowerShell"
+        "category": "PowerShell",
+        "icon": {
+          "light": "resources/light/play.svg",
+          "dark": "resources/dark/play.svg"
+        }
       },
       {
         "command": "PowerShell.RestartSession",
@@ -258,6 +262,13 @@
           "when": "editorLangId == powershell",
           "command": "PowerShell.ShowHelp",
           "group": "2_powershell"
+        }
+      ],
+      "editor/title": [
+        {
+          "when": "resourceLangId == powershell",
+          "command": "PowerShell.RunSelection",
+          "group": "navigation@100"
         }
       ],
       "editor/title/context": [

--- a/resources/dark/play.svg
+++ b/resources/dark/play.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="19" viewBox="0 0 16 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 6V18.4805L15.9146 12.2402L7 6ZM14.1809 12.2402L7.995 16.5684V7.91209L14.1809 12.2402Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 1L1 0H7L7.70711 0.292893L10.7071 3.29289L11 4V8.80841V10L8 7.5V14H1L0 13L0 1ZM1 1V13H8V7.5L10 9.30203V8.10005V4L7 1H1Z" fill="#C5C5C5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 1H7V4H10.5V5H6V1Z" fill="#C5C5C5"/>
+</svg>

--- a/resources/dark/run.svg
+++ b/resources/dark/run.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 2V14.4805L12.9146 8.24024L4 2ZM11.1809 8.24024L4.995 12.5684V3.91209L11.1809 8.24024Z" fill="#C5C5C5"/>
+</svg>

--- a/resources/light/play.svg
+++ b/resources/light/play.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="19" viewBox="0 0 16 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M7 6V18.4805L15.9146 12.2402L7 6ZM14.1809 12.2402L7.995 16.5684V7.91209L14.1809 12.2402Z" fill="#424242"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 1L1 0H7L7.70711 0.292893L10.7071 3.29289L11 4V8.80841V10L8 7.5V14H1L0 13L0 1ZM1 1V13H8V7.5L10 9.30203V8.10005V4L7 1H1Z" fill="#424242"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 1H7V4H10.5V5H6V1Z" fill="#424242"/>
+</svg>

--- a/resources/light/run.svg
+++ b/resources/light/run.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M4 2V14.4805L12.9146 8.24024L4 2ZM11.1809 8.24024L4.995 12.5684V3.91209L11.1809 8.24024Z" fill="#424242"/>
+</svg>


### PR DESCRIPTION
## PR Summary

This adds a editor title menu button for the `powershell.RunSelection` command in the primary navigation group, and the `run` icon from the https://github.com/microsoft/vscode-icons repo.
This shows the button in the visible part of the menu when a PowerShell file is open.

This PR is marked as WIP because the icon chosen is the closest approximation I could find in the vscode suggested icon library, but if there is another one that is preferred I can change it to that.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] PR has tests `NA`
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready

This PR fixes #2215 