### PR TITLE
When migrating old whitespaceAroundPipe setting to AddWhitespaceAroundPipe, remove old setting now

### DIFF
--- a/package.json
+++ b/package.json
@@ -801,6 +801,11 @@
           "default": false,
           "description": "Removes redundant whitespace between parameters."
         },
+        "powershell.codeFormatting.whitespaceAroundPipe": {
+          "type": "boolean",
+          "default": true,
+          "description": "REMOVED. Please use the \"powershell.codeFormatting.addWhitespaceAroundPipe\" setting instead. If you've used this setting before, we have moved it for you automatically."
+        },
         "powershell.codeFormatting.addWhitespaceAroundPipe": {
           "type": "boolean",
           "default": true,

--- a/src/session.ts
+++ b/src/session.ts
@@ -326,8 +326,7 @@ export class SessionManager implements Middleware {
             return resolvedCodeLens;
     }
 
-    // During preview, populate a new setting value but not remove the old value.
-    // TODO: When the next stable extension releases, then the old value can be safely removed. Tracked in this issue: https://github.com/PowerShell/vscode-powershell/issues/2693
+    // Move old setting codeFormatting.whitespaceAroundPipe to new setting codeFormatting.addWhitespaceAroundPipe
     private async migrateWhitespaceAroundPipeSetting() {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'
@@ -337,6 +336,7 @@ export class SessionManager implements Middleware {
             const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
             const value = configuration.get(deprecatedSetting, configurationTarget)
             await Settings.change(newSetting, value, configurationTarget);
+            await Settings.change(deprecatedSetting, undefined, configurationTarget);
         }
     }
 


### PR DESCRIPTION
## PR Summary

Resolves #2693

Remove old setting values now instead of just populating the new one.
Old setting has to be temporarily introduced because the `vscode.WorkspaceConfiguration.update('codeFormatting.whitespaceAroundPipe', undefined)` API only works when the extension defines the setting.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
