### PR TITLE
Rev version to v2020.4.2-preview and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PowerShell Preview Extension Release History
 
+## v2020.4.2-preview
+### Monday, April 13, 2020
+#### [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices)
+
+- 🐛📟 [PowerShellEditorServices #1258](https://github.com/PowerShell/PowerShellEditorServices/pull/1258) -
+  No more warning about PowerShellEditorServices module being imported with unapproved verb.
+
 ## v2020.4.1-preview
 ### Wednesday, April 09, 2020
 #### [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powershell-preview",
-  "version": "2020.3.2",
+  "version": "2020.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "powershell-preview",
   "displayName": "PowerShell Preview",
-  "version": "2020.4.1",
+  "version": "2020.4.2",
   "preview": true,
   "publisher": "ms-vscode",
   "description": "(Preview) Develop PowerShell scripts in Visual Studio Code!",


### PR DESCRIPTION
## v2020.4.2-preview
### Monday, April 13, 2020
#### [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices)

- 🐛📟 [PowerShellEditorServices #1258](https://github.com/PowerShell/PowerShellEditorServices/pull/1258) -
  No more warning about PowerShellEditorServices module being imported with unapproved verb.
