### PR TITLE
Tweak whitespaceAroundPipe settings migration logic to do it only once

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -324,10 +324,12 @@ export class SessionManager implements Middleware {
     private async migrateWhitespaceAroundPipeSetting() {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'
-        const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
-        if (configuration.has(deprecatedSetting) && configurationTarget != null) {
+        const newSetting = 'codeFormatting.addWhitespaceAroundPipe'
+        const configurationTargetOfNewSetting = await Settings.getEffectiveConfigurationTarget(newSetting);
+        if (configuration.has(deprecatedSetting) && configurationTargetOfNewSetting === null) {
+            const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
             const value = configuration.get(deprecatedSetting, configurationTarget)
-            await Settings.change('codeFormatting.addWhitespaceAroundPipe', value, configurationTarget);
+            await Settings.change(newSetting, value, configurationTarget);
         }
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -324,8 +324,8 @@ export class SessionManager implements Middleware {
     private async migrateWhitespaceAroundPipeSetting() {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'
-        if (configuration.has(deprecatedSetting) && !configuration.has('codeFormatting.addWhitespaceAroundPipe')) {
-            const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
+        const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
+        if (configuration.has(deprecatedSetting) && configurationTarget != null) {
             const value = configuration.get(deprecatedSetting, configurationTarget)
             await Settings.change('codeFormatting.addWhitespaceAroundPipe', value, configurationTarget);
         }


### PR DESCRIPTION
## PR Summary

This makes the settings migration  happen only once, instead of every time. That is because of how `configuration.has` works.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
