### PR TITLE
Add new Pester 5 GA Output Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -826,8 +826,10 @@
           "type": "string",
           "enum": [
             "FromPreference",
+            "None",
             "Minimal",
             "Normal",
+            "Detailed",
             "Diagnostic"
           ],
           "default": "FromPreference",
@@ -836,8 +838,10 @@
         "powershell.pester.debugOutputVerbosity": {
           "type": "string",
           "enum": [
+            "None",
             "Minimal",
             "Normal",
+            "Detailed",
             "Diagnostic"
           ],
           "default": "Diagnostic",


### PR DESCRIPTION
New Pester 5 Output Types were added last-minute to GA. These should also be available in the extension pester settings options.
https://github.com/pester/Pester/blob/v5.0/README.md#actual-breaking-changes

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
