### PR TITLE
Problem matcher support for Context errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -355,9 +355,9 @@
             "message": 1
           },
           {
-            "regexp": "^\\s+at\\s+[^,]+,\\s*(.*?):\\s+line\\s+(\\d+)$",
-            "file": 1,
-            "line": 2
+            "regexp": "^\\s+[Aa]t\\s+([^,]+,)?(.+?):(\\s+line\\s+)?(\\d+)(\\s+char:\\d+)?$",
+            "file": 2,
+            "line": 4
           }
         ]
       }


### PR DESCRIPTION
## PR Summary

Fixes #2438 - allows errors that occur in Pester test context to be shown in the Problems window just like other test failures. Solution is a simple regex fix in the problem matcher for line number/location.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- N/A - PR has tests
- [x] This PR is ready to merge and is not work in progress

I didn't see that there were any existing problem matcher tests. If there are, I'd be happy to try adding some updates to them.
