### PR TITLE
[Ignore] disable dependabot for legacy

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -7,9 +7,3 @@ update_configs:
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
-
-  # Will also update legacy branch
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
-    target_branch: "legacy/1.x"


### PR DESCRIPTION
Since we're doing the (hopefully) final release out of the legacy, we should disable dependabot.