### PR TITLE
Add coloring for $ and wordSepartors 

### DIFF
--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -24,6 +24,7 @@ export class ISECompatibilityFeature implements IFeature {
         { path: "powershell.integratedConsole", name: "focusConsoleOnExecute", value: false },
         { path: "files", name: "defaultLanguage", value: "powershell" },
         { path: "workbench", name: "colorTheme", value: "PowerShell ISE" },
+        { path: "editor", name: "wordSeparators", value: "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?" }
     ];
     private iseCommandRegistration: vscode.Disposable;
     private defaultCommandRegistration: vscode.Disposable;

--- a/themes/theme-psise/theme.json
+++ b/themes/theme-psise/theme.json
@@ -93,7 +93,9 @@
 			"name": "Variables",
 			"scope": [
 				"variable",
-				"support.variable"
+				"support.variable",
+				"punctuation.definition.variable.powershell",
+				"variable.other.readwrite.powershell"
 			],
 			"settings": {
 				"foreground": "#FF4500"


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
Adding scopes in the theme to make the $ orange aswell. 
![image](https://user-images.githubusercontent.com/22131101/81986311-db9ba600-9637-11ea-95ea-65e2d3e4375b.png)

Also adding wordSepartors to ISE Mode 
Fixes #2546

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
