### PR TITLE
Update vsce to use auto link opt out

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "sinon": "~9.0.0",
     "tslint": "~6.0.0",
     "typescript": "~3.5.3",
-    "vsce": "~1.64.0",
+    "vsce": "~1.74.0",
     "vscode-test": "~1.3.0"
   },
   "extensionDependencies": [

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -187,7 +187,7 @@ task Package UpdateReadme, {
     }
 
     Write-Host "`n### Packaging PowerShell-insiders.vsix`n" -ForegroundColor Green
-    exec { & node ./node_modules/vsce/out/vsce package }
+    exec { & node ./node_modules/vsce/out/vsce package --noGitHubIssueLinking }
 
     # Change the package to have a static name for automation purposes
     Move-Item -Force .\$($script:PackageJson.name)-$($script:PackageJson.version).vsix .\PowerShell-insiders.vsix


### PR DESCRIPTION
With https://github.com/microsoft/vscode-vsce/pull/424, we can update vsce again!