### PR TITLE
actually hide terminal until debug session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -140,9 +140,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.34.0",
-      "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/vscode/-/@types/vscode-1.34.0.tgz",
-      "integrity": "sha1-Wr3YtUi+CMj+P/98PjstUy4yV0E=",
+      "version": "1.40.0",
+      "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/vscode/-/@types/vscode-1.40.0.tgz",
+      "integrity": "sha1-R9GenjLaUSyYb1ef5q+8jT5uDFU=",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "ms-vscode",
   "description": "(Preview) Develop PowerShell scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.34.0"
+    "vscode": "^1.40.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
@@ -57,7 +57,7 @@
     "@types/rewire": "~2.5.28",
     "@types/semver": "~6.2.0",
     "@types/sinon": "~7.5.1",
-    "@types/vscode": "1.34.0",
+    "@types/vscode": "1.40.0",
     "mocha": "~5.2.0",
     "mocha-junit-reporter": "~1.23.2",
     "mocha-multi-reporters": "~1.1.7",

--- a/src/process.ts
+++ b/src/process.ts
@@ -108,12 +108,15 @@ export class PowerShellProcess {
 
                     // Launch PowerShell in the integrated terminal
                     this.consoleTerminal =
-                        vscode.window.createTerminal(
-                            this.title,
-                            this.exePath,
-                            powerShellArgs);
+                        vscode.window.createTerminal({
+                            name: this.title,
+                            shellPath: this.exePath,
+                            shellArgs: powerShellArgs,
+                            hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
+                        });
 
                     if (this.sessionSettings.integratedConsole.showOnStartup) {
+                        // We still need to run this to set the active terminal to the Integrated Console.
                         this.consoleTerminal.show(true);
                     }
 


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/vscode-powershell/issues/2434

This uses a new terminal API (`TerminalOptions.hideFromUser`) to actually hide the terminal from the list of terminals until a debug session is started.

It's currently impossible to re-hide a terminal so this is the best we can do for now.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
