### PR TITLE
Fix quoting of banner for global tool

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -11,9 +11,6 @@ steps:
 
       # Using `prependpath` to update the PATH just for this build.
       Write-Host "##vso[task.prependpath]$powerShellPath"
-
-      # Force override of unimportant errors in the install script
-      exit 0
     displayName: Install PowerShell Daily
   - pwsh: '$PSVersionTable'
     displayName: Display PowerShell version information

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -11,6 +11,9 @@ steps:
 
       # Using `prependpath` to update the PATH just for this build.
       Write-Host "##vso[task.prependpath]$powerShellPath"
+
+      # Force override of unimportant errors in the install script
+      exit 0
     displayName: Install PowerShell Daily
   - pwsh: '$PSVersionTable'
     displayName: Display PowerShell version information

--- a/src/session.ts
+++ b/src/session.ts
@@ -196,7 +196,7 @@ export class SessionManager implements Middleware {
         } else {
             const startupBanner = `=====> ${this.HostName} Integrated Console v${this.HostVersion} <=====
 `;
-            this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
+            this.editorServicesArgs += `-StartupBanner '${startupBanner}' `;
         }
 
         if (this.sessionSettings.developer.editorServicesWaitForDebugger) {


### PR DESCRIPTION
## PR Summary

Fixes the way the startup banner is quoted so that it works with the pwsh dotnet global tool.

Fixes https://github.com/PowerShell/vscode-powershell/issues/2780

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
