### PR TITLE
Handle block comments with text on the same line as <# #>

### DIFF
--- a/src/features/PowerShellNotebooks.ts
+++ b/src/features/PowerShellNotebooks.ts
@@ -9,6 +9,7 @@ import { LanguageClientConsumer } from "../languageClientConsumer";
 import Settings = require("../settings");
 import { ILogger } from "../logging";
 import { LanguageClient } from "vscode-languageclient";
+import { EOL } from "os";
 
 export class PowerShellNotebooksFeature extends LanguageClientConsumer {
 
@@ -124,7 +125,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                         cellKind: vscode.CellKind.Markdown,
                         language: "markdown",
                         outputs: [],
-                        source: currentCellSource.join("\n"),
+                        source: currentCellSource.join(EOL),
                         metadata: {
                             custom: {
                                 commentType: CommentType.BlockComment,
@@ -152,7 +153,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                         cellKind,
                         language: cellKind === vscode.CellKind.Markdown ? "markdown" : "powershell",
                         outputs: [],
-                        source: currentCellSource.join("\n"),
+                        source: currentCellSource.join(EOL),
                         metadata: {
                             custom: {
                                 commentType: cellKind === vscode.CellKind.Markdown ? CommentType.LineComment : CommentType.Disabled,
@@ -195,7 +196,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                         cellKind: cellKind!,
                         language: cellKind === vscode.CellKind.Markdown ? "markdown" : "powershell",
                         outputs: [],
-                        source: currentCellSource.join("\n"),
+                        source: currentCellSource.join(EOL),
                         metadata: {
                             custom: {
                                 commentType: cellKind === vscode.CellKind.Markdown ? CommentType.LineComment : CommentType.Disabled,
@@ -219,7 +220,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                 cellKind: cellKind!,
                 language: cellKind === vscode.CellKind.Markdown ? "markdown" : "powershell",
                 outputs: [],
-                source: currentCellSource.join("\n"),
+                source: currentCellSource.join(EOL),
                 metadata: {
                     custom: {
                         commentType: cellKind === vscode.CellKind.Markdown ? CommentType.LineComment : CommentType.Disabled,
@@ -261,7 +262,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
         const retArr: string[] = [];
         for (const cell of document.cells) {
             if (cell.cellKind === vscode.CellKind.Code) {
-                retArr.push(...cell.document.getText().split(/\r|\n|\r\n/));
+                retArr.push(...cell.document.getText().split(/\r\n|\r|\n/));
             } else {
                 // First honor the comment type of the cell if it already has one.
                 // If not, use the user setting.
@@ -270,7 +271,7 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                 if (commentKind === CommentType.BlockComment) {
                     const openBlockCommentOnOwnLine: boolean = cell.metadata.custom?.openBlockCommentOnOwnLine;
                     const closeBlockCommentOnOwnLine: boolean = cell.metadata.custom?.closeBlockCommentOnOwnLine;
-                    const text = cell.document.getText().split(/\r|\n|\r\n/);
+                    const text = cell.document.getText().split(/\r\n|\r|\n/);
                     if (openBlockCommentOnOwnLine) {
                         retArr.push("<#");
                     } else {
@@ -285,12 +286,12 @@ class PowerShellNotebookContentProvider implements vscode.NotebookContentProvide
                         retArr.push("#>");
                     }
                 } else {
-                    retArr.push(...cell.document.getText().split(/\r|\n|\r\n/).map((line) => `# ${line}`));
+                    retArr.push(...cell.document.getText().split(/\r\n|\r|\n/).map((line) => `# ${line}`));
                 }
             }
         }
 
-        await vscode.workspace.fs.writeFile(targetResource, new TextEncoder().encode(retArr.join("\n")));
+        await vscode.workspace.fs.writeFile(targetResource, new TextEncoder().encode(retArr.join(EOL)));
     }
 }
 

--- a/test/features/PowerShellNotebooks.test.ts
+++ b/test/features/PowerShellNotebooks.test.ts
@@ -162,6 +162,54 @@ suite("PowerShellNotebooks tests", () => {
                 }
             }
         },
+        {
+            cellKind: vscode.CellKind.Code,
+            language: "powershell",
+            source: content.slice(9, 10).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.Disabled,
+                }
+            }
+        },
+        {
+            cellKind: vscode.CellKind.Markdown,
+            language: "markdown",
+            source: content.slice(10, 13).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.BlockComment,
+                    closeBlockCommentOnOwnLine: true,
+                    openBlockCommentOnOwnLine: false
+                }
+            }
+        },
+        {
+            cellKind: vscode.CellKind.Code,
+            language: "powershell",
+            source: content.slice(13, 14).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.Disabled,
+                }
+            }
+        },
+        {
+            cellKind: vscode.CellKind.Markdown,
+            language: "markdown",
+            source: content.slice(14, 17).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.BlockComment,
+                    closeBlockCommentOnOwnLine: false,
+                    openBlockCommentOnOwnLine: true
+                }
+            }
+        },
     ]);
 
     content = readBackingFile(notebookSimpleLineComments).split(os.EOL);
@@ -294,20 +342,12 @@ suite("PowerShellNotebooks tests", () => {
             vscode.notebook.activeNotebookEditor.document.uri.toString(),
             notebookBlockCommentsWithTextOnSameLine.toString());
 
-        // Save it as testFile1.ps1 and reopen it using the feature.
+        // Save it as testFile1.ps1
+        const contentOfBackingFileBefore = (await vscode.workspace.fs.readFile(notebookBlockCommentsWithTextOnSameLine)).toString();
         await notebookContentProvider.saveNotebookAs(uri, vscode.notebook.activeNotebookEditor.document, null);
-        const contentOfBackingFile = (await vscode.workspace.fs.readFile(uri)).toString();
+        const contentOfBackingFileAfter = (await vscode.workspace.fs.readFile(uri)).toString();
 
-        assert.strictEqual(
-`<#
-Foo
-bar
-baz
-#>
-Get-ChildItem
-<# ========
-# Foo
-========= #>`,
-            contentOfBackingFile);
+        // Verify that saving does not mutate result.
+        assert.strictEqual(contentOfBackingFileBefore, contentOfBackingFileAfter);
     }).timeout(20000);
 });

--- a/test/features/PowerShellNotebooks.test.ts
+++ b/test/features/PowerShellNotebooks.test.ts
@@ -210,6 +210,41 @@ suite("PowerShellNotebooks tests", () => {
                 }
             }
         },
+        {
+            cellKind: vscode.CellKind.Code,
+            language: "powershell",
+            source: content.slice(17, 18).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.Disabled,
+                }
+            }
+        },
+        {
+            cellKind: vscode.CellKind.Markdown,
+            language: "markdown",
+            source: content.slice(18, 19).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.BlockComment,
+                    closeBlockCommentOnOwnLine: false,
+                    openBlockCommentOnOwnLine: false
+                }
+            }
+        },
+        {
+            cellKind: vscode.CellKind.Code,
+            language: "powershell",
+            source: content.slice(19, 20).join(os.EOL),
+            outputs: [],
+            metadata: {
+                custom: {
+                    commentType: CommentType.Disabled,
+                }
+            }
+        },
     ]);
 
     content = readBackingFile(notebookSimpleLineComments).split(os.EOL);

--- a/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
+++ b/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
@@ -1,0 +1,9 @@
+<#
+Foo
+bar
+baz
+#>
+Get-ChildItem
+<# ========
+# Foo
+========= #>

--- a/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
+++ b/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
@@ -5,13 +5,16 @@ baz
 #>
 Get-ChildItem
 <# ========
-# Foo
+# A
 ========= #>
 Get-ChildItem
 <# ========
-# Foo
+# B
 #>
 Get-ChildItem
 <#
-# Foo
+# C
 ========= #>
+Get-ChildItem
+<# D #>
+Get-ChildItem

--- a/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
+++ b/test/features/testNotebookFiles/blockCommentsWithTextOnSameLine.ps1
@@ -7,3 +7,11 @@ Get-ChildItem
 <# ========
 # Foo
 ========= #>
+Get-ChildItem
+<# ========
+# Foo
+#>
+Get-ChildItem
+<#
+# Foo
+========= #>


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/vscode-powershell/issues/2845

This will better support block comments with stuff on the line:

```
<# foo
bar
baz #>
```

and also make sure that saving doesn't mess up the style it previously used.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
