### PR TITLE
🔧🚗 Migrate setting value of codeFormatting.whitespaceAroundPipe (if present) to new setting codeFormatting.addWhitespaceAroundPipe automatically.

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -323,7 +323,7 @@ export class SessionManager implements Middleware {
     }
 
     // During preview, populate a new setting value but not remove the old value.
-    // When the PowerShell extension releases the RTM version, then the old value can be safely removed.
+    // TODO: When the next stable extension releases, then the old value can be safely removed. Tracked in this issue: https://github.com/PowerShell/vscode-powershell/issues/2693
     private async migrateWhitespaceAroundPipeSetting() {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'

--- a/src/session.ts
+++ b/src/session.ts
@@ -328,7 +328,7 @@ export class SessionManager implements Middleware {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'
         if (configuration.has(deprecatedSetting) && !configuration.has('codeFormatting.addWhitespaceAroundPipe')) {
-            const configurationTarget = await Settings.getConfigurationTarget(deprecatedSetting);
+            const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
             const value = configuration.get(deprecatedSetting, configurationTarget)
             await Settings.change('codeFormatting.addWhitespaceAroundPipe', value, configurationTarget);
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -251,13 +251,13 @@ export async function getEffectiveConfigurationTarget(settingName: string): Prom
 
     const detail = configuration.inspect(settingName);
     let configurationTarget = null;
-    if (typeof detail.workspaceFolderValue !== undefined) {
+    if (typeof detail.workspaceFolderValue !== "undefined") {
         configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder;
     }
-    else if (typeof detail.workspaceValue !== undefined) {
+    else if (typeof detail.workspaceValue !== "undefined") {
         configurationTarget = vscode.ConfigurationTarget.Workspace;
     }
-    else if (typeof detail.globalValue !== undefined) {
+    else if (typeof detail.globalValue !== "undefined") {
         configurationTarget = vscode.ConfigurationTarget.Global;
     }
     return configurationTarget;
@@ -265,7 +265,8 @@ export async function getEffectiveConfigurationTarget(settingName: string): Prom
 
 export async function change(
     settingName: string,
-    newValue: any, configurationTarget?: vscode.ConfigurationTarget | boolean): Promise<void> {
+    newValue: any,
+    configurationTarget?: vscode.ConfigurationTarget | boolean): Promise<void> {
 
     const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -245,12 +245,30 @@ export function load(): ISettings {
     };
 }
 
-export async function change(settingName: string, newValue: any, global: boolean = false): Promise<void> {
-    const configuration: vscode.WorkspaceConfiguration =
-        vscode.workspace.getConfiguration(
-            utils.PowerShellLanguageId);
+export async function getConfigurationTarget(settingName: string): Promise<vscode.ConfigurationTarget> {
+    const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
 
-    await configuration.update(settingName, newValue, global);
+    const detail = configuration.inspect(settingName);
+    let configurationTarget = null;
+    if (detail.workspaceFolderValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder
+    }
+    else if (detail.workspaceValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.Workspace
+    }
+    else if (detail.globalValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.Global
+    }
+    return configurationTarget;
+}
+
+export async function change(
+    settingName: string,
+    newValue: any, configurationTarget?: vscode.ConfigurationTarget | boolean): Promise<void> {
+
+    const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
+
+    await configuration.update(settingName, newValue, configurationTarget);
 }
 
 function getWorkspaceSettingsWithDefaults<TSettings>(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -245,7 +245,8 @@ export function load(): ISettings {
     };
 }
 
-export async function getConfigurationTarget(settingName: string): Promise<vscode.ConfigurationTarget> {
+// Get the ConfigurationTarget (read: scope) of where the *effective* setting value comes from
+export async function getEffectiveConfigurationTarget(settingName: string): Promise<vscode.ConfigurationTarget> {
     const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
 
     const detail = configuration.inspect(settingName);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -250,14 +250,14 @@ export async function getConfigurationTarget(settingName: string): Promise<vscod
 
     const detail = configuration.inspect(settingName);
     let configurationTarget = null;
-    if (detail.workspaceFolderValue !== undefined) {
-        configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder
+    if (typeof detail.workspaceFolderValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder;
     }
-    else if (detail.workspaceValue !== undefined) {
-        configurationTarget = vscode.ConfigurationTarget.Workspace
+    else if (typeof detail.workspaceValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.Workspace;
     }
-    else if (detail.globalValue !== undefined) {
-        configurationTarget = vscode.ConfigurationTarget.Global
+    else if (typeof detail.globalValue !== undefined) {
+        configurationTarget = vscode.ConfigurationTarget.Global;
     }
     return configurationTarget;
 }


### PR DESCRIPTION
## PR Summary

This for the time of the preview with PSSA 1.19.0 to help migrate the setting automatically.
Because of settings sync, I do not want to remove the old setting yet, we should add removal of the old setting only for the RTM version of the PowerShell extension (where we will then also be able to give an informational window to the user)

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
