### PR TITLE
Add -Login startup option

### DIFF
--- a/package.json
+++ b/package.json
@@ -550,7 +550,12 @@
           "description": "Specifies whether you should be prompted to update your version of PowerShell.",
           "default": true
         },
-        "powershell.startAsLoginShell": {
+        "powershell.startAsLoginShell.osx": {
+          "type": "boolean",
+          "default": true,
+          "description": "Starts the PowerShell extension's underlying PowerShell process as a login shell, if applicable."
+        },
+        "powershell.startAsLoginShell.linux": {
           "type": "boolean",
           "default": false,
           "description": "Starts the PowerShell extension's underlying PowerShell process as a login shell, if applicable."
@@ -740,11 +745,6 @@
           "type": "array",
           "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
-        },
-        "powershell.developer.powerShellExeIsWindowsDevBuild": {
-          "type": "boolean",
-          "default": false,
-          "description": "Indicates that the powerShellExePath points to a developer build of Windows PowerShell and configures it for development."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -550,6 +550,11 @@
           "description": "Specifies whether you should be prompted to update your version of PowerShell.",
           "default": true
         },
+        "powershell.startAsLoginShell": {
+          "type": "boolean",
+          "default": false,
+          "description": "Starts the PowerShell extension's underlying PowerShell process as a login shell, if applicable."
+        },
         "powershell.startAutomatically": {
           "type": "boolean",
           "default": true,

--- a/src/process.ts
+++ b/src/process.ts
@@ -65,11 +65,11 @@ export class PowerShellProcess {
 
                     const powerShellArgs = [];
 
-                    const checkLoginShell: boolean =
+                    const useLoginShell: boolean =
                         (utils.isMacOS && this.sessionSettings.startAsLoginShell.osx)
                         || (utils.isLinux && this.sessionSettings.startAsLoginShell.linux);
 
-                    if (checkLoginShell && this.isLoginShell(this.exePath)) {
+                    if (useLoginShell && this.isLoginShell(this.exePath)) {
                         // This MUST be the first argument.
                         powerShellArgs.push("-Login");
                     }

--- a/src/process.ts
+++ b/src/process.ts
@@ -63,10 +63,19 @@ export class PowerShellProcess {
                         this.startArgs += "-UseLegacyReadLine";
                     }
 
-                    const powerShellArgs = [
-                        "-NoProfile",
-                        "-NonInteractive",
-                    ];
+                    const powerShellArgs = [];
+
+                    const checkLoginShell: boolean =
+                        (utils.isMacOS && this.sessionSettings.startAsLoginShell.osx)
+                        || (utils.isLinux && this.sessionSettings.startAsLoginShell.linux);
+
+                    if (checkLoginShell && this.isLoginShell(this.exePath)) {
+                        // This MUST be the first argument.
+                        powerShellArgs.push("-Login");
+                    }
+
+                    powerShellArgs.push("-NoProfile");
+                    powerShellArgs.push("-NonInteractive");
 
                     // Only add ExecutionPolicy param on Windows
                     if (utils.isWindows) {
@@ -88,27 +97,11 @@ export class PowerShellProcess {
                             Buffer.from(startEditorServices, "utf16le").toString("base64"));
                     }
 
-                    let powerShellExePath = this.exePath;
-
-                    if (this.sessionSettings.developer.powerShellExeIsWindowsDevBuild) {
-                        // Windows PowerShell development builds need the DEVPATH environment
-                        // variable set to the folder where development binaries are held
-
-                        // NOTE: This batch file approach is needed temporarily until VS Code's
-                        // createTerminal API gets an argument for setting environment variables
-                        // on the launched process.
-                        const batScriptPath = path.resolve(__dirname, "../../sessions/powershell.bat");
-                        fs.writeFileSync(
-                            batScriptPath,
-                            `@set DEVPATH=${path.dirname(powerShellExePath)}\r\n@${powerShellExePath} %*`);
-
-                        powerShellExePath = batScriptPath;
-                    }
-
                     this.log.write(
                         "Language server starting --",
-                        "    exe: " + powerShellExePath,
-                        "    args: " + startEditorServices);
+                        "    PowerShell executable: " + this.exePath,
+                        "    PowerShell args: " + powerShellArgs.join(" "),
+                        "    PowerShell Editor Services args: " + startEditorServices);
 
                     // Make sure no old session file exists
                     utils.deleteSessionFile(this.sessionFilePath);
@@ -117,7 +110,7 @@ export class PowerShellProcess {
                     this.consoleTerminal =
                         vscode.window.createTerminal(
                             this.title,
-                            powerShellExePath,
+                            this.exePath,
                             powerShellArgs);
 
                     if (this.sessionSettings.integratedConsole.showOnStartup) {
@@ -177,5 +170,19 @@ export class PowerShellProcess {
             this.consoleTerminal.dispose();
             this.consoleTerminal = undefined;
         }
+    }
+
+    private isLoginShell(pwshPath: string): boolean {
+        try {
+            // We can't know what version of PowerShell we have without running it
+            // So we try to start PowerShell with -Login
+            // If it exits successfully, we return true
+            // If it exits unsuccessfully, node throws, we catch, and return false
+            cp.execFileSync(pwshPath, ["-Login", "-NoProfile", "-NoLogo", "-Command", "exit 0"]);
+        } catch {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -188,12 +188,6 @@ export class SessionManager implements Middleware {
             `-BundledModulesPath '${PowerShellProcess.escapeSingleQuotes(this.bundledModulesPath)}' ` +
             `-EnableConsoleRepl `;
 
-        if (this.sessionSettings.startAsLoginShell
-            && this.platformDetails.operatingSystem !== OperatingSystem.Windows
-            && this.isLoginShell(this.PowerShellExeDetails.exePath)) {
-            this.editorServicesArgs = "-Login " + this.editorServicesArgs;
-        }
-
         if (this.sessionSettings.developer.editorServicesWaitForDebugger) {
             this.editorServicesArgs += "-WaitForDebugger ";
         }
@@ -725,20 +719,6 @@ export class SessionManager implements Middleware {
             .window
             .showQuickPick<SessionMenuItem>(menuItems)
             .then((selectedItem) => { selectedItem.callback(); });
-    }
-
-    private isLoginShell(pwshPath: string): boolean {
-        try {
-            // We can't know what version of PowerShell we have without running it
-            // So we try to start PowerShell with -Login
-            // If it exits successfully, we return true
-            // If it exits unsuccessfully, node throws, we catch, and return false
-            cp.execFileSync(pwshPath, ["-Login", "-NoProfile", "-NoLogo", "-Command", "exit 0"]);
-        } catch {
-            return false;
-        }
-
-        return true;
     }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -729,6 +729,10 @@ export class SessionManager implements Middleware {
 
     private isLoginShell(pwshPath: string): boolean {
         try {
+            // We can't know what version of PowerShell we have without running it
+            // So we try to start PowerShell with -Login
+            // If it exits successfully, we return true
+            // If it exits unsuccessfully, node throws, we catch, and return false
             cp.execFileSync(pwshPath, ["-Login", "-NoProfile", "-NoLogo", "-Command", "exit 0"]);
         } catch {
             return false;

--- a/src/session.ts
+++ b/src/session.ts
@@ -729,7 +729,7 @@ export class SessionManager implements Middleware {
 
     private isLoginShell(pwshPath: string): boolean {
         try {
-            cp.execFileSync(pwshPath, ["-Login", "-NoProfile", "-NoLogo", "-Command", "0"]);
+            cp.execFileSync(pwshPath, ["-Login", "-NoProfile", "-NoLogo", "-Command", "exit 0"]);
         } catch {
             return false;
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -2,7 +2,6 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import * as cp from "child_process";
 import fs = require("fs");
 import net = require("net");
 import path = require("path");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,7 +72,6 @@ export interface IDeveloperSettings {
     bundledModulesPath?: string;
     editorServicesLogLevel?: string;
     editorServicesWaitForDebugger?: boolean;
-    powerShellExeIsWindowsDevBuild?: boolean;
 }
 
 export interface ISettings {
@@ -82,7 +81,7 @@ export interface ISettings {
     powerShellExePath?: string;
     promptToUpdatePowerShell?: boolean;
     bundledModulesPath?: string;
-    startAsLoginShell?: boolean;
+    startAsLoginShell?: IStartAsLoginShellSettings;
     startAutomatically?: boolean;
     useX86Host?: boolean;
     enableProfileLoading?: boolean;
@@ -95,6 +94,11 @@ export interface ISettings {
     integratedConsole?: IIntegratedConsoleSettings;
     bugReporting?: IBugReportingSettings;
     sideBar?: ISideBarSettings;
+}
+
+export interface IStartAsLoginShellSettings {
+    osx?: boolean;
+    linux?: boolean;
 }
 
 export interface IIntegratedConsoleSettings {
@@ -131,7 +135,6 @@ export function load(): ISettings {
         bundledModulesPath: "../../../PowerShellEditorServices/module",
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false,
-        powerShellExeIsWindowsDevBuild: false,
     };
 
     const defaultCodeFoldingSettings: ICodeFoldingSettings = {
@@ -155,6 +158,11 @@ export function load(): ISettings {
         ignoreOneLineBlock: true,
         alignPropertyValuePairs: true,
         useCorrectCasing: false,
+    };
+
+    const defaultStartAsLoginShellSettings: IStartAsLoginShellSettings = {
+        osx: true,
+        linux: false,
     };
 
     const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {
@@ -203,6 +211,13 @@ export function load(): ISettings {
             configuration.get<IBugReportingSettings>("bugReporting", defaultBugReportingSettings),
         sideBar:
             configuration.get<ISideBarSettings>("sideBar", defaultSideBarSettings),
+        startAsLoginShell:
+            // tslint:disable-next-line
+            // We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107
+            //   "Unlike on Linux, ~/.profile is not sourced when logging into a macOS session. This
+            //   is the reason terminals on macOS typically run login shells by default which set up
+            //   the environment. See http://unix.stackexchange.com/a/119675/115410"
+            configuration.get<IStartAsLoginShellSettings>("startAsLoginShell", defaultStartAsLoginShellSettings),
     };
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,6 +82,7 @@ export interface ISettings {
     powerShellExePath?: string;
     promptToUpdatePowerShell?: boolean;
     bundledModulesPath?: string;
+    startAsLoginShell?: boolean;
     startAutomatically?: boolean;
     useX86Host?: boolean;
     enableProfileLoading?: boolean;


### PR DESCRIPTION
## PR Summary

Resolves https://github.com/PowerShell/vscode-powershell/issues/2384.

Adds a config setting to start the PSIC with `-Login`.

Needs testing on *nix platforms, so still WIP.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
