### PR TITLE
Clean up WaitForSessionFile logic and support increasing timeout with warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "powershell-preview",
-  "version": "2020.4.2",
+  "version": "2020.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -761,10 +761,10 @@
           "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
         },
-        "powershell.developer.waitForSessionFileNumOfTries": {
-          "type":"number",
-          "default": 120,
-          "description": "When the PowerShell extension is starting up, it checks for a session file in order to connect to the language server. It checks this number of times ever 2 seconds."
+        "powershell.developer.waitForSessionFileTimeoutSeconds": {
+          "type": "number",
+          "default": 240,
+          "description": "When the PowerShell extension is starting up, it checks for a session file in order to connect to the language server. This setting determines how long until checking for the session file times out. (default is 240 seconds or 4 minutes)"
         },
         "powershell.pester.useLegacyCodeLens": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -761,6 +761,11 @@
           "default": null,
           "description": "An array of strings that enable experimental features in the PowerShell extension."
         },
+        "powershell.developer.waitForSessionFileNumOfTries": {
+          "type":"number",
+          "default": 120,
+          "description": "When the PowerShell extension is starting up, it checks for a session file in order to connect to the language server. It checks this number of times ever 2 seconds."
+        },
         "powershell.pester.useLegacyCodeLens": {
           "type": "boolean",
           "default": true,

--- a/src/process.ts
+++ b/src/process.ts
@@ -174,20 +174,18 @@ export class PowerShellProcess {
         return true;
     }
 
-    private waitForSessionFile(): Promise<utils.IEditorServicesSessionDetails> {
-        return new Promise((resolve, reject) => {
-            utils.waitForSessionFile(this.sessionFilePath, this.sessionSettings.developer.waitForSessionFileNumOfTries, (sessionDetails, error) => {
-                utils.deleteSessionFile(this.sessionFilePath);
-
-                if (error) {
-                    this.log.write(`Error occurred retrieving session file:\n${error}`);
-                    return reject(error);
-                }
-
-                this.log.write("Session file found");
-                resolve(sessionDetails);
-            });
-        });
+    private async waitForSessionFile(): Promise<utils.IEditorServicesSessionDetails> {
+        try {
+            const sessionDetails: utils.IEditorServicesSessionDetails = await utils.waitForSessionFile(
+                this.sessionFilePath, this.sessionSettings.developer.waitForSessionFileNumOfTries);
+            this.log.write("Session file found");
+            return sessionDetails;
+        } catch (e) {
+            this.log.write(`Error occurred retrieving session file:\n${e}`);
+            throw e;
+        } finally {
+            utils.deleteSessionFile(this.sessionFilePath);
+        }
     }
 
     private onTerminalClose(terminal: vscode.Terminal) {

--- a/src/process.ts
+++ b/src/process.ts
@@ -176,7 +176,7 @@ export class PowerShellProcess {
 
     private waitForSessionFile(): Promise<utils.IEditorServicesSessionDetails> {
         return new Promise((resolve, reject) => {
-            utils.waitForSessionFile(this.sessionFilePath, (sessionDetails, error) => {
+            utils.waitForSessionFile(this.sessionFilePath, this.sessionSettings.developer.waitForSessionFileNumOfTries, (sessionDetails, error) => {
                 utils.deleteSessionFile(this.sessionFilePath);
 
                 if (error) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,6 +72,7 @@ export interface IDeveloperSettings {
     bundledModulesPath?: string;
     editorServicesLogLevel?: string;
     editorServicesWaitForDebugger?: boolean;
+    waitForSessionFileNumOfTries?: number;
 }
 
 export interface ISettings {
@@ -142,6 +143,7 @@ export function load(): ISettings {
         bundledModulesPath: "../../../PowerShellEditorServices/module",
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false,
+        waitForSessionFileNumOfTries: 120,
     };
 
     const defaultCodeFoldingSettings: ICodeFoldingSettings = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -72,7 +72,7 @@ export interface IDeveloperSettings {
     bundledModulesPath?: string;
     editorServicesLogLevel?: string;
     editorServicesWaitForDebugger?: boolean;
-    waitForSessionFileNumOfTries?: number;
+    waitForSessionFileTimeoutSeconds?: number;
 }
 
 export interface ISettings {
@@ -143,7 +143,7 @@ export function load(): ISettings {
         bundledModulesPath: "../../../PowerShellEditorServices/module",
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false,
-        waitForSessionFileNumOfTries: 120,
+        waitForSessionFileTimeoutSeconds: 240,
     };
 
     const defaultCodeFoldingSettings: ICodeFoldingSettings = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,7 +7,6 @@
 import fs = require("fs");
 import os = require("os");
 import path = require("path");
-import * as vscode from "vscode";
 
 export const PowerShellLanguageId = "powershell";
 
@@ -70,31 +69,6 @@ export function writeSessionFile(sessionFilePath: string, sessionDetails: IEdito
     writeStream.close();
 }
 
-function sleep(ms: number) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-export async function waitForSessionFile(sessionFilePath: string, numOfTries: number = 120): Promise<IEditorServicesSessionDetails> {
-    // This is used to warn the user that the extension is taking longer than expected to startup.
-    const warnUserThreshold = numOfTries / 2;
-
-    for (let i = numOfTries; i > 0; i--) {
-        if (checkIfFileExists(sessionFilePath)) {
-            // Session file was found, load and return it
-            return readSessionFile(sessionFilePath);
-        }
-
-        if (warnUserThreshold === i) {
-            vscode.window.showWarningMessage(`Loading the PowerShell extension is taking longer than expected.
-If you're using anti-virus software, this can affect start up performance.`);
-        }
-
-        // Wait a bit and try again
-        await sleep(2000);
-    }
-
-    throw new Error("Timed out waiting for session file to appear.");
-}
 
 export function readSessionFile(sessionFilePath: string): IEditorServicesSessionDetails {
     const fileContents = fs.readFileSync(sessionFilePath, "utf-8");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,6 @@ export interface IEditorServicesSessionDetails {
 }
 
 export type IReadSessionFileCallback = (details: IEditorServicesSessionDetails) => void;
-export type IWaitForSessionFileCallback = (details: IEditorServicesSessionDetails, error: string) => void;
 
 const sessionsFolder = path.resolve(__dirname, "..", "..", "sessions/");
 const sessionFilePathPrefix = path.resolve(sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID);


### PR DESCRIPTION
## PR Summary

fixes https://github.com/PowerShell/vscode-powershell/issues/2526

This does 3 things:
* ups the time out to 120 attempts * 2sec between each = 4min
* exposes `powershell.developer.waitForSessionFileNumOfTries` to modify the 120 value
* warns the user after waitForSessionFileNumOfTries/2 to say "this shouldn't be happening"
* cleans up the code to use promises/async/await instead of callbacks

Note: I needed to move this function from utils.ts into process.ts because utils.ts is also used in debugAdapter.ts which can't use the `vscode` node_module.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests - how?
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
