### PR TITLE
Expose new formatter setting powershell.codeFormatting.useConstantStrings from PSSA 1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -821,6 +821,11 @@
           "default": true,
           "description": "Align assignment statements in a hashtable or a DSC Configuration."
         },
+        "powershell.codeFormatting.useConstantStrings": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use single quotes if a string is not interpolated and its value does not contain a single quote."
+        },
         "powershell.codeFormatting.useCorrectCasing": {
           "type": "boolean",
           "default": false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,6 +58,7 @@ export interface ICodeFormattingSettings {
     trimWhitespaceAroundPipe: boolean;
     ignoreOneLineBlock: boolean;
     alignPropertyValuePairs: boolean;
+    useConstantStrings: boolean;
     useCorrectCasing: boolean;
 }
 
@@ -185,6 +186,7 @@ export function load(): ISettings {
         trimWhitespaceAroundPipe: false,
         ignoreOneLineBlock: true,
         alignPropertyValuePairs: true,
+        useConstantStrings: false,
         useCorrectCasing: false,
     };
 


### PR DESCRIPTION
## PR Summary

Expose new formatter setting powershell.codeFormatting.useConstantStrings (disabled by default) for new rule AvoidUsingDoubleQuotesForConstantString (disabled by default) added in PSSA 1.19.1

Pending https://github.com/PowerShell/PowerShellEditorServices/pull/1333

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
