### PR TITLE
Support adding an OutputFile and allow running from command pallet

### DIFF
--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -53,7 +53,10 @@ param(
     [switch] $MinimumVersion5,
 
     [Parameter(Mandatory)]
-    [string] $Output
+    [string] $Output,
+
+    [Parameter()]
+    [string] $OutputPath
 )
 
 $pesterModule = Microsoft.PowerShell.Core\Get-Module Pester
@@ -103,6 +106,14 @@ if ($All) {
         if ("FromPreference" -ne $Output) {
             $configuration.Add('Output', @{ Verbosity = $Output })
         }
+
+        if ($OutputPath) {
+            $configuration.Add('TestResult', @{
+                Enabled = $true
+                OutputFormat = "NUnit2.5"
+                OutputPath = $OutputPath
+            })
+        }
         Pester\Invoke-Pester -Configuration $configuration | Out-Null
     }
     elseif ($pesterModule.Version -ge '3.4.5') {
@@ -132,6 +143,15 @@ elseif (($LineNumber -match '\d+') -and ($pesterModule.Version -ge '4.6.0')) {
         if ("FromPreference" -ne $Output) {
             $configuration.Add('Output', @{ Verbosity = $Output })
         }
+
+        if ($OutputPath) {
+            $configuration.Add('TestResult', @{
+                Enabled = $true
+                OutputFormat = "NUnit2.5"
+                OutputPath = $OutputPath
+            })
+        }
+
         Pester\Invoke-Pester -Configuration $configuration | Out-Null
     }
     else {

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -54,7 +54,6 @@ export class PesterTestsFeature implements IFeature {
     private launchAllTestsInActiveEditor(launchType: LaunchType, fileUri: vscode.Uri) {
         const uriString = (fileUri || vscode.window.activeTextEditor.document.uri).toString();
         const launchConfig = this.createLaunchConfig(uriString, launchType);
-        launchConfig.args.push("-All");
         this.launch(launchConfig);
     }
 
@@ -105,15 +104,15 @@ export class PesterTestsFeature implements IFeature {
 
         if (lineNum) {
             launchConfig.args.push("-LineNumber", `${lineNum}`);
-        }
-
-        if (testName) {
+        } else if (testName) {
             // Escape single quotes inside double quotes by doubling them up
             if (testName.includes("'")) {
                 testName = testName.replace(/'/g, "''");
             }
 
             launchConfig.args.push("-TestName", `'${testName}'`);
+        } else {
+            launchConfig.args.push("-All");
         }
 
         if (!settings.pester.useLegacyCodeLens) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -283,7 +283,7 @@ export class SessionManager implements Middleware {
             const resolvedCodeLens = next(codeLens, token);
             const resolveFunc =
                 (codeLensToFix: vscode.CodeLens): vscode.CodeLens => {
-                    if (codeLensToFix.command.command === "editor.action.showReferences") {
+                    if (codeLensToFix.command?.command === "editor.action.showReferences") {
                         const oldArgs = codeLensToFix.command.arguments;
 
                         // Our JSON objects don't get handled correctly by


### PR DESCRIPTION
## PR Summary

This will enable the Test Explorer extension to output the file needed to change its state.

This also fixes https://github.com/PowerShell/vscode-powershell/issues/2715

cc @nohwnd 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
