### PR TITLE
Handle clearTerminal message by using vscode clear command

### DIFF
--- a/package.json
+++ b/package.json
@@ -688,6 +688,10 @@
           "default": false,
           "description": "Falls back to the legacy (lightweight) ReadLine experience. This will disable the use of PSReadLine in the PowerShell Integrated Console."
         },
+        "powershell.integratedConsole.useTrueClear": {
+          "type": "boolean",
+          "description": "Use the vscode API to clear the terminal since that's the only way to trigger a true clear. A true clear is a clear that shows nothing when you scroll up after running Clear-Host."
+        },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -688,9 +688,9 @@
           "default": false,
           "description": "Falls back to the legacy (lightweight) ReadLine experience. This will disable the use of PSReadLine in the PowerShell Integrated Console."
         },
-        "powershell.integratedConsole.useTrueClear": {
+        "powershell.integratedConsole.forceClearScrollbackBuffer": {
           "type": "boolean",
-          "description": "Use the vscode API to clear the terminal since that's the only way to trigger a true clear. A true clear is a clear that shows nothing when you scroll up after running Clear-Host."
+          "description": "Use the vscode API to clear the terminal since that's the only reliable way to clear the scrollback buffer. Turn this on if you're use to 'Clear-Host' clearing scroll history as wellclear-terminal-via-lsp."
         },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -6,7 +6,8 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { LanguageClient, NotificationType, NotificationType0, Position, Range, RequestType } from "vscode-languageclient";
+import { LanguageClient, NotificationType, NotificationType0,
+    Position, Range, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
 import { Logger } from "../logging";
 import Settings = require("../settings");

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -276,7 +276,7 @@ export class ExtensionCommandsFeature implements IFeature {
                 () => {
                     // We check to see if they have TrueClear on. If not, no-op because the
                     // overriden Clear-Host already calls [System.Console]::Clear()
-                    if (Settings.load().integratedConsole.useTrueClear) {
+                    if (Settings.load().integratedConsole.forceClearScrollbackBuffer) {
                         vscode.commands.executeCommand("workbench.action.terminal.clear");
                     }
                 });

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -6,9 +6,10 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { LanguageClient, NotificationType, Position, Range, RequestType } from "vscode-languageclient";
+import { LanguageClient, NotificationType, NotificationType0, Position, Range, RequestType } from "vscode-languageclient";
 import { IFeature } from "../feature";
 import { Logger } from "../logging";
+import Settings = require("../settings");
 
 export interface IExtensionCommand {
     name: string;
@@ -155,6 +156,9 @@ export const SetStatusBarMessageRequestType =
     new RequestType<IStatusBarMessageDetails, EditorOperationResponse, void, void>(
         "editor/setStatusBarMessage");
 
+export const ClearTerminalNotificationType =
+        new NotificationType0("editor/clearTerminal");
+
 export interface ISaveFileDetails {
     filePath: string;
     newPath?: string;
@@ -265,6 +269,16 @@ export class ExtensionCommandsFeature implements IFeature {
             this.languageClient.onRequest(
                 SetStatusBarMessageRequestType,
                 (messageDetails) => this.setStatusBarMessage(messageDetails));
+
+            this.languageClient.onNotification(
+                ClearTerminalNotificationType,
+                () => {
+                    // We check to see if they have TrueClear on. If not, no-op because the
+                    // overriden Clear-Host already calls [System.Console]::Clear()
+                    if (Settings.load().integratedConsole.useTrueClear) {
+                        vscode.commands.executeCommand("workbench.action.terminal.clear");
+                    }
+                });
         }
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -99,6 +99,7 @@ export interface IIntegratedConsoleSettings {
     showOnStartup?: boolean;
     focusConsoleOnExecute?: boolean;
     useLegacyReadLine?: boolean;
+    useTrueClear?: boolean;
 }
 
 export function load(): ISettings {
@@ -155,6 +156,8 @@ export function load(): ISettings {
         showOnStartup: true,
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
+        // This behavior is expected on Windows but not on non-Windows
+        useTrueClear: utils.isWindowsOS(),
     };
 
     return {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -99,7 +99,7 @@ export interface IIntegratedConsoleSettings {
     showOnStartup?: boolean;
     focusConsoleOnExecute?: boolean;
     useLegacyReadLine?: boolean;
-    useTrueClear?: boolean;
+    forceClearScrollbackBuffer?: boolean;
 }
 
 export function load(): ISettings {
@@ -157,7 +157,7 @@ export function load(): ISettings {
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
         // This behavior is expected on Windows but not on non-Windows
-        useTrueClear: utils.isWindowsOS(),
+        forceClearScrollbackBuffer: false,
     };
 
     return {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -156,7 +156,6 @@ export function load(): ISettings {
         showOnStartup: true,
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
-        // This behavior is expected on Windows but not on non-Windows
         forceClearScrollbackBuffer: false,
     };
 


### PR DESCRIPTION
## PR Summary

This fixes an "issue" that comes up a lot that when you Clear-Host and are still able to scroll up.

On non-Windows this is the typical behavior of Clear-Host but on Windows the expectation is that the console is truly cleared out. This sends a message to the client to say "hey clear the terminal" and if the terminal properly supports a "true clear" in can register a handler for this notification.

Pairs with: https://github.com/PowerShell/PowerShellEditorServices/pull/1108

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
