### PR TITLE
Display preview state and version info in PSIC startup banner

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -136,6 +136,7 @@ export function activate(context: vscode.ExtensionContext): void {
             requiredEditorServicesVersion,
             logger,
             documentSelector,
+            PackageJSON.displayName,
             PackageJSON.version,
             telemetryReporter);
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,7 +4,6 @@
 
 import fs = require("fs");
 import net = require("net");
-import * as os from "os";
 import path = require("path");
 import * as semver from "semver";
 import vscode = require("vscode");
@@ -196,7 +195,9 @@ export class SessionManager implements Middleware {
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
         } else {
-            const startupBanner = `=====> ${this.HostName} Integrated Console v${this.HostVersion} <=====${os.EOL}`;
+            const startupBanner = `
+        =====> ${this.HostName} Integrated Console v${this.HostVersion} <=====
+`;
             this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
         }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -195,8 +195,7 @@ export class SessionManager implements Middleware {
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
         } else {
-            const startupBanner = `
-        =====> ${this.HostName} Integrated Console v${this.HostVersion} <=====
+            const startupBanner = `=====> ${this.HostName} Integrated Console v${this.HostVersion} <=====
 `;
             this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -194,11 +194,10 @@ export class SessionManager implements Middleware {
         } else {
             const packageJSON: any = require("../../package.json");
             const previewStr = (packageJSON.name.toLowerCase() === "powershell-preview") ? "Preview " : "";
-            const version = packageJSON.version;
 
             const startupBanner = `
 
-            =====> PowerShell ${previewStr}Integrated Console v${version} <=====
+            =====> PowerShell ${previewStr}Integrated Console v${this.HostVersion} <=====
 
             `;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,6 +4,7 @@
 
 import fs = require("fs");
 import net = require("net");
+import * as os from "os";
 import path = require("path");
 import * as semver from "semver";
 import vscode = require("vscode");
@@ -35,6 +36,7 @@ export enum SessionStatus {
 }
 
 export class SessionManager implements Middleware {
+    public HostName: string;
     public HostVersion: string;
     public PowerShellExeDetails: IPowerShellExeDetails;
     private ShowSessionMenuCommandName = "PowerShell.ShowSessionMenu";
@@ -68,11 +70,13 @@ export class SessionManager implements Middleware {
         private requiredEditorServicesVersion: string,
         private log: Logger,
         private documentSelector: DocumentSelector,
+        private hostName: string,
         private version: string,
         private reporter: TelemetryReporter) {
 
         this.platformDetails = getPlatformDetails();
 
+        this.HostName = hostName;
         this.HostVersion = version;
         this.telemetryReporter = reporter;
 
@@ -81,7 +85,7 @@ export class SessionManager implements Middleware {
 
         this.log.write(
             `Visual Studio Code v${vscode.version} ${procBitness}`,
-            `PowerShell Extension v${this.HostVersion}`,
+            `${this.HostName} Extension v${this.HostVersion}`,
             `Operating System: ${OperatingSystem[this.platformDetails.operatingSystem]} ${osBitness}`);
 
         // Fix the host version so that PowerShell can consume it.
@@ -192,15 +196,7 @@ export class SessionManager implements Middleware {
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
         } else {
-            const packageJSON: any = require("../../package.json");
-            const previewStr = (packageJSON.name.toLowerCase() === "powershell-preview") ? "Preview " : "";
-
-            const startupBanner = `
-
-            =====> PowerShell ${previewStr}Integrated Console v${this.HostVersion} <=====
-
-            `;
-
+            const startupBanner = `=====> ${this.HostName} Integrated Console v${this.HostVersion} <=====${os.EOL}`;
             this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
         }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -191,6 +191,18 @@ export class SessionManager implements Middleware {
 
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
+        } else {
+            const packageJSON: any = require("../../package.json");
+            const previewStr = (packageJSON.name.toLowerCase() === "powershell-preview") ? "Preview " : "";
+            const version = packageJSON.version;
+
+            const startupBanner = `
+
+            =====> PowerShell ${previewStr}Integrated Console v${version} <=====
+
+            `;
+
+            this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
         }
 
         if (this.sessionSettings.developer.editorServicesWaitForDebugger) {


### PR DESCRIPTION
## PR Summary

Adds preview status and version info to the PSIC startup banner.  The info comes from the extension (not PSES).

Fix #2643 

![image](https://user-images.githubusercontent.com/5177512/79673747-baab7680-8199-11ea-940f-f30adc78440b.png)

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
