### PR TITLE
Add explorer context menus for 'Run/Debug Pester tests'

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,6 +287,16 @@
           "when": "false"
         }
       ],
+      "explorer/context": [
+        {
+          "command": "PowerShell.RunPesterTestsFromFile",
+          "when": "resourceFilename =~ /\\.tests\\.ps1$/i"
+        },
+        {
+          "command": "PowerShell.DebugPesterTestsFromFile",
+          "when": "resourceFilename =~ /\\.tests\\.ps1$/i"
+        }
+      ],
       "editor/context": [
         {
           "when": "editorLangId == powershell",

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -26,14 +26,14 @@ export class PesterTestsFeature implements IFeature {
         // File context-menu command - Run Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTestsFromFile",
-            () => {
-                this.launchAllTestsInActiveEditor(LaunchType.Run);
+            (fileUri) => {
+                this.launchAllTestsInActiveEditor(LaunchType.Run, fileUri);
             });
         // File context-menu command - Debug Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.DebugPesterTestsFromFile",
-            () => {
-                this.launchAllTestsInActiveEditor(LaunchType.Debug);
+            (fileUri) => {
+                this.launchAllTestsInActiveEditor(LaunchType.Debug, fileUri);
             });
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
@@ -51,8 +51,8 @@ export class PesterTestsFeature implements IFeature {
         this.languageClient = languageClient;
     }
 
-    private launchAllTestsInActiveEditor(launchType: LaunchType) {
-        const uriString = vscode.window.activeTextEditor.document.uri.toString();
+    private launchAllTestsInActiveEditor(launchType: LaunchType, fileUri?: vscode.Uri) {
+        const uriString = fileUri.toString();
         const launchConfig = this.createLaunchConfig(uriString, launchType);
         launchConfig.args.push("-All");
         this.launch(launchConfig);

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -51,7 +51,7 @@ export class PesterTestsFeature implements IFeature {
         this.languageClient = languageClient;
     }
 
-    private launchAllTestsInActiveEditor(launchType: LaunchType, fileUri?: vscode.Uri) {
+    private launchAllTestsInActiveEditor(launchType: LaunchType, fileUri: vscode.Uri) {
         const uriString = fileUri.toString();
         const launchConfig = this.createLaunchConfig(uriString, launchType);
         launchConfig.args.push("-All");


### PR DESCRIPTION
## PR Summary

Similar to the existing context menu for the files tab. Manually tested that it works

![image](https://user-images.githubusercontent.com/9250262/73305150-6f746e00-4211-11ea-9aec-1b0b1e273035.png)


cc @JustinGrote @nohwnd

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
