### PR TITLE
Make PowerShell names case insensitive for configuration

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -127,7 +127,8 @@ export class SessionManager implements Middleware {
             let powerShellExeDetails;
             if (this.sessionSettings.powerShellDefaultVersion) {
                 for (const details of this.powershellExeFinder.enumeratePowerShellInstallations()) {
-                    if (details.displayName === this.sessionSettings.powerShellDefaultVersion) {
+                    const wantedName = this.sessionSettings.powerShellDefaultVersion;
+                    if (wantedName.localeCompare(details.displayName, undefined, { sensitivity: "accent" }) === 0) {
                         powerShellExeDetails = details;
                         break;
                     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -127,6 +127,7 @@ export class SessionManager implements Middleware {
             let powerShellExeDetails;
             if (this.sessionSettings.powerShellDefaultVersion) {
                 for (const details of this.powershellExeFinder.enumeratePowerShellInstallations()) {
+                    // Need to compare names case-insensitively, from https://stackoverflow.com/a/2140723
                     const wantedName = this.sessionSettings.powerShellDefaultVersion;
                     if (wantedName.localeCompare(details.displayName, undefined, { sensitivity: "accent" }) === 0) {
                         powerShellExeDetails = details;


### PR DESCRIPTION
## PR Summary

Makes PowerShell names in settings case insensitive.

Resolves https://github.com/PowerShell/vscode-powershell/issues/2380.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
