### PR TITLE
Add external API part 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
 			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+			"outFiles": ["${workspaceFolder}/out/src/**/*.js"],
 			"preLaunchTask": "BuildAll"
 		},
 		{
@@ -17,10 +17,10 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": [ "--extensionDevelopmentPath=${workspaceRoot}" ],
+			"args": [ "--extensionDevelopmentPath=${workspaceFolder}" ],
 			"stopOnEntry": false,
 			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/src/**/*.js"],
+			"outFiles": ["${workspaceFolder}/out/src/**/*.js"],
 			"preLaunchTask": "Build"
 		},
 		{
@@ -28,25 +28,11 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
-			"stopOnEntry": false,
-			"sourceMaps": true,
-			"outFiles": ["${workspaceRoot}/out/test/**/*.js"],
-			"preLaunchTask": "Build",
-			"skipFiles": [
-				"${workspaceFolder}/node_modules/**/*",
-				"${workspaceFolder}/lib/**/*",
-				"/private/var/folders/**/*",
-				"<node_internals>/**/*"
-			]
-		},
-		{
-			"name": "Attach",
-			"type": "node",
-			"request": "attach",
-			"address": "localhost",
-			"port": 5858,
-			"sourceMaps": false
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/testRunner.js" ],
+			"outFiles": ["${workspaceFolder}/out/**/*.js"],
+			"preLaunchTask": "Build"
 		}
 	]
 }

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -11,6 +11,7 @@ steps:
 
       # Using `prependpath` to update the PATH just for this build.
       Write-Host "##vso[task.prependpath]$powerShellPath"
+    continueOnError: true
     displayName: Install PowerShell Daily
   - pwsh: '$PSVersionTable'
     displayName: Display PowerShell version information

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,12 @@
       "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/uuid/-/@types/uuid-8.0.0.tgz",
+      "integrity": "sha1-FlquSBmtIXShdHbb5m/uvVSVVsA=",
+      "dev": true
+    },
     "@types/vscode": {
       "version": "1.43.0",
       "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/@types/vscode/-/@types/vscode-1.43.0.tgz",
@@ -2080,6 +2086,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "8.2.0",
+      "resolved": "https://botbuilder.myget.org/F/botframework-cli/npm/uuid/-/uuid-8.2.0.tgz",
+      "integrity": "sha1-yxDdaxGOLa2n0M2XMLp0F8k9kg4="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,15 @@
     "onCommand:PowerShell.RestartSession",
     "onCommand:PowerShell.EnableISEMode",
     "onCommand:PowerShell.DisableISEMode",
+    "onCommand:PowerShell.RegisterExternalExtension",
+    "onCommand:PowerShell.UnregisterExternalExtension",
+    "onCommand:PowerShell.GetPowerShellVersionDetails",
     "onView:PowerShellCommands"
   ],
   "dependencies": {
     "node-fetch": "^2.6.0",
     "semver": "^7.3.2",
+    "uuid": "^8.2.0",
     "vscode-extension-telemetry": "~0.1.6",
     "vscode-languageclient": "~6.1.3"
   },
@@ -57,6 +61,7 @@
     "@types/rewire": "~2.5.28",
     "@types/semver": "~7.2.0",
     "@types/sinon": "~9.0.4",
+    "@types/uuid": "^8.0.0",
     "@types/vscode": "1.43.0",
     "mocha": "~5.2.0",
     "mocha-junit-reporter": "~2.0.0",
@@ -292,6 +297,21 @@
           "light": "resources/light/MovePanelBottom.svg",
           "dark": "resources/dark/MovePanelBottom.svg"
         }
+      },
+      {
+        "command": "PowerShell.RegisterExternalExtension",
+        "title": "Register an external extension",
+        "category": "PowerShell"
+      },
+      {
+        "command": "PowerShell.UnregisterExternalExtension",
+        "title": "Unregister an external extension",
+        "category": "PowerShell"
+      },
+      {
+        "command": "PowerShell.GetPowerShellVersionDetails",
+        "title": "Get details about the PowerShell version that the PowerShell extension is using",
+        "category": "PowerShell"
       }
     ],
     "menus": {

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -82,9 +82,9 @@ export class ExternalApiFeature implements IFeature {
             RETURNS:
                 true if it worked, otherwise throws an error.
             */
-            vscode.commands.registerCommand("PowerShell.UnregisterExternalExtension", (uuid: string): boolean => {
+            vscode.commands.registerCommand("PowerShell.UnregisterExternalExtension", (uuid: string = ""): boolean => {
                 log.writeDiagnostic(`Unregistering extension with session UUID: ${uuid}`);
-                if (!uuid && !ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
+                if (!ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
                     throw new Error(`No extension registered with session UUID: ${uuid}`);
                 }
                 return true;
@@ -109,8 +109,8 @@ export class ExternalApiFeature implements IFeature {
                     architecture: string;
                 }
             */
-           vscode.commands.registerCommand("PowerShell.GetPowerShellVersionDetails", async (uuid: string): Promise<IExternalPowerShellDetails> => {
-                if (!uuid && !ExternalApiFeature.registeredExternalExtension.has(uuid)) {
+           vscode.commands.registerCommand("PowerShell.GetPowerShellVersionDetails", async (uuid: string = ""): Promise<IExternalPowerShellDetails> => {
+                if (!ExternalApiFeature.registeredExternalExtension.has(uuid)) {
                     throw new Error(
                         "UUID provided was invalid, make sure you execute the 'PowerShell.GetPowerShellVersionDetails' command and pass in the UUID that it returns to subsequent command executions.");
                 }

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -1,0 +1,144 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import * as vscode from "vscode";
+import { v4 as uuidv4 } from 'uuid';
+import { LanguageClient } from "vscode-languageclient";
+import { IFeature } from "../feature";
+import { Logger } from "../logging";
+import { SessionManager } from "../session";
+
+interface IExternalExtension {
+    readonly id: string;
+    readonly apiVersion: string;
+}
+
+export interface IExternalPowerShellDetails {
+    exePath: string;
+    version: string;
+    displayName: string;
+    architecture: string;
+}
+
+export class ExternalApiFeature implements IFeature {
+    private commands: vscode.Disposable[];
+    private languageClient: LanguageClient;
+    private static readonly registeredExternalExtension: Map<string, IExternalExtension> = new Map<string, IExternalExtension>();
+
+    constructor(private sessionManager: SessionManager, private log: Logger) {
+        this.commands = [
+            /*
+            DESCRIPTION:
+                Registers your extension to allow usage of the external API. The returns
+                a session UUID that will need to be passed in to subsequent API calls.
+
+            USAGE:
+                vscode.commands.executeCommand(
+                    "PowerShell.RegisterExternalExtension",
+                    "ms-vscode.PesterTestExplorer" // the name of the extension using us
+                    "v1"); // API Version.
+
+            RETURNS:
+                string session uuid
+            */
+            vscode.commands.registerCommand("PowerShell.RegisterExternalExtension", (id: string, apiVersion: string = 'v1'): string => {
+                log.writeDiagnostic(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
+
+                for (const [_, externalExtension] of ExternalApiFeature.registeredExternalExtension) {
+                    if (externalExtension.id === id) {
+                        const message = `The extension '${id}' is already registered.`;
+                        log.writeWarning(message);
+                        throw new Error(message);
+                    }
+                }
+
+                if (!vscode.extensions.all.some(ext => ext.id === id)) {
+                    throw new Error(`No extension installed with id '${id}'. You must use a valid extension id.`);
+                }
+
+                // If we're in development mode, we allow these to be used for testing purposes.
+                if (!sessionManager.InDevelopmentMode && (id === "ms-vscode.PowerShell" || id === "ms-vscode.PowerShell-Preview")) {
+                    throw new Error("You can't use the PowerShell extension's id in this registration.");
+                }
+
+                const uuid = uuidv4();
+                ExternalApiFeature.registeredExternalExtension.set(uuid, {
+                    id,
+                    apiVersion
+                });
+                return uuid;
+            }),
+
+            /*
+            DESCRIPTION:
+                Unregisters a session that an extension has. This returns
+                true if it succeeds or throws if it fails.
+
+            USAGE:
+                vscode.commands.executeCommand(
+                    "PowerShell.UnregisterExternalExtension",
+                    "uuid"); // the uuid from above for tracking purposes
+
+            RETURNS:
+                true if it worked, otherwise throws an error.
+            */
+            vscode.commands.registerCommand("PowerShell.UnregisterExternalExtension", (uuid: string): boolean => {
+                log.writeDiagnostic(`Unregistering extension with session UUID: ${uuid}`);
+                if (!uuid && !ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
+                    throw new Error(`No extension registered with session UUID: ${uuid}`);
+                }
+                return true;
+            }),
+
+            /*
+            DESCRIPTION:
+                This will fetch the version details of the PowerShell used to start
+                PowerShell Editor Services in the PowerShell extension.
+
+            USAGE:
+                vscode.commands.executeCommand(
+                    "PowerShell.GetPowerShellVersionDetails",
+                    "uuid"); // the uuid from above for tracking purposes
+
+            RETURNS:
+                An IPowerShellVersionDetails which consists of:
+                {
+                    version: string;
+                    displayVersion: string;
+                    edition: string;
+                    architecture: string;
+                }
+            */
+           vscode.commands.registerCommand("PowerShell.GetPowerShellVersionDetails", async (uuid: string): Promise<IExternalPowerShellDetails> => {
+                if (!uuid && !ExternalApiFeature.registeredExternalExtension.has(uuid)) {
+                    throw new Error(
+                        "UUID provided was invalid, make sure you execute the 'PowerShell.GetPowerShellVersionDetails' command and pass in the UUID that it returns to subsequent command executions.");
+                }
+
+                // TODO: When we have more than one API version, make sure to include a check here.
+                const extension = ExternalApiFeature.registeredExternalExtension.get(uuid);
+                log.writeDiagnostic(`Extension '${extension.id}' used command 'PowerShell.GetPowerShellVersionDetails'.`);
+
+                await sessionManager.waitUntilStarted();
+                const versionDetails = sessionManager.getPowerShellVersionDetails();
+
+                return {
+                    exePath: sessionManager.PowerShellExeDetails.exePath,
+                    version: versionDetails.version,
+                    displayName: sessionManager.PowerShellExeDetails.displayName, // comes from the Session Menu
+                    architecture: versionDetails.architecture
+                };
+            }),
+        ]
+    }
+
+    public dispose() {
+        for (const command of this.commands) {
+            command.dispose();
+        }
+    }
+
+    public setLanguageClient(languageclient: LanguageClient) {
+        this.languageClient = languageclient;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,12 +13,10 @@ import { CodeActionsFeature } from "./features/CodeActions";
 import { ConsoleFeature } from "./features/Console";
 import { CustomViewsFeature } from "./features/CustomViews";
 import { DebugSessionFeature } from "./features/DebugSession";
-import { PickPSHostProcessFeature } from "./features/DebugSession";
-import { PickRunspaceFeature } from "./features/DebugSession";
-import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { ExamplesFeature } from "./features/Examples";
 import { ExpandAliasFeature } from "./features/ExpandAlias";
 import { ExtensionCommandsFeature } from "./features/ExtensionCommands";
+import { ExternalApiFeature } from "./features/ExternalApi";
 import { FindModuleFeature } from "./features/FindModule";
 import { GenerateBugReportFeature } from "./features/GenerateBugReport";
 import { GetCommandsFeature } from "./features/GetCommands";
@@ -27,14 +25,15 @@ import { ISECompatibilityFeature } from "./features/ISECompatibility";
 import { NewFileOrProjectFeature } from "./features/NewFileOrProject";
 import { OpenInISEFeature } from "./features/OpenInISE";
 import { PesterTestsFeature } from "./features/PesterTests";
+import { PickPSHostProcessFeature, PickRunspaceFeature } from "./features/DebugSession";
 import { RemoteFilesFeature } from "./features/RemoteFiles";
 import { RunCodeFeature } from "./features/RunCode";
 import { ShowHelpFeature } from "./features/ShowHelp";
+import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { Logger, LogLevel } from "./logging";
 import { SessionManager } from "./session";
 import Settings = require("./settings");
 import { PowerShellLanguageId } from "./utils";
-import utils = require("./utils");
 
 // The most reliable way to get the name and version of the current extension.
 // tslint:disable-next-line: no-var-requires
@@ -157,6 +156,7 @@ export function activate(context: vscode.ExtensionContext): void {
         new HelpCompletionFeature(logger),
         new CustomViewsFeature(),
         new PickRunspaceFeature(),
+        new ExternalApiFeature(sessionManager, logger)
     ];
 
     sessionManager.setExtensionFeatures(extensionFeatures);

--- a/src/process.ts
+++ b/src/process.ts
@@ -179,10 +179,6 @@ export class PowerShellProcess {
         return true;
     }
 
-    private sleep(ms: number) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-    }
-
     private async waitForSessionFile(): Promise<utils.IEditorServicesSessionDetails> {
         // Determine how many tries by dividing by 2000 thus checking every 2 seconds.
         const numOfTries = this.sessionSettings.developer.waitForSessionFileTimeoutSeconds / 2;
@@ -203,7 +199,7 @@ export class PowerShellProcess {
             }
 
             // Wait a bit and try again
-            await this.sleep(2000);
+            await utils.sleep(2000);
         }
 
         const err = "Timed out waiting for session file to appear.";

--- a/src/session.ts
+++ b/src/session.ts
@@ -54,6 +54,7 @@ export class SessionManager implements Middleware {
     private sessionSettings: Settings.ISettings = undefined;
     private sessionDetails: utils.IEditorServicesSessionDetails;
     private bundledModulesPath: string;
+    private started: boolean = false;
 
     // Initialized by the start() method, since this requires settings
     private powershellExeFinder: PowerShellExeFinder;
@@ -61,7 +62,7 @@ export class SessionManager implements Middleware {
     // When in development mode, VS Code's session ID is a fake
     // value of "someValue.machineId".  Use that to detect dev
     // mode for now until Microsoft/vscode#10272 gets implemented.
-    private readonly inDevelopmentMode =
+    public readonly InDevelopmentMode =
         vscode.env.sessionId === "someValue.sessionId";
 
     constructor(
@@ -167,7 +168,7 @@ export class SessionManager implements Middleware {
 
         this.bundledModulesPath = path.resolve(__dirname, this.sessionSettings.bundledModulesPath);
 
-        if (this.inDevelopmentMode) {
+        if (this.InDevelopmentMode) {
             const devBundledModulesPath =
                 path.resolve(
                     __dirname,
@@ -272,6 +273,12 @@ export class SessionManager implements Middleware {
                 sessionSettings);
 
         return this.debugSessionProcess;
+    }
+
+    public async waitUntilStarted(): Promise<void> {
+        while(!this.started) {
+            await utils.sleep(300);
+        }
     }
 
     // ----- LanguageClient middleware methods -----
@@ -549,8 +556,9 @@ export class SessionManager implements Middleware {
                         .then(
                             async (versionDetails) => {
                                 this.versionDetails = versionDetails;
+                                this.started = true;
 
-                                if (!this.inDevelopmentMode) {
+                                if (!this.InDevelopmentMode) {
                                     this.telemetryReporter.sendTelemetryEvent("powershellVersionCheck",
                                         { powershellVersion: versionDetails.version });
                                 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,7 +96,7 @@ export function getTimestampString() {
     return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`;
 }
 
-export function sleep(ms: number) {
+export function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,10 @@ export function getTimestampString() {
     return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`;
 }
 
+export function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 export const isMacOS: boolean = process.platform === "darwin";
 export const isWindows: boolean = process.platform === "win32";
 export const isLinux: boolean = !isMacOS && !isWindows;

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { beforeEach, afterEach } from "mocha";
+import { IExternalPowerShellDetails } from "../../src/features/ExternalApi";
+
+const testExtensionId = "ms-vscode.powershell-preview";
+
+suite("ExternalApi feature - Registration API", () => {
+    test("It can register and unregister an extension", async () => {
+        const sessionId: string = await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", testExtensionId);
+        assert.notStrictEqual(sessionId , "");
+        assert.notStrictEqual(sessionId , null);
+        assert.strictEqual(
+            await vscode.commands.executeCommand("PowerShell.UnregisterExternalExtension", sessionId),
+            true);
+    });
+
+    test("It can register and unregister an extension with a version", async () => {
+        const sessionId: string = await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", "ms-vscode.powershell-preview", "v2");
+        assert.notStrictEqual(sessionId , "");
+        assert.notStrictEqual(sessionId , null);
+        assert.strictEqual(
+            await vscode.commands.executeCommand("PowerShell.UnregisterExternalExtension", sessionId),
+            true);
+    });
+
+    /*
+        NEGATIVE TESTS
+    */
+    test("API fails if not registered", async () => {
+        assert.rejects(
+            async () => await vscode.commands.executeCommand("PowerShell.GetPowerShellVersionDetails"),
+            "UUID provided was invalid, make sure you execute the 'PowerShell.RegisterExternalExtension' command and pass in the UUID that it returns to subsequent command executions.");
+    });
+
+    test("It can't register the same extension twice", async () => {
+        const sessionId: string = await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", testExtensionId);
+        try {
+            assert.rejects(
+                async () => await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", testExtensionId),
+                `The extension '${testExtensionId}' is already registered.`);
+        } finally {
+            await vscode.commands.executeCommand("PowerShell.UnregisterExternalExtension", sessionId);
+        }
+    });
+
+    test("It can't unregister an extension that isn't registered", async () => {
+        assert.rejects(
+            async () => await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", "not-real"),
+            `No extension registered with session UUID: not-real`);
+    });
+});
+
+suite("ExternalApi feature - Other APIs", () => {
+    let sessionId: string;
+
+    beforeEach(async () => {
+        sessionId = await vscode.commands.executeCommand("PowerShell.RegisterExternalExtension", "ms-vscode.powershell-preview");
+    });
+
+    afterEach(async () => {
+        await vscode.commands.executeCommand("PowerShell.UnregisterExternalExtension", sessionId);
+    });
+
+    test("It can get PowerShell version details", async () => {
+        const versionDetails: IExternalPowerShellDetails = await vscode.commands.executeCommand("PowerShell.GetPowerShellVersionDetails", sessionId);
+
+        assert.notStrictEqual(versionDetails.architecture, "");
+        assert.notStrictEqual(versionDetails.architecture, null);
+
+        assert.notStrictEqual(versionDetails.displayName, "");
+        assert.notStrictEqual(versionDetails.displayName, null);
+
+        assert.notStrictEqual(versionDetails.exePath, "");
+        assert.notStrictEqual(versionDetails.exePath, null);
+
+        assert.notStrictEqual(versionDetails.version, "");
+        assert.notStrictEqual(versionDetails.version, null);
+
+        // Start up can take some time... so set the time out to 30s
+    }).timeout(30000);
+});


### PR DESCRIPTION
## PR Summary

This adds the foundation of the API that external extensions will use. Once @rjmholt is done with the work in PSES to better handle the runspace, we can add part 2 which will execute PowerShell script in the PowerShell runspace.

Here are the messages that are encompassed in this PR:

## RegisterExternalExtension

I want to be able to track what extensions are leveraging this feature.
In order to do this,
we can have them register first.
With that,
they'll get a UUID back that they use in any future request.
It's like an API KEY of sorts...

```js
vscode.commands.executeCommand(
    "PowerShell.RegisterExternalExtension",
    "ms-vscode.PesterTestExplorer" // the name of the extension using us
    "v1"); // API Version. I made it a single number because I don't want to be in the business of maintaining 1.x.x versions
// returns string session uuid
```

## UnregisterExternalExtension

This will remove the session. Not a very useful API, but it's there.

```js
vscode.commands.executeCommand(
    "PowerShell.UnregisterExternalExtension",
    "uuid"); // the uuid from above for tracking purposes
// returns boolean
```

## GetPowerShellVersionDetails

This will fetch the version details of the PowerShell used to start VS Code.

```js
vscode.commands.executeCommand(
    "PowerShell.GetPowerShellVersionDetails",
    "uuid"); // the uuid from above for tracking purposes
```

This will return an object with common properties that might be useful:

```js
{
    exePath: "/usr/local/bin/pwsh",
    verison: "7.1.0-preview.4",
    displayName: "PowerShell Preview (x64)", // comes from the Session Menu
    architecture: "x64"
}
```

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
