### PR TITLE
Introduce new setting that controls UseLegacyReadLine

### DIFF
--- a/package.json
+++ b/package.json
@@ -683,6 +683,11 @@
           "default": true,
           "description": "Switches focus to the console when a script selection is run or a script file is debugged. This is an accessibility feature. To disable it, set to false."
         },
+        "powershell.integratedConsole.useLegacyReadLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "Falls back to the legacy (lightweight) ReadLine experience. This will disable the use of PSReadLine in the PowerShell Integrated Console."
+        },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",
           "default": false,

--- a/src/process.ts
+++ b/src/process.ts
@@ -57,7 +57,11 @@ export class PowerShellProcess {
                     this.startArgs +=
                         `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath)}' ` +
                         `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath)}' ` +
-                        `-FeatureFlags @(${featureFlags})`;
+                        `-FeatureFlags @(${featureFlags}) `;
+
+                    if (this.sessionSettings.integratedConsole.useLegacyReadLine) {
+                        this.startArgs += "-UseLegacyReadLine";
+                    }
 
                     const powerShellArgs = [
                         "-NoProfile",

--- a/src/session.ts
+++ b/src/session.ts
@@ -406,7 +406,9 @@ export class SessionManager implements Middleware {
              settings.developer.editorServicesLogLevel.toLowerCase() !==
                 this.sessionSettings.developer.editorServicesLogLevel.toLowerCase() ||
              settings.developer.bundledModulesPath.toLowerCase() !==
-                this.sessionSettings.developer.bundledModulesPath.toLowerCase())) {
+                this.sessionSettings.developer.bundledModulesPath.toLowerCase() ||
+            settings.integratedConsole.useLegacyReadLine !==
+                this.sessionSettings.integratedConsole.useLegacyReadLine)) {
 
             vscode.window.showInformationMessage(
                 "The PowerShell runtime configuration has changed, would you like to start a new session?",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -98,6 +98,7 @@ export interface ISettings {
 export interface IIntegratedConsoleSettings {
     showOnStartup?: boolean;
     focusConsoleOnExecute?: boolean;
+    useLegacyReadLine?: boolean;
 }
 
 export function load(): ISettings {
@@ -118,14 +119,8 @@ export function load(): ISettings {
         createTemporaryIntegratedConsole: false,
     };
 
-    // TODO: Remove when PSReadLine is out of preview
-    const featureFlags = [];
-    if (utils.isWindowsOS()) {
-        featureFlags.push("PSReadLine");
-    }
-
     const defaultDeveloperSettings: IDeveloperSettings = {
-        featureFlags,
+        featureFlags: [],
         powerShellExePath: undefined,
         bundledModulesPath: "../../../PowerShellEditorServices/module",
         editorServicesLogLevel: "Normal",
@@ -159,6 +154,7 @@ export function load(): ISettings {
     const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {
         showOnStartup: true,
         focusConsoleOnExecute: true,
+        useLegacyReadLine: false,
     };
 
     return {

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -10,16 +10,6 @@ suite("Settings module", () => {
         assert.doesNotThrow(Settings.load);
     });
 
-    // TODO: Remove this test when PSReadLine is in stable
-    test("PSReadLine featureFlag set correctly", () => {
-        const settings: Settings.ISettings = Settings.load();
-        if (process.platform === "win32") {
-            assert.deepEqual(settings.developer.featureFlags, ["PSReadLine"]);
-        } else {
-            assert.deepEqual(settings.developer.featureFlags, []);
-        }
-    });
-
     test("Settings update correctly", async () => {
         // then syntax
         Settings.change("helpCompletion", "BlockComment", false).then(() =>


### PR DESCRIPTION
## PR Summary

This parameter was added to `Start-EditorServices.ps1` in this PR: https://github.com/PowerShell/PowerShellEditorServices/pull/1076

To graduate the PSReadLine feature from a flag to being more integrated into the product. This adds a setting to force PSES to use the the legacy version of ReadLine.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests N/A
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
