### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -262,7 +262,7 @@ EditorConfig.EditorConfig@0.12.4
 jchannon.csharpextensions@1.3.0
 k--kato.docomment@0.1.2
 ms-vscode.cpptools@0.18.1
-ms-vscode.csharp@1.16.1
+ms-dotnettools.csharp@1.12.13
 ms-vscode.PowerShell@2.0.0
 twxs.cmake@0.0.17
 vscodevim.vim@0.16.5


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)