### PR TITLE
Add setting to change the cwd of the Powershell Integrated Console

### DIFF
--- a/package.json
+++ b/package.json
@@ -643,7 +643,7 @@
         "powershell.cwd": {
           "type": "string",
           "default": null,
-          "description": "An explicit start path where the Powershell Integrated Console will be launched. Open workspace folders will take precedence over this setting. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
+          "description": "An explicit start path where the Powershell Integrated Console will be launched. Both the PowerShell process and the shell's location will be set to this directory. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
         },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -781,6 +781,11 @@
           "default": false,
           "description": "Do not show the Powershell Integrated Console banner on launch"
         },
+        "powershell.integratedConsole.cwd": {
+          "type": "string",
+          "default": null,
+          "description": "An explicit start path where the Powershell Integrated Console will be launched. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory"
+        },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",
           "default": false,

--- a/package.json
+++ b/package.json
@@ -640,6 +640,11 @@
           "default": "BlockComment",
           "description": "Controls the comment-based help completion behavior triggered by typing '##'. Set the generated help style with 'BlockComment' or 'LineComment'. Disable the feature with 'Disabled'."
         },
+        "powershell.cwd": {
+          "type": "string",
+          "default": null,
+          "description": "An explicit start path where the Powershell Integrated Console will be launched. Open workspace folders will take precedence over this setting. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
+        },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",
           "default": true,
@@ -780,11 +785,6 @@
           "type": "boolean",
           "default": false,
           "description": "Do not show the Powershell Integrated Console banner on launch"
-        },
-        "powershell.integratedConsole.cwd": {
-          "type": "string",
-          "default": null,
-          "description": "An explicit start path where the Powershell Integrated Console will be launched. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory"
         },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",

--- a/src/process.ts
+++ b/src/process.ts
@@ -105,9 +105,6 @@ export class PowerShellProcess {
         // Make sure no old session file exists
         utils.deleteSessionFile(this.sessionFilePath);
 
-        // Open workspace folders take precedence over cwd setting
-        const cwd = vscode.workspace.workspaceFolders === undefined ? this.sessionSettings.cwd : null;
-
         // Launch PowerShell in the integrated terminal
         this.consoleTerminal =
             vscode.window.createTerminal({
@@ -115,7 +112,7 @@ export class PowerShellProcess {
                 shellPath: this.exePath,
                 shellArgs: powerShellArgs,
                 hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
-                cwd
+                cwd: this.sessionSettings.cwd
             });
 
         const pwshName = path.basename(this.exePath);

--- a/src/process.ts
+++ b/src/process.ts
@@ -105,6 +105,9 @@ export class PowerShellProcess {
         // Make sure no old session file exists
         utils.deleteSessionFile(this.sessionFilePath);
 
+        // Open workspace folders take precedence over cwd setting
+        const cwd = vscode.workspace.workspaceFolders === undefined ? this.sessionSettings.cwd : null;
+
         // Launch PowerShell in the integrated terminal
         this.consoleTerminal =
             vscode.window.createTerminal({
@@ -112,7 +115,7 @@ export class PowerShellProcess {
                 shellPath: this.exePath,
                 shellArgs: powerShellArgs,
                 hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
-                cwd: this.sessionSettings.integratedConsole.cwd
+                cwd
             });
 
         const pwshName = path.basename(this.exePath);

--- a/src/process.ts
+++ b/src/process.ts
@@ -112,6 +112,7 @@ export class PowerShellProcess {
                 shellPath: this.exePath,
                 shellArgs: powerShellArgs,
                 hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
+                cwd: this.sessionSettings.integratedConsole.cwd
             });
 
         const pwshName = path.basename(this.exePath);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -114,6 +114,7 @@ export interface IIntegratedConsoleSettings {
     useLegacyReadLine?: boolean;
     forceClearScrollbackBuffer?: boolean;
     suppressStartupBanner?: boolean;
+    cwd?: string
 }
 
 export interface ISideBarSettings {
@@ -192,6 +193,7 @@ export function load(): ISettings {
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
         forceClearScrollbackBuffer: false,
+        cwd: null
     };
 
     const defaultSideBarSettings: ISideBarSettings = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,6 +101,7 @@ export interface ISettings {
     sideBar?: ISideBarSettings;
     pester?: IPesterSettings;
     buttons?: IButtonSettings;
+    cwd?: string;
 }
 
 export interface IStartAsLoginShellSettings {
@@ -114,7 +115,6 @@ export interface IIntegratedConsoleSettings {
     useLegacyReadLine?: boolean;
     forceClearScrollbackBuffer?: boolean;
     suppressStartupBanner?: boolean;
-    cwd?: string
 }
 
 export interface ISideBarSettings {
@@ -193,7 +193,6 @@ export function load(): ISettings {
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
         forceClearScrollbackBuffer: false,
-        cwd: null
     };
 
     const defaultSideBarSettings: ISideBarSettings = {
@@ -259,6 +258,8 @@ export function load(): ISettings {
             //   is the reason terminals on macOS typically run login shells by default which set up
             //   the environment. See http://unix.stackexchange.com/a/119675/115410"
             configuration.get<IStartAsLoginShellSettings>("startAsLoginShell", defaultStartAsLoginShellSettings),
+        cwd:
+            configuration.get<string>("cwd", null),
     };
 }
 


### PR DESCRIPTION
## PR Summary

This adds a new setting that will allow users to set the current working directory for the Powershell Integrated Console

Resolves #2227

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ]  `NA` PR has tests
- [x] This PR is ready to merge and is not work in progress
