### PR TITLE
Don't scan node_modules for secrets during release

### DIFF
--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -83,8 +83,15 @@ steps:
     optionsFTPATH: '$(Build.SourcesDirectory)\tools\terms\FileTypeSet.xml'
     # toolVersion: 5.8.2.1
 
+- pwsh: |
+    Get-ChildItem -Exclude node_modules | Get-ChildItem -Recurse | ForEach-Object FullName > "$env:BUILD_SOURCESDIRECTORY/credscan.tsv"
+  displayName: Create credscan.tsv as the list of files to scan
+
 - task: CredScan@2
   condition: succeededOrFailed()
+  inputs:
+    debugMode: false
+    scanFolder: '$(Build.SourcesDirectory)/credscan.tsv'
 
 # Publish results as artifacts
 - task: PublishSecurityAnalysisLogs@3


### PR DESCRIPTION
## PR Summary

CredScan was complaining because a node_module that we pull in had some test pem's in their package. This was only occurring in the release build because CredScan happens _after_ the build in that.

This PR creates a tsv with all the files we want to scan (excluding `node_modules`) and then gives that to the CredScan task since the CredScan executable cannot take multiple inputs...

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests N/A
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
