### PR TITLE
Close other pwsh's in the VSCode instance

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     "windows": {
         "options": {
             "shell": {
-                "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                "executable": "pwsh.exe",
                 "args": [ "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command" ]
             }
         }

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -116,7 +116,8 @@ export async function InvokePowerShellUpdateCheck(
 
     const result = await window.showInformationMessage(
         `${commonText} Would you like to update the version? ${
-            isMacOS ? "(Homebrew is required on macOS)" : ""
+            isMacOS ? "(Homebrew is required on macOS)"
+                : "(This will close ALL pwsh terminals running in this Visual Studio Code session)"
         }`, ...options);
 
     // If the user cancels the notification.
@@ -150,6 +151,15 @@ export async function InvokePowerShellUpdateCheck(
 
                 // Stop the Integrated Console session because Windows likes to hold on to files.
                 sessionManager.stop();
+
+                // Close all terminals with the name "pwsh" in the current VS Code session.
+                // This will encourage folks to not close the instance of VS Code that spawned
+                // the MSI process.
+                for (const terminal of window.terminals) {
+                    if (terminal.name === "pwsh") {
+                        terminal.dispose();
+                    }
+                }
 
                 // Invoke the MSI via cmd.
                 const msi = spawn("msiexec", ["/i", msiDownloadPath]);


### PR DESCRIPTION
## PR Summary

People having a hard time using the UpdatePowerShell feature and [would often close VS Code](https://twitter.com/oising/status/1227292965506252800?s=20) which causes the MSI to close because it's a child process.

I tried using `detached:true` in the `SpawnConfig` parameter of `spawn` but [it didn't work in vscode](https://gist.github.com/TylerLeonhardt/7deb5f39877a48ebb41a2f9b208cce65)... (it did work in a raw js file so I suspect a vscode or electron bug...)

As a best effort, I have us closing all terminals named "pwsh" in hope that that will discourage folks from closing the VS Code instance that ran the MSI.


also I snuck in using pwsh for the Windows task because I'm tired of errors caused by Windows PowerShell...

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
