### PR TITLE
Fix bug finding Windows PowerShell

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -94,7 +94,7 @@ export function getDefaultPowerShellPath(
                     exePath: path.join(item, "pwsh.exe"),
                 }));
 
-            if (psCorePaths) {
+            if (psCorePaths && psCorePaths.length > 0) {
                 return powerShellExePath = psCorePaths[0].exePath;
             }
         }


### PR DESCRIPTION
## PR Summary

Fixes the issue where the extension won't start when PowerShell Core is not present.

This is the minimal "backport" of https://github.com/PowerShell/vscode-powershell/pull/2238.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
