### PR TITLE
Fix update powershell feature on windows

### DIFF
--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -152,11 +152,7 @@ export async function InvokePowerShellUpdateCheck(
                 sessionManager.stop();
 
                 // Invoke the MSI via cmd.
-                const msi = spawn("cmd", [`/S /C ${msiDownloadPath}`], {
-                    detached: true,
-                    cwd: os.homedir(),
-                    env: process.env,
-                });
+                const msi = spawn("msiexec", ["/i", msiDownloadPath]);
 
                 msi.on("close", (code) => {
                     // Now that the MSI is finished, start the Integrated Console session.
@@ -165,10 +161,9 @@ export async function InvokePowerShellUpdateCheck(
                 });
 
             } else if (isMacOS) {
-                let script = "brew cask upgrade powershell";
-                if (release.isPreview) {
-                    script = "brew cask upgrade powershell-preview";
-                }
+                const script = release.isPreview
+                    ? "brew cask upgrade powershell-preview"
+                    : "brew cask upgrade powershell";
 
                 await languageServerClient.sendRequest(EvaluateRequestType, {
                     expression: script,

--- a/src/process.ts
+++ b/src/process.ts
@@ -69,7 +69,7 @@ export class PowerShellProcess {
                     ];
 
                     // Only add ExecutionPolicy param on Windows
-                    if (utils.isWindowsOS()) {
+                    if (utils.isWindows) {
                         powerShellArgs.push("-ExecutionPolicy", "Bypass");
                     }
 
@@ -77,7 +77,7 @@ export class PowerShellProcess {
                         PowerShellProcess.escapeSingleQuotes(startScriptPath) +
                         "' " + this.startArgs;
 
-                    if (utils.isWindowsOS()) {
+                    if (utils.isWindows) {
                         powerShellArgs.push(
                             "-Command",
                             startEditorServices);

--- a/src/session.ts
+++ b/src/session.ts
@@ -546,6 +546,7 @@ export class SessionManager implements Middleware {
                                         await GitHubReleaseInformation.FetchLatestRelease(isPreRelease);
 
                                     await InvokePowerShellUpdateCheck(
+                                        this,
                                         this.languageServerClient,
                                         localVersion,
                                         this.versionDetails.architecture,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,7 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 
-export let PowerShellLanguageId = "powershell";
+export const PowerShellLanguageId = "powershell";
 
 export function ensurePathExists(targetPath: string) {
     // Ensure that the path exists
@@ -116,6 +116,6 @@ export function getTimestampString() {
     return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`;
 }
 
-export function isWindowsOS(): boolean {
-    return os.platform() === "win32";
-}
+export const isMacOS: boolean = process.platform === "darwin";
+export const isWindows: boolean = process.platform === "win32";
+export const isLinux: boolean = !isMacOS && !isWindows;


### PR DESCRIPTION
## PR Summary

fixes #2323 

This uses the node runtime to fetch the MSI and then uses cmd to execute the MSI. This will also stop the PSIC and then restart it when the MSI is done.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
