### PR TITLE
Change default of powershell.codeFormatting.pipelineIndentationStyle from None back to NoIndentation due to PSSA bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -657,8 +657,8 @@
             "NoIndentation",
             "None"
           ],
-          "default": "None",
-          "description": "Multi-line pipeline style settings (default: None)."
+          "default": "NoIndentation",
+          "description": "Multi-line pipeline style settings (default: NoIndentation)."
         },
         "powershell.codeFormatting.whitespaceBeforeOpenBrace": {
           "type": "boolean",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -162,7 +162,7 @@ export function load(): ISettings {
         openBraceOnSameLine: true,
         newLineAfterOpenBrace: true,
         newLineAfterCloseBrace: true,
-        pipelineIndentationStyle: PipelineIndentationStyle.None,
+        pipelineIndentationStyle: PipelineIndentationStyle.NoIndentation,
         whitespaceBeforeOpenBrace: true,
         whitespaceBeforeOpenParen: true,
         whitespaceAroundOperator: true,


### PR DESCRIPTION
## PR Summary

Fixes #2696
cc @TylerLeonhardt  @rjmholt 

Tracking PSSA bug is here: https://github.com/PowerShell/PSScriptAnalyzer/issues/1496
I already have a fix ready for the PSSA issue, it is an embarrassing mistake, I used break when I meant to use continue in a for loop :-(
Sorry, but without the test coverage from the preview extension, I wouldn't have found this earlier because locally I don't use the default value for that setting.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
