### PR TITLE
Run single Pester test

### DIFF
--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -79,7 +79,7 @@ $pester4Output = switch ($Output) {
 }
 
 if ($MinimumVersion5 -and $pesterModule.Version -lt "5.0.0") {
-    Write-Warning "Pester 5.0.0 or newer is required because setting PowerShell > Pester > Pester5 Code Lens is enabled, but Pester $($pesterModule.Version) is loaded. Some of the code lense features might not work as expected."
+    Write-Warning "Pester 5.0.0 or newer is required because setting PowerShell > Pester: Enable Legacy Code Lens is disabled, but Pester $($pesterModule.Version) is loaded. Some of the code lense features might not work as expected."
 }
 
 

--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -47,36 +47,81 @@ param(
     # If specified, executes all the tests in the specified test script.
     [Parameter()]
     [switch]
-    $All
+    $All,
+
+    [Parameter()]
+    [switch] $MinimumVersion5,
+
+    [Parameter(Mandatory)]
+    [string] $Output
 )
 
 $pesterModule = Microsoft.PowerShell.Core\Get-Module Pester
+# add one line, so the subsequent output is not shifted to the side
+Write-Output ''
 if (!$pesterModule) {
     Write-Output "Importing Pester module..."
-    $pesterModule = Microsoft.PowerShell.Core\Import-Module Pester -ErrorAction Ignore -PassThru
+    $minimumVersion = if ($MinimumVersion5) { "5.0.0" } else { "0.0.0" }
+    $versionMessage = " version $minimumVersion"
+    $pesterModule = Microsoft.PowerShell.Core\Import-Module Pester -ErrorAction Ignore -PassThru -MinimumVersion $minimumVersion
     if (!$pesterModule) {
         # If we still don't have an imported Pester module, that is (most likely) because Pester is not installed.
-        Write-Warning "Failed to import the Pester module. You must install Pester to run or debug Pester tests."
-        Write-Warning "You can install Pester by executing: Install-Module Pester -Scope CurrentUser -Force"
+        Write-Warning "Failed to import Pester$(if ($MinimumVersion5){ $versionMessage }). You must install Pester module to run or debug Pester tests."
+        Write-Warning "You can install Pester by executing: Install-Module Pester $(if ($MinimumVersion5) {"-MinimumVersion 5.0.0" }) -Scope CurrentUser -Force"
         return
     }
 }
 
+$pester4Output = switch ($Output) {
+    "None" { "None" }
+    "Minimal" { "Fails" }
+    default { "All" }
+}
+
+if ($MinimumVersion5 -and $pesterModule.Version -lt "5.0.0") {
+    Write-Warning "Pester 5.0.0 or newer is required because setting PowerShell > Pester > Pester5 Code Lens is enabled, but Pester $($pesterModule.Version) is loaded. Some of the code lense features might not work as expected."
+}
+
+
 if ($All) {
     if ($pesterModule.Version -ge '5.0.0') {
-        Pester\Invoke-Pester -Configuration @{ Run = $ScriptPath } | Out-Null
+        $configuration = @{
+            Run = @{
+                Path = $ScriptPath
+            }
+        }
+        # only override this if user asks us to do it, to allow Pester to pick up
+        # $PesterPreference from caller context and merge it with the configuration
+        # we provide below, this way user can specify his output (and other) settings
+        # using the standard [PesterConfiguration] object, and we can avoid providing
+        # settings for everything
+        if ("FromPreference" -ne $Output) {
+            $configuration.Add('Output', @{ Verbosity = $Output })
+        }
+        Pester\Invoke-Pester -Configuration $configuration | Out-Null
     }
     else {
-        Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true}
+        Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -Show $pester4Output
     }
 }
 elseif (($LineNumber -match '\d+') -and ($pesterModule.Version -ge '4.6.0')) {
     if ($pesterModule.Version -ge '5.0.0') {
-       Pester\Invoke-Pester -Configuration @{ Run = $ScriptPath; Filter = @{ Line = "${ScriptPath}:$LineNumber"} } | Out-Null
+        $configuration = @{
+            Run = @{
+                Path = $ScriptPath
+            }
+            Filter = @{
+                Line = "${ScriptPath}:$LineNumber"
+            }
+        }
+        if ("FromPreference" -ne $Output) {
+            $configuration.Add('Output', @{ Verbosity = $Output })
+        }
+        Pester\Invoke-Pester -Configuration $configuration | Out-Null
     }
     else {
         Pester\Invoke-Pester -Script $ScriptPath -PesterOption (New-PesterOption -ScriptBlockFilter @{
-            IncludeVSCodeMarker=$true; Line=$LineNumber; Path=$ScriptPath})
+            IncludeVSCodeMarker=$true; Line=$LineNumber; Path=$ScriptPath}) -Show $pester4Output
     }
 }
 elseif ($TestName) {
@@ -84,7 +129,7 @@ elseif ($TestName) {
        throw "Running tests by test name is unsafe. This should not trigger for Pester 5."
     }
     else {
-        Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -TestName $TestName
+        Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -TestName $TestName -Show $pester4Output
     }
 }
 else {
@@ -97,5 +142,5 @@ else {
     Write-Warning "The Describe block's TestName cannot be evaluated. EXECUTING ALL TESTS instead."
     Write-Warning "To avoid this, install Pester >= 4.6.0 or remove any expressions in the TestName."
 
-    Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true}
+    Pester\Invoke-Pester -Script $ScriptPath -PesterOption @{IncludeVSCodeMarker=$true} -Show $pester4Output
 }

--- a/package.json
+++ b/package.json
@@ -751,12 +751,12 @@
           "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
         },
-        "powershell.pester.pester5CodeLens": {
+        "powershell.pester.enableLegacyCodeLens": {
           "type": "boolean",
-          "default": false,
-          "description": "Enables code lense that is specific to Pester 5. This enables Run Tests on every Describe / Context and It and other features."
+          "default": true,
+          "description": "Enable code lense that is compatible with Pester 4. Disabling this will show 'Run Tests' on all It, Describe and Context blocks, and will correctly work only with Pester 5 and newer."
         },
-        "powershell.pester.output": {
+        "powershell.pester.outputVerbosity": {
           "type": "string",
           "enum": [
             "FromPreference",
@@ -764,7 +764,7 @@
             "Minimal"
           ],
           "default": "FromPreference",
-          "description": "Defines the verbosity of output to be used. For Pester5 the default value FromPreference, will use the Output settings from the $PesterPreference defined in the caller context, or use Normal if there is none. For Pester4 the Normal and FromPreference options map to All, and Minimal option maps to Fails."
+          "description": "Defines the verbosity of output to be used. For Pester 5 and newer the default value FromPreference, will use the Output settings from the $PesterPreference defined in the caller context, and will default to Normal if there is none. For Pester 4 the FromPreference and Normal options map to All, and Minimal option maps to Fails."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -750,6 +750,21 @@
           "type": "array",
           "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
+        },
+        "powershell.pester.pester5CodeLens": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables code lense that is specific to Pester 5. This enables Run Tests on every Describe / Context and It and other features."
+        },
+        "powershell.pester.output": {
+          "type": "string",
+          "enum": [
+            "FromPreference",
+            "Normal",
+            "Minimal"
+          ],
+          "default": "FromPreference",
+          "description": "Defines the verbosity of output to be used. For Pester5 the default value FromPreference, will use the Output settings from the $PesterPreference defined in the caller context, or use Normal if there is none. For Pester4 the Normal and FromPreference options map to All, and Minimal option maps to Fails."
         }
       }
     },

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -109,7 +109,7 @@ export class PesterTestsFeature implements IFeature {
             launchConfig.args.push("-TestName", `'${testName}'`);
         }
 
-        if (!settings.pester.enableLegacyCodeLens) {
+        if (!settings.pester.useLegacyCodeLens) {
             launchConfig.args.push("-MinimumVersion5");
         }
 

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -109,11 +109,11 @@ export class PesterTestsFeature implements IFeature {
             launchConfig.args.push("-TestName", `'${testName}'`);
         }
 
-        if (settings.pester.pester5CodeLens) {
+        if (!settings.pester.enableLegacyCodeLens) {
             launchConfig.args.push("-MinimumVersion5");
         }
 
-        launchConfig.args.push("-Output", `'${settings.pester.output}'`);
+        launchConfig.args.push("-Output", `'${settings.pester.outputVerbosity}'`);
 
         return launchConfig;
     }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -109,6 +109,12 @@ export class PesterTestsFeature implements IFeature {
             launchConfig.args.push("-TestName", `'${testName}'`);
         }
 
+        if (settings.pester.pester5CodeLens) {
+            launchConfig.args.push("-MinimumVersion5");
+        }
+
+        launchConfig.args.push("-Output", `'${settings.pester.output}'`);
+
         return launchConfig;
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -115,7 +115,7 @@ export interface ISideBarSettings {
 }
 
 export interface IPesterSettings {
-    enableLegacyCodeLens?: boolean;
+    useLegacyCodeLens?: boolean;
     outputVerbosity?: string;
 }
 
@@ -184,7 +184,7 @@ export function load(): ISettings {
     };
 
     const defaultPesterSettings: IPesterSettings = {
-        enableLegacyCodeLens: true,
+        useLegacyCodeLens: true,
         outputVerbosity: "FromPreference",
     };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -115,8 +115,8 @@ export interface ISideBarSettings {
 }
 
 export interface IPesterSettings {
-    pester5CodeLens?: boolean;
-    output?: string;
+    enableLegacyCodeLens?: boolean;
+    outputVerbosity?: string;
 }
 
 export function load(): ISettings {
@@ -184,8 +184,8 @@ export function load(): ISettings {
     };
 
     const defaultPesterSettings: IPesterSettings = {
-        pester5CodeLens: false,
-        output: "FromPreference",
+        enableLegacyCodeLens: true,
+        outputVerbosity: "FromPreference",
     };
 
     return {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -94,6 +94,7 @@ export interface ISettings {
     integratedConsole?: IIntegratedConsoleSettings;
     bugReporting?: IBugReportingSettings;
     sideBar?: ISideBarSettings;
+    pester?: IPesterSettings;
 }
 
 export interface IStartAsLoginShellSettings {
@@ -111,6 +112,11 @@ export interface IIntegratedConsoleSettings {
 
 export interface ISideBarSettings {
     CommandExplorerVisibility?: boolean;
+}
+
+export interface IPesterSettings {
+    pester5CodeLens?: boolean;
+    output?: string;
 }
 
 export function load(): ISettings {
@@ -177,6 +183,11 @@ export function load(): ISettings {
         CommandExplorerVisibility: true,
     };
 
+    const defaultPesterSettings: IPesterSettings = {
+        pester5CodeLens: false,
+        output: "FromPreference",
+    };
+
     return {
         startAutomatically:
             configuration.get<boolean>("startAutomatically", true),
@@ -212,6 +223,8 @@ export function load(): ISettings {
             configuration.get<IBugReportingSettings>("bugReporting", defaultBugReportingSettings),
         sideBar:
             configuration.get<ISideBarSettings>("sideBar", defaultSideBarSettings),
+        pester:
+            configuration.get<IPesterSettings>("pester", defaultPesterSettings),
         startAsLoginShell:
             // tslint:disable-next-line
             // We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107


### PR DESCRIPTION
## PR Summary

Add support for Pester v5 to run single test, all tests in any describe or all tests in via the task. 

The VSCodeMarker is not provided. The Pester side would work, but the highlighting (or what was it for) does not work in VSCode, and so it only makes the output uglier, with stacktrace on the top.

To test this you need Pester v5 ( branch `filter-by-lines` or once merged `v5.0`), you will also need the updated lense from powershell services (branch same as here). Once your VSCode is started with the new version (after running the extension by F5), open a .Tests.ps1 file and load Pester v5.

```powershell
Get-Module Pester | Remove-Module ; Import-Module Projects/Pester/Pester.psd1
```

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests NA
- [x] This PR is ready to merge and is not work in progress
  This is be safe to merge, the new behavior is version checked.