### PR TITLE
Add workspace file to load both vscode-powershell and PSES

### DIFF
--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "..\\PowerShellEditorServices"
+		}
+	],
+  "settings": {
+    "files.associations": {
+      "**/snippets/*.json": "jsonc"
+    },
+    "typescript.tsdk": "./node_modules/typescript/lib"
+  }
+}


### PR DESCRIPTION
## PR Summary

It is convenient to have both the extension and PSES loaded at the same time into VSCode.  I would think that anyone working on the extension would want that.  The name I have for it currently is `extension-dev.code-workspace` but I'm open to whatever name folks prefer.  If we don't want this then I'd like to instead add an entry to `.gitignore` to ignore `*.code-workspace` files.  That said, I don't see much harm in adding the workspace file.  Folks don't have to use it.

![image](https://user-images.githubusercontent.com/5177512/79705245-4264b400-8272-11ea-92ba-637a5be165bf.png)

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
