### PR TITLE
🐛 Respect user choice when dismissing the powerShellExePath dialog

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -329,7 +329,7 @@ export class SessionManager implements Middleware {
 
             const choice = await vscode.window.showWarningMessage(warningMessage, "Let's do it!");
 
-            if (choice === "") {
+            if (choice === undefined) {
                 // They hit the 'x' to close the dialog.
                 return;
             }


### PR DESCRIPTION
## PR Summary

Currently the extension actually changes the user's `powerShellExePath` if the user dismisses the presented dialog by clicking on the `x` button.
The VS-Code API `vscode.window.showWarningMessage(message: string, items: string[])` returns `undefined` when the user dismisses the dialog: https://code.visualstudio.com/api/references/vscode-api#window.showWarningMessage
![image](https://user-images.githubusercontent.com/9250262/81500437-229d3a80-92ca-11ea-84c7-7c3920a4bd5b.png)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
