### PR TITLE
Fix link in TOC: link to 'Exchange Online Connection' returns 404

### DIFF
--- a/docs/community_snippets.md
+++ b/docs/community_snippets.md
@@ -23,7 +23,7 @@ _To contribute, check out our [guide here](#contributing)._
 | [DataTable](#datatable) | _Creates a DataTable_ |
 | [DateTimeWriteVerbose](#datetimewriteverbose) | _Write-Verbose with the time and date pre-pended to your message by @ThmsRynr_ |
 | [Error-Terminating](#error-terminating) | _Create a full terminating error by @omniomi_ |
-| [Exchange Online Connection](exchange-online-connection) | _Create a connection to Exchange Online by @vmsilvamolina_ | 
+| [Exchange Online Connection](#exchange-online-connection) | _Create a connection to Exchange Online by @vmsilvamolina_ |
 | [HTML header](#html-header) | _Add HTML header with the style tag by @vmsilvamolina_ |
 | [MaxColumnLengthinDataTable](#maxcolumnlengthindatatable) | _Gets the max length of string columns in datatables_ |
 | [New Azure Resource Group](#new-azure-resource-group) | _Create an Azure Resource group by @vmsilvamolina_ |


### PR DESCRIPTION
## PR Summary

When clicking on Exchange Online Connection in [Table of contents](https://github.com/PowerShell/vscode-powershell/blob/master/docs/community_snippets.md#table-of-contents) in community_snippets.md the user is not taken to the snippet but to a page that does not exist.

This is fixed by adding a the missing # in the link

I have added the missing #
```markdown
| [Exchange Online Connection](exchange-online-connection) | _Create a connection to Exchange Online by @vmsilvamolina_ |
```
vs
```markdown
| [Exchange Online Connection](#exchange-online-connection) | _Create a connection to Exchange Online by @vmsilvamolina_ |
```

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] `NA` ~~PR has tests~~
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
