### PR TITLE
Surface Invoke Registered Editor Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,11 @@
         "command": "PowerShell.OpenExamplesFolder",
         "title": "Open Examples Folder",
         "category": "PowerShell"
+      },
+      {
+        "command": "PowerShell.InvokeRegisteredEditorCommand",
+        "title": "Invoke Registered Editor Command",
+        "category": "PowerShell"
       }
     ],
     "menus": {
@@ -246,6 +251,10 @@
         {
           "command": "PowerShell.RefreshCommandsExplorer",
           "when": "config.powershell.sideBar.CommandExplorerVisibility"
+        },
+        {
+          "command": "PowerShell.InvokeRegisteredEditorCommand",
+          "when": "false"
         }
       ],
       "editor/context": [


### PR DESCRIPTION
## PR Summary

This commit allows the `PowerShell.InvokeRegisteredEditorCommand` command to be accessible to the user in the Command Palette.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] PR has tests `NA`
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready

Fixes #2145