### PR TITLE
Update mac Image to 10.14 in CI as 10.13 is going to be deprecated in March

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -41,7 +41,7 @@ jobs:
 
 - job: macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
   - template: templates/ci-general.yml
 


### PR DESCRIPTION
# PR Summary

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/

Note that Azure DevOps recently added 10.15 as well, so an alternative would be to use `macOS-latest` or both images
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
