### PR TITLE
Remove caption usage from message

### DIFF
--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -114,7 +114,7 @@ function showChoicePrompt(
             vscode.window
                 .showQuickPick(
                     quickPickItems,
-                    { placeHolder: promptDetails.caption + " - " + promptDetails.message })
+                    { placeHolder: promptDetails.message })
                 .then(onItemSelected);
     } else {
         const checkboxQuickPickItems =
@@ -134,7 +134,7 @@ function showChoicePrompt(
         resultThenable =
             showCheckboxQuickPick(
                     checkboxQuickPickItems,
-                    { confirmPlaceHolder: `${promptDetails.caption} - ${promptDetails.message}`})
+                    { confirmPlaceHolder: promptDetails.message })
                 .then(onItemsSelected);
     }
 


### PR DESCRIPTION
## PR Summary

Changes how we use the `powerShell/showChoicePrompt` message so that `caption` is not used. Instead we just display the `message` field.

Should merge after https://github.com/PowerShell/PowerShellEditorServices/pull/1183.
