### PR TITLE
[Ignore] Fix vsce changelog mangling (downgrade vsce)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,9 +2293,9 @@
       }
     },
     "vsce": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.68.0.tgz",
-      "integrity": "sha512-yFbRYu4x4GbdQzZdEQQeRJBxgPdummgcUOFHUtnclW8XQl3MTuKgXL3TtI09gb5oq7jE6kdyvBmpBcmDGsmhcQ==",
+      "version": "1.64.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.64.0.tgz",
+      "integrity": "sha512-t3R7QTe2nAXQZs2kD+nA8GjdlX8pAQlnzxaNTG2976i5cyQ8r+ZsMNa/f9PDt7bhjcQM+u/fL+LkNuw+hwoy2A==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sinon": "~7.5.0",
     "tslint": "~5.20.0",
     "typescript": "~3.5.3",
-    "vsce": "~1.68.0",
+    "vsce": "~1.64.0",
     "vscode": "~1.1.36"
   },
   "extensionDependencies": [


### PR DESCRIPTION
Temporary resolution for https://github.com/microsoft/vscode-vsce/issues/398.

Allows us to build the VSIX with the changelog working.
