### PR TITLE
Workaround for terminal PID freeze

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -122,9 +122,9 @@ export class PowerShellProcess {
         this.consoleCloseSubscription = vscode.window.onDidCloseTerminal((terminal) => this.onTerminalClose(terminal));
 
         // Log that the PowerShell terminal process has been started
-        const terminalPid = await this.consoleTerminal.processId;
         const pwshName = path.basename(this.exePath);
-        this.log.write(`${pwshName} started, pid: ${terminalPid}`);
+        this.consoleTerminal.processId.then((pid) => this.logTerminalPid(pid, pwshName));
+        this.log.write(`${pwshName} started.`);
 
         return sessionDetails;
     }
@@ -150,6 +150,10 @@ export class PowerShellProcess {
             this.consoleTerminal.dispose();
             this.consoleTerminal = undefined;
         }
+    }
+
+    private logTerminalPid(pid: number, exeName: string) {
+        this.log.write(`${exeName} PID: ${pid}`);
     }
 
     private isLoginShell(pwshPath: string): boolean {

--- a/src/process.ts
+++ b/src/process.ts
@@ -110,21 +110,25 @@ export class PowerShellProcess {
                 hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
             });
 
+        const pwshName = path.basename(this.exePath);
+        this.log.write(`${pwshName} started.`);
+
         if (this.sessionSettings.integratedConsole.showOnStartup) {
             // We still need to run this to set the active terminal to the Integrated Console.
             this.consoleTerminal.show(true);
         }
 
         // Start the language client
+        this.log.write("Waiting for session file");
         const sessionDetails = await this.waitForSessionFile();
 
         // Subscribe a log event for when the terminal closes
+        this.log.write("Registering terminal close callback");
         this.consoleCloseSubscription = vscode.window.onDidCloseTerminal((terminal) => this.onTerminalClose(terminal));
 
         // Log that the PowerShell terminal process has been started
-        const pwshName = path.basename(this.exePath);
+        this.log.write("Registering terminal PID log callback");
         this.consoleTerminal.processId.then((pid) => this.logTerminalPid(pid, pwshName));
-        this.log.write(`${pwshName} started.`);
 
         return sessionDetails;
     }
@@ -176,9 +180,11 @@ export class PowerShellProcess {
                 utils.deleteSessionFile(this.sessionFilePath);
 
                 if (error) {
+                    this.log.write("Error occurred retrieving session file");
                     return reject(error);
                 }
 
+                this.log.write("Session file found");
                 resolve(sessionDetails);
             });
         });

--- a/src/session.ts
+++ b/src/session.ts
@@ -458,7 +458,11 @@ export class SessionManager implements Middleware {
                     this.log.write("Language server startup failed.");
                     this.setSessionFailure("The language service could not be started: ", error);
                 },
-            );
+            )
+            .catch((error) => {
+                this.log.write("Language server startup failed.");
+                this.setSessionFailure("The language server could not be started: ", error);
+            });
     }
 
     private promptForRestart() {


### PR DESCRIPTION
See https://github.com/PowerShell/vscode-powershell/issues/2491.

Now we don't wait for the terminal's PID.

We also have slightly more logging so we can see progress.