### PR TITLE
PSSA 1.19.0 settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -656,10 +656,11 @@
           "enum": [
             "IncreaseIndentationForFirstPipeline",
             "IncreaseIndentationAfterEveryPipeline",
-            "NoIndentation"
+            "NoIndentation",
+            "None"
           ],
-          "default": "NoIndentation",
-          "description": "Multi-line pipeline style settings."
+          "default": "None",
+          "description": "Multi-line pipeline style settings (default: None)."
         },
         "powershell.codeFormatting.whitespaceBeforeOpenBrace": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -686,10 +686,20 @@
           "default": true,
           "description": "Adds a space after an opening brace ('{') and before a closing brace ('}')."
         },
-        "powershell.codeFormatting.whitespaceAroundPipe": {
+        "powershell.codeFormatting.whitespaceBetweenParameters": {
+          "type": "boolean",
+          "default": false,
+          "description": "Removes redundant whitespace between parameters."
+        },
+        "powershell.codeFormatting.addWhitespaceAroundPipe": {
           "type": "boolean",
           "default": true,
-          "description": "Adds a space before and after the pipeline operator ('|')."
+          "description": "Adds a space before and after the pipeline operator ('|') if it is missing."
+        },
+        "powershell.codeFormatting.trimWhitespaceAroundPipe": {
+          "type": "boolean",
+          "default": false,
+          "description": "Trims extraneous whitespace (more than 1 character) before and after the pipeline operator ('|')."
         },
         "powershell.codeFormatting.ignoreOneLineBlock": {
           "type": "boolean",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,8 +51,9 @@ export interface ICodeFormattingSettings {
     whitespaceBeforeOpenParen: boolean;
     whitespaceAroundOperator: boolean;
     whitespaceAfterSeparator: boolean;
-    whitespaceInsideBrace: true;
-    whitespaceAroundPipe: true;
+    whitespaceInsideBrace: boolean;
+    addWhitespaceAroundPipe: boolean;
+    trimWhitespaceAroundPipe: boolean;
     ignoreOneLineBlock: boolean;
     alignPropertyValuePairs: boolean;
     useCorrectCasing: boolean;
@@ -164,7 +165,8 @@ export function load(): ISettings {
         whitespaceAroundOperator: true,
         whitespaceAfterSeparator: true,
         whitespaceInsideBrace: true,
-        whitespaceAroundPipe: true,
+        addWhitespaceAroundPipe: true,
+        trimWhitespaceAroundPipe: false,
         ignoreOneLineBlock: true,
         alignPropertyValuePairs: true,
         useCorrectCasing: false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,6 +18,7 @@ enum PipelineIndentationStyle {
     IncreaseIndentationForFirstPipeline,
     IncreaseIndentationAfterEveryPipeline,
     NoIndentation,
+    None,
 }
 
 export enum HelpCompletion {
@@ -51,6 +52,7 @@ export interface ICodeFormattingSettings {
     whitespaceBeforeOpenParen: boolean;
     whitespaceAroundOperator: boolean;
     whitespaceAfterSeparator: boolean;
+    whitespaceBetweenParameters: boolean;
     whitespaceInsideBrace: boolean;
     addWhitespaceAroundPipe: boolean;
     trimWhitespaceAroundPipe: boolean;
@@ -159,11 +161,12 @@ export function load(): ISettings {
         openBraceOnSameLine: true,
         newLineAfterOpenBrace: true,
         newLineAfterCloseBrace: true,
-        pipelineIndentationStyle: PipelineIndentationStyle.NoIndentation,
+        pipelineIndentationStyle: PipelineIndentationStyle.None,
         whitespaceBeforeOpenBrace: true,
         whitespaceBeforeOpenParen: true,
         whitespaceAroundOperator: true,
         whitespaceAfterSeparator: true,
+        whitespaceBetweenParameters: false,
         whitespaceInsideBrace: true,
         addWhitespaceAroundPipe: true,
         trimWhitespaceAroundPipe: false,


### PR DESCRIPTION
## PR Summary

Pending PSSA `1.19.0` release and this PSES PR, but I tested it locally: https://github.com/PowerShell/PowerShellEditorServices/pull/1280

- Split the `powershell.codeFormatting.trimWhitespaceAroundPipe` setting into 2 settings since PSSA has changed the behaviour of the current setting to only add the missing white space around pipes but not remove any more. For trimming of redundant whitespace a new settings was added in PSSA (this way it would not be breaking if someone used PSSA 1.19.0 with the current version of the extension). I could've applied something similar here and only added the new setting but for better naming, I decided to rename the setting `powershell.codeFormatting.whitespaceAroundPipe` to `powershell.codeFormatting.trimWhitespaceAroundPipe`, this is a breaking change, can we help the user point to the new setting? The new setting is `powershell.codeFormatting.addWhitespaceAroundPipe` and is disabled by default)
- Add new setting `powershell.codeFormatting.whitespaceBetweenParameters` (disabled by default)
- Add new `None` option for `powershell.codeFormatting.pipelineIndentationStyle` and make it the default. This new setting means that the formatter will not change the user's pipeline indentation so that the user has to explicitly opt-in, this was due community feedback.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
