### PR TITLE
Add debug output option for Pester

### DIFF
--- a/package.json
+++ b/package.json
@@ -790,7 +790,7 @@
             "Diagnostic"
           ],
           "default": "Diagnostic",
-          "description": "Defines the verbosity of output to be used when debugging a test. For Pester 5 and newer the default value Diagnostic will print additional information about discovery, skipped and filtered tests, mocking and more."
+          "description": "Defines the verbosity of output to be used when debugging a test or a block. For Pester 5 and newer the default value Diagnostic will print additional information about discovery, skipped and filtered tests, mocking and more."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -775,11 +775,22 @@
           "type": "string",
           "enum": [
             "FromPreference",
+            "Minimal",
             "Normal",
-            "Minimal"
+            "Diagnostic"
           ],
           "default": "FromPreference",
           "description": "Defines the verbosity of output to be used. For Pester 5 and newer the default value FromPreference, will use the Output settings from the $PesterPreference defined in the caller context, and will default to Normal if there is none. For Pester 4 the FromPreference and Normal options map to All, and Minimal option maps to Fails."
+        },
+        "powershell.pester.debugOutputVerbosity": {
+          "type": "string",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Diagnostic"
+          ],
+          "default": "Diagnostic",
+          "description": "Defines the verbosity of output to be used when debugging a test. For Pester 5 and newer the default value Diagnostic will print additional information about discovery, skipped and filtered tests, mocking and more."
         }
       }
     },

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -113,7 +113,13 @@ export class PesterTestsFeature implements IFeature {
             launchConfig.args.push("-MinimumVersion5");
         }
 
-        launchConfig.args.push("-Output", `'${settings.pester.outputVerbosity}'`);
+        if (launchType === LaunchType.Debug) {
+            launchConfig.args.push("-Output", `'${settings.pester.debugOutputVerbosity}'`);
+
+        }
+        else {
+            launchConfig.args.push("-Output", `'${settings.pester.outputVerbosity}'`);
+        }
 
         return launchConfig;
     }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -115,7 +115,6 @@ export class PesterTestsFeature implements IFeature {
 
         if (launchType === LaunchType.Debug) {
             launchConfig.args.push("-Output", `'${settings.pester.debugOutputVerbosity}'`);
-
         }
         else {
             launchConfig.args.push("-Output", `'${settings.pester.outputVerbosity}'`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -119,6 +119,7 @@ export interface ISideBarSettings {
 export interface IPesterSettings {
     useLegacyCodeLens?: boolean;
     outputVerbosity?: string;
+    debugOutputVerbosity?: string;
 }
 
 export function load(): ISettings {
@@ -189,6 +190,7 @@ export function load(): ISettings {
     const defaultPesterSettings: IPesterSettings = {
         useLegacyCodeLens: true,
         outputVerbosity: "FromPreference",
+        debugOutputVerbosity: "Diagnostic",
     };
 
     return {


### PR DESCRIPTION
## PR Summary

Add an option to Pester section to print different level of output when test or a block is debugged, and set that to Diagnostic. This allows me to print a more verbose output from Discovery, Skip, Filter, and especially Mock with information that is helpful when debugging, but too verbose for normal usage.

This only affects Pester 5, in Pester 4 we fall back to the Normal output.

This change will ship in Pester 5.0.0-rc6 which will be released before tomorrow evening.

![mock-diag2](https://user-images.githubusercontent.com/5735905/80570032-5ccd2900-89fa-11ea-8d5d-8e6f3aa032f2.gif)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
