### PR TITLE
Add buttons for moving the terminal around.

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,33 @@
         "command": "PowerShell.InvokeRegisteredEditorCommand",
         "title": "Invoke Registered Editor Command",
         "category": "PowerShell"
+      },
+      {
+        "command": "workbench.action.closePanel",
+        "title": "Close panel",
+        "category": "PowerShell",
+        "icon": {
+          "light": "resources/light/ClosePanel.svg",
+          "dark": "resources/dark/ClosePanel.svg"
+        }
+      },
+      {
+        "command": "workbench.action.positionPanelLeft",
+        "title": "Move panel left",
+        "category": "PowerShell",
+        "icon": {
+          "light": "resources/light/MovePanelLeft.svg",
+          "dark": "resources/dark/MovePanelLeft.svg"
+        }
+      },
+      {
+        "command": "workbench.action.positionPanelBottom",
+        "title": "Move panel to bottom",
+        "category": "PowerShell",
+        "icon": {
+          "light": "resources/light/MovePanelBottom.svg",
+          "dark": "resources/dark/MovePanelBottom.svg"
+        }
       }
     ],
     "menus": {
@@ -305,6 +332,21 @@
         }
       ],
       "editor/title": [
+        {
+          "when": "editorLangId == powershell",
+          "command": "workbench.action.positionPanelBottom",
+          "group": "navigation@97"
+        },
+        {
+          "when": "editorLangId == powershell",
+          "command": "workbench.action.positionPanelLeft",
+          "group": "navigation@98"
+        },
+        {
+          "when": "editorLangId == powershell",
+          "command": "workbench.action.closePanel",
+          "group": "navigation@99"
+        },
         {
           "when": "editorLangId == powershell",
           "command": "workbench.action.debug.start",

--- a/package.json
+++ b/package.json
@@ -333,27 +333,27 @@
       ],
       "editor/title": [
         {
-          "when": "editorLangId == powershell",
+          "when": "editorLangId == powershell && config.powershell.buttons.MovePanelToBottomButtonVisibility",
           "command": "workbench.action.positionPanelBottom",
           "group": "navigation@97"
         },
         {
-          "when": "editorLangId == powershell",
+          "when": "editorLangId == powershell && config.powershell.buttons.MovePanelLeftButtonVisibility",
           "command": "workbench.action.positionPanelLeft",
           "group": "navigation@98"
         },
         {
-          "when": "editorLangId == powershell",
+          "when": "editorLangId == powershell && config.powershell.buttons.ClosePanelButtonVisibility",
           "command": "workbench.action.closePanel",
           "group": "navigation@99"
         },
         {
-          "when": "editorLangId == powershell",
+          "when": "editorLangId == powershell && config.powershell.buttons.RunButtonVisibility",
           "command": "workbench.action.debug.start",
           "group": "navigation@100"
         },
         {
-          "when": "editorLangId == powershell",
+          "when": "editorLangId == powershell && config.powershell.buttons.RunSelectionButtonVisibility",
           "command": "PowerShell.RunSelection",
           "group": "navigation@101"
         }
@@ -842,6 +842,31 @@
           ],
           "default": "Diagnostic",
           "description": "Defines the verbosity of output to be used when debugging a test or a block. For Pester 5 and newer the default value Diagnostic will print additional information about discovery, skipped and filtered tests, mocking and more."
+        },
+        "powershell.buttons.RunButtonVisibility": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the Run button in the editor titlebar."
+        },
+        "powershell.buttons.RunSelectionButtonVisibility": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the Run Selection button in the editor titlebar."
+        },
+        "powershell.buttons.ClosePanelButtonVisibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the Close panel button in the editor titlebar."
+        },
+        "powershell.buttons.MovePanelLeftButtonVisibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the Move panel left button in the editor titlebar."
+        },
+        "powershell.buttons.MovePanelToBottomButtonVisibility": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show the Move panel to bottom button in the editor titlebar."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -333,27 +333,27 @@
       ],
       "editor/title": [
         {
-          "when": "editorLangId == powershell && config.powershell.buttons.MovePanelToBottomButtonVisibility",
+          "when": "editorLangId == powershell && config.powershell.buttons.showPanelMovementButtons",
           "command": "workbench.action.positionPanelBottom",
           "group": "navigation@97"
         },
         {
-          "when": "editorLangId == powershell && config.powershell.buttons.MovePanelLeftButtonVisibility",
+          "when": "editorLangId == powershell && config.powershell.buttons.showPanelMovementButtons",
           "command": "workbench.action.positionPanelLeft",
           "group": "navigation@98"
         },
         {
-          "when": "editorLangId == powershell && config.powershell.buttons.ClosePanelButtonVisibility",
+          "when": "editorLangId == powershell && config.powershell.buttons.showPanelMovementButtons",
           "command": "workbench.action.closePanel",
           "group": "navigation@99"
         },
         {
-          "when": "editorLangId == powershell && config.powershell.buttons.RunButtonVisibility",
+          "when": "editorLangId == powershell && config.powershell.buttons.showRunButtons",
           "command": "workbench.action.debug.start",
           "group": "navigation@100"
         },
         {
-          "when": "editorLangId == powershell && config.powershell.buttons.RunSelectionButtonVisibility",
+          "when": "editorLangId == powershell && config.powershell.buttons.showRunButtons",
           "command": "PowerShell.RunSelection",
           "group": "navigation@101"
         }
@@ -843,30 +843,15 @@
           "default": "Diagnostic",
           "description": "Defines the verbosity of output to be used when debugging a test or a block. For Pester 5 and newer the default value Diagnostic will print additional information about discovery, skipped and filtered tests, mocking and more."
         },
-        "powershell.buttons.RunButtonVisibility": {
+        "powershell.buttons.showRunButtons": {
           "type": "boolean",
           "default": true,
-          "description": "Show the Run button in the editor titlebar."
+          "description": "Show the Run and Run Selection buttons in the editor titlebar."
         },
-        "powershell.buttons.RunSelectionButtonVisibility": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show the Run Selection button in the editor titlebar."
-        },
-        "powershell.buttons.ClosePanelButtonVisibility": {
+        "powershell.buttons.showPanelMovementButtons": {
           "type": "boolean",
           "default": false,
-          "description": "Show the Close panel button in the editor titlebar."
-        },
-        "powershell.buttons.MovePanelLeftButtonVisibility": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show the Move panel left button in the editor titlebar."
-        },
-        "powershell.buttons.MovePanelToBottomButtonVisibility": {
-          "type": "boolean",
-          "default": false,
-          "description": "Show the Move panel to bottom button in the editor titlebar."
+          "description": "Show buttons in the editor titlebar for moving the panel around."
         }
       }
     },

--- a/resources/dark/ClosePanel.svg
+++ b/resources/dark/ClosePanel.svg
@@ -1,0 +1,9 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"   stroke="#C5C5C5" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"  stroke="#C5C5C5" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"    stroke="#C5C5C5" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder" stroke="#C5C5C5" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder" stroke="#C5C5C5" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"  stroke="#C5C5C5" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"  stroke="#C5C5C5" x1="16"   y1="1"    x2="16"   y2="4"/>
+</svg>

--- a/resources/dark/MovePanelBottom.svg
+++ b/resources/dark/MovePanelBottom.svg
@@ -1,0 +1,10 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"     stroke="#C5C5C5" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"    stroke="#C5C5C5" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"      stroke="#C5C5C5" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder"   stroke="#C5C5C5" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder"   stroke="#C5C5C5" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"    stroke="#C5C5C5" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"    stroke="#C5C5C5" x1="16"   y1="1"    x2="16"   y2="4"/>
+  <line id="TerminalBorder" stroke="#C5C5C5" x1="1"    y1="10.5" x2="18"   y2="10.5"/>
+</svg>

--- a/resources/dark/MovePanelLeft.svg
+++ b/resources/dark/MovePanelLeft.svg
@@ -1,0 +1,10 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"     stroke="#C5C5C5" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"    stroke="#C5C5C5" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"      stroke="#C5C5C5" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder"   stroke="#C5C5C5" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder"   stroke="#C5C5C5" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"    stroke="#C5C5C5" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"    stroke="#C5C5C5" x1="16"   y1="1"    x2="16"   y2="4"/>
+  <line id="TerminalBorder" stroke="#C5C5C5" x1="9.5"  y1="5"    x2="9.5"  y2="15"/>
+</svg>

--- a/resources/light/ClosePanel.svg
+++ b/resources/light/ClosePanel.svg
@@ -1,0 +1,9 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"   stroke="#000000" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"  stroke="#000000" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"    stroke="#000000" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder" stroke="#000000" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder" stroke="#000000" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"  stroke="#000000" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"  stroke="#000000" x1="16"   y1="1"    x2="16"   y2="4"/>
+</svg>

--- a/resources/light/MovePanelBottom.svg
+++ b/resources/light/MovePanelBottom.svg
@@ -1,0 +1,10 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"     stroke="#000000" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"    stroke="#000000" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"      stroke="#000000" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder"   stroke="#000000" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder"   stroke="#000000" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"    stroke="#000000" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"    stroke="#000000" x1="16"   y1="1"    x2="16"   y2="4"/>
+  <line id="TerminalBorder" stroke="#000000" x1="1"    y1="10.5" x2="18"   y2="10.5"/>
+</svg>

--- a/resources/light/MovePanelLeft.svg
+++ b/resources/light/MovePanelLeft.svg
@@ -1,0 +1,10 @@
+<svg width="19" height="16" xmlns="http://www.w3.org/2000/svg">
+  <line id="LeftBorder"     stroke="#000000" x1="0.5"  y1="0"    x2="0.5"  y2="16"/>
+  <line id="RightBorder"    stroke="#000000" x1="18.5" y1="0"    x2="18.5" y2="16"/>
+  <line id="TopBorder"      stroke="#000000" x1="1"    y1="0.5"  x2="18"   y2="0.5"/>
+  <line id="BottomBorder"   stroke="#000000" x1="1"    y1="15.5" x2="18"   y2="15.5"/>
+  <line id="HeaderBorder"   stroke="#000000" x1="1"    y1="4.5"  x2="18"   y2="4.5"/>
+  <line id="FakeButton1"    stroke="#000000" x1="13"   y1="1"    x2="13"   y2="4"/>
+  <line id="FakeButton2"    stroke="#000000" x1="16"   y1="1"    x2="16"   y2="4"/>
+  <line id="TerminalBorder" stroke="#000000" x1="9.5"  y1="5"    x2="9.5"  y2="15"/>
+</svg>

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -24,6 +24,9 @@ export class ISECompatibilityFeature implements IFeature {
         { path: "powershell.integratedConsole", name: "focusConsoleOnExecute", value: false },
         { path: "files", name: "defaultLanguage", value: "powershell" },
         { path: "workbench", name: "colorTheme", value: "PowerShell ISE" },
+        { path: "powershell.buttons", name: "ClosePanelButtonVisibility", value: true },
+        { path: "powershell.buttons", name: "MovePanelLeftButtonVisibility", value: true },
+        { path: "powershell.buttons", name: "MovePanelToBottomButtonVisibility", value: true }
     ];
     private iseCommandRegistration: vscode.Disposable;
     private defaultCommandRegistration: vscode.Disposable;

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -24,9 +24,7 @@ export class ISECompatibilityFeature implements IFeature {
         { path: "powershell.integratedConsole", name: "focusConsoleOnExecute", value: false },
         { path: "files", name: "defaultLanguage", value: "powershell" },
         { path: "workbench", name: "colorTheme", value: "PowerShell ISE" },
-        { path: "powershell.buttons", name: "ClosePanelButtonVisibility", value: true },
-        { path: "powershell.buttons", name: "MovePanelLeftButtonVisibility", value: true },
-        { path: "powershell.buttons", name: "MovePanelToBottomButtonVisibility", value: true }
+        { path: "powershell.buttons", name: "showPanelMovementButtons", value: true }
     ];
     private iseCommandRegistration: vscode.Disposable;
     private defaultCommandRegistration: vscode.Disposable;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -127,11 +127,8 @@ export interface IPesterSettings {
 }
 
 export interface IButtonSettings {
-    RunButtonVisibility?: boolean;
-    RunSelectionButtonVisibility?: boolean;
-    ClosePanelButtonVisibility?: boolean;
-    MovePanelLeftButtonVisibility?: boolean;
-    MovePanelToBottomButtonVisibility?: boolean;
+    showRunButtons?: boolean;
+    showPanelMovementButtons?: boolean;
 }
 
 export function load(): ISettings {
@@ -202,11 +199,8 @@ export function load(): ISettings {
     };
 
     const defaultButtonSettings: IButtonSettings = {
-        RunButtonVisibility: true,
-        RunSelectionButtonVisibility: true,
-        ClosePanelButtonVisibility: false,
-        MovePanelLeftButtonVisibility: false,
-        MovePanelToBottomButtonVisibility: false
+        showRunButtons: true,
+        showPanelMovementButtons: false
     };
 
     const defaultPesterSettings: IPesterSettings = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -100,6 +100,7 @@ export interface ISettings {
     bugReporting?: IBugReportingSettings;
     sideBar?: ISideBarSettings;
     pester?: IPesterSettings;
+    buttons?: IButtonSettings;
 }
 
 export interface IStartAsLoginShellSettings {
@@ -123,6 +124,14 @@ export interface IPesterSettings {
     useLegacyCodeLens?: boolean;
     outputVerbosity?: string;
     debugOutputVerbosity?: string;
+}
+
+export interface IButtonSettings {
+    RunButtonVisibility?: boolean;
+    RunSelectionButtonVisibility?: boolean;
+    ClosePanelButtonVisibility?: boolean;
+    MovePanelLeftButtonVisibility?: boolean;
+    MovePanelToBottomButtonVisibility?: boolean;
 }
 
 export function load(): ISettings {
@@ -192,6 +201,14 @@ export function load(): ISettings {
         CommandExplorerVisibility: true,
     };
 
+    const defaultButtonSettings: IButtonSettings = {
+        RunButtonVisibility: true,
+        RunSelectionButtonVisibility: true,
+        ClosePanelButtonVisibility: false,
+        MovePanelLeftButtonVisibility: false,
+        MovePanelToBottomButtonVisibility: false
+    };
+
     const defaultPesterSettings: IPesterSettings = {
         useLegacyCodeLens: true,
         outputVerbosity: "FromPreference",
@@ -237,6 +254,8 @@ export function load(): ISettings {
             configuration.get<ISideBarSettings>("sideBar", defaultSideBarSettings),
         pester:
             configuration.get<IPesterSettings>("pester", defaultPesterSettings),
+        buttons:
+            configuration.get<IButtonSettings>("buttons", defaultButtonSettings),
         startAsLoginShell:
             // tslint:disable-next-line
             // We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107


### PR DESCRIPTION
## PR Summary

This adds 3 new buttons to the titlebar for moving the terminal around, like the ISE had.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [NA] PR has tests
- [X] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
