### PR TITLE
Address Notebook breaking changes

### DIFF
--- a/.github/workflows/updateNotebookApi.yml
+++ b/.github/workflows/updateNotebookApi.yml
@@ -79,9 +79,6 @@ jobs:
         # Remove the old file so it doesn't get picked up by tsc
         Remove-Item ./old.vscode.proposed.d.ts -Force
 
-    - name: Compile the TypeScript to check for errors
-      run: npm run compile
-
     - name: Create Pull Request
       if: github.event_name == 'schedule'
       id: cpr

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ npm-debug.log
 *.DS_Store
 test-results.xml
 vscode.d.ts
+test/.vscode/settings.json

--- a/package.json
+++ b/package.json
@@ -218,8 +218,8 @@
         }
       },
       {
-        "command": "PowerShell.ShowNotebookMode",
-        "title": "(Preview) Show Notebook Mode",
+        "command": "PowerShell.EnableNotebookMode",
+        "title": "(Preview) Enable Notebook Mode",
         "category": "PowerShell",
         "icon": {
           "light": "resources/light/book.svg",
@@ -227,8 +227,8 @@
         }
       },
       {
-        "command": "PowerShell.HideNotebookMode",
-        "title": "Show Text Editor",
+        "command": "PowerShell.DisableNotebookMode",
+        "title": "(Preview) Disable Notebook Mode",
         "category": "PowerShell",
         "icon": {
           "light": "resources/light/file-code.svg",
@@ -413,12 +413,12 @@
         },
         {
           "when": "editorLangId == powershell && config.powershell.notebooks.showToggleButton",
-          "command": "PowerShell.ShowNotebookMode",
+          "command": "PowerShell.EnableNotebookMode",
           "group": "navigation@102"
         },
         {
           "when": "resourceLangId == powershell && notebookEditorFocused",
-          "command": "PowerShell.HideNotebookMode",
+          "command": "PowerShell.DisableNotebookMode",
           "group": "navigation@102"
         }
       ],

--- a/src/features/PowerShellNotebooks.ts
+++ b/src/features/PowerShellNotebooks.ts
@@ -8,6 +8,7 @@ import { EvaluateRequestType } from "./Console";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 import Settings = require("../settings");
 import { ILogger } from "../logging";
+import { LanguageClient } from "vscode-languageclient";
 
 export class PowerShellNotebooksFeature extends LanguageClientConsumer {
 

--- a/src/features/PowerShellNotebooks.ts
+++ b/src/features/PowerShellNotebooks.ts
@@ -248,13 +248,26 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
 }
 
 class PowerShellNotebookKernel implements vscode.NotebookKernel, vscode.NotebookKernelProvider {
+    private static informationMessage = "PowerShell extension has not finished starting up yet. Please try again in a few moments.";
+
     public id?: string;
     public label: string = "PowerShell";
     public description?: string = "The PowerShell Notebook Mode kernel that runs commands in the PowerShell Integrated Console.";
     public isPreferred?: boolean;
     public preloads?: vscode.Uri[];
 
-    private languageClient: LanguageClient;
+    private _languageClient: LanguageClient;
+    private get languageClient(): LanguageClient {
+        if (!this._languageClient) {
+            vscode.window.showInformationMessage(
+                PowerShellNotebookKernel.informationMessage);
+        }
+        return this._languageClient;
+    }
+
+    private set languageClient(value: LanguageClient) {
+        this._languageClient = value;
+    }
 
     public async executeAllCells(document: vscode.NotebookDocument): Promise<void> {
         for (const cell of document.cells) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -170,13 +170,17 @@ export function activate(context: vscode.ExtensionContext): void {
         const powerShellNotebooksFeature = new PowerShellNotebooksFeature(logger);
 
         try {
-            context.subscriptions.push(vscode.notebook.registerNotebookContentProvider("PowerShellNotebookMode", powerShellNotebooksFeature));
+            powerShellNotebooksFeature.registerNotebookProviders();
             languageClientConsumers.push(powerShellNotebooksFeature);
         } catch (e) {
             // This would happen if VS Code changes their API.
             powerShellNotebooksFeature.dispose();
             logger.writeVerbose("Failed to register NotebookContentProvider", e);
         }
+    } else {
+        vscode.commands.registerCommand(
+            "PowerShell.EnableNotebookMode",
+            () => vscode.window.showWarningMessage("Notebook Mode only works in Visual Studio Code Insiders. To get it, go to: aka.ms/vscode-insiders"));
     }
 
     sessionManager.setLanguageClientConsumers(languageClientConsumers);

--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "powershell.helpCompletion": "LineComment"
-}

--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "powershell.helpCompletion": "LineComment"
+}

--- a/test/features/PowerShellNotebooks.test.ts
+++ b/test/features/PowerShellNotebooks.test.ts
@@ -192,10 +192,12 @@ suite("PowerShellNotebooks tests", () => {
     ]);
 
     const feature = new PowerShellNotebooksFeature(new MockLogger(), true);
+    // `notebookContentProvider` is a private property so cast the feature as `any` so we can access it.
+    const notebookContentProvider: vscode.NotebookContentProvider = (feature as any).notebookContentProvider;
 
     for (const [uri, expectedCells] of notebookTestData) {
         test(`Can open a notebook with expected cells - ${uri.fsPath}`, async () => {
-            const actualNotebookData = await feature.openNotebook(uri, {});
+            const actualNotebookData = await notebookContentProvider.openNotebook(uri, {});
             compareCells(actualNotebookData.cells, expectedCells);
         });
     }
@@ -218,8 +220,8 @@ suite("PowerShellNotebooks tests", () => {
             notebookSimpleMixedComments.toString());
 
         // Save it as testFile.ps1 and reopen it using the feature.
-        await feature.saveNotebookAs(uri, vscode.notebook.activeNotebookEditor.document, null);
-        const newNotebook = await feature.openNotebook(uri, {});
+        await notebookContentProvider.saveNotebookAs(uri, vscode.notebook.activeNotebookEditor.document, null);
+        const newNotebook = await notebookContentProvider.openNotebook(uri, {});
 
         // Compare that saving as a file results in the same cell data as the existing one.
         const expectedCells = notebookTestData.get(notebookSimpleMixedComments);

--- a/vscode.proposed.d.ts
+++ b/vscode.proposed.d.ts
@@ -89,6 +89,11 @@ declare module 'vscode' {
 		Error = 4
 	}
 
+	export enum NotebookRunState {
+		Running = 1,
+		Idle = 2
+	}
+
 	export interface NotebookCellMetadata {
 		/**
 		 * Controls if the content of a cell is editable or not.
@@ -191,6 +196,11 @@ declare module 'vscode' {
 		 * Additional attributes of the document metadata.
 		 */
 		custom?: { [key: string]: any };
+
+		/**
+		 * The document's current run state
+		 */
+		runState?: NotebookRunState;
 	}
 
 	export interface NotebookDocument {
@@ -498,8 +508,10 @@ declare module 'vscode' {
 		description?: string;
 		isPreferred?: boolean;
 		preloads?: Uri[];
-		executeCell(document: NotebookDocument, cell: NotebookCell, token: CancellationToken): Promise<void>;
-		executeAllCells(document: NotebookDocument, token: CancellationToken): Promise<void>;
+		executeCell(document: NotebookDocument, cell: NotebookCell): void;
+		cancelCellExecution(document: NotebookDocument, cell: NotebookCell): void;
+		executeAllCells(document: NotebookDocument): void;
+		cancelAllCellsExecution(document: NotebookDocument): void;
 	}
 
 	export interface NotebookDocumentFilter {


### PR DESCRIPTION
## PR Summary

See the changes in vscode.proposed.d.ts...

Basically, they added more methods to the `vscode.NotebookKernel` interface so I wanted to separate it out into another class...

also, now we need a `vscode.NotebookKernelProvider` instead of just setting the `kernel` on the `vscode.NotebookContentProvider`

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
