### PR TITLE
Expose the API via exports instead of editor commands

### DIFF
--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -3,7 +3,6 @@
  *--------------------------------------------------------*/
 import * as vscode from "vscode";
 import { v4 as uuidv4 } from 'uuid';
-import { LanguageClient } from "vscode-languageclient";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 import { Logger } from "../logging";
 import { SessionManager } from "../session";
@@ -15,71 +14,44 @@ export interface IExternalPowerShellDetails {
     architecture: string;
 }
 
-export class ExternalApiFeature extends LanguageClientConsumer {
-    private commands: vscode.Disposable[];
+export interface IPowerShellExtensionClient {
+    registerExternalExtension(id: string, apiVersion?: string): string;
+    unregisterExternalExtension(uuid: string): boolean;
+    getPowerShellVersionDetails(uuid: string): Promise<IExternalPowerShellDetails>;
+}
+
+/*
+In order to use this in a Visual Studio Code extension, you can do the following:
+
+const powershellExtension = vscode.extensions.getExtension<IPowerShellExtensionClient>("ms-vscode.PowerShell-Preview");
+const powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
+
+NOTE: At some point, we should release a helper npm package that wraps the API and does:
+* Discovery of what extension they have installed: PowerShell or PowerShell Preview
+* Manages session id for you
+
+*/
+export class ExternalApiFeature extends LanguageClientConsumer implements IPowerShellExtensionClient {
     private static readonly registeredExternalExtension: Map<string, IExternalExtension> = new Map<string, IExternalExtension>();
 
     constructor(private sessionManager: SessionManager, private log: Logger) {
         super();
-        this.commands = [
-            /*
-            DESCRIPTION:
-                Registers your extension to allow usage of the external API. The returns
-                a session UUID that will need to be passed in to subsequent API calls.
-
-            USAGE:
-                vscode.commands.executeCommand(
-                    "PowerShell.RegisterExternalExtension",
-                    "ms-vscode.PesterTestExplorer" // the name of the extension using us
-                    "v1"); // API Version.
-
-            RETURNS:
-                string session uuid
-            */
-            vscode.commands.registerCommand("PowerShell.RegisterExternalExtension", (id: string, apiVersion: string = 'v1'): string =>
-                this.registerExternalExtension(id, apiVersion)),
-
-            /*
-            DESCRIPTION:
-                Unregisters a session that an extension has. This returns
-                true if it succeeds or throws if it fails.
-
-            USAGE:
-                vscode.commands.executeCommand(
-                    "PowerShell.UnregisterExternalExtension",
-                    "uuid"); // the uuid from above for tracking purposes
-
-            RETURNS:
-                true if it worked, otherwise throws an error.
-            */
-            vscode.commands.registerCommand("PowerShell.UnregisterExternalExtension", (uuid: string = ""): boolean =>
-                this.unregisterExternalExtension(uuid)),
-
-            /*
-            DESCRIPTION:
-                This will fetch the version details of the PowerShell used to start
-                PowerShell Editor Services in the PowerShell extension.
-
-            USAGE:
-                vscode.commands.executeCommand(
-                    "PowerShell.GetPowerShellVersionDetails",
-                    "uuid"); // the uuid from above for tracking purposes
-
-            RETURNS:
-                An IPowerShellVersionDetails which consists of:
-                {
-                    version: string;
-                    displayVersion: string;
-                    edition: string;
-                    architecture: string;
-                }
-            */
-            vscode.commands.registerCommand("PowerShell.GetPowerShellVersionDetails", (uuid: string = ""): Promise<IExternalPowerShellDetails> =>
-                this.getPowerShellVersionDetails(uuid)),
-        ]
     }
 
-    private registerExternalExtension(id: string, apiVersion: string = 'v1'): string {
+    /*
+    DESCRIPTION:
+        Registers your extension to allow usage of the external API. The returns
+        a session UUID that will need to be passed in to subsequent API calls.
+
+    USAGE:
+        powerShellExtensionClient.registerExternalExtension(
+            "ms-vscode.PesterTestExplorer" // the name of the extension using us
+            "v1"); // API Version.
+
+    RETURNS:
+        string session uuid
+    */
+    public registerExternalExtension(id: string, apiVersion: string = 'v1'): string {
         this.log.writeDiagnostic(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
 
         for (const [_, externalExtension] of ExternalApiFeature.registeredExternalExtension) {
@@ -107,7 +79,19 @@ export class ExternalApiFeature extends LanguageClientConsumer {
         return uuid;
     }
 
-    private unregisterExternalExtension(uuid: string = ""): boolean {
+    /*
+    DESCRIPTION:
+        Unregisters a session that an extension has. This returns
+        true if it succeeds or throws if it fails.
+
+    USAGE:
+        powerShellExtensionClient.unregisterExternalExtension(
+            "uuid"); // the uuid from above for tracking purposes
+
+    RETURNS:
+        true if it worked, otherwise throws an error.
+    */
+    public unregisterExternalExtension(uuid: string = ""): boolean {
         this.log.writeDiagnostic(`Unregistering extension with session UUID: ${uuid}`);
         if (!ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
             throw new Error(`No extension registered with session UUID: ${uuid}`);
@@ -115,10 +99,28 @@ export class ExternalApiFeature extends LanguageClientConsumer {
         return true;
     }
 
-    private async getPowerShellVersionDetails(uuid: string = ""): Promise<IExternalPowerShellDetails> {
+    /*
+    DESCRIPTION:
+        This will fetch the version details of the PowerShell used to start
+        PowerShell Editor Services in the PowerShell extension.
+
+    USAGE:
+        powerShellExtensionClient.getPowerShellVersionDetails(
+            "uuid"); // the uuid from above for tracking purposes
+
+    RETURNS:
+        An IPowerShellVersionDetails which consists of:
+        {
+            version: string;
+            displayVersion: string;
+            edition: string;
+            architecture: string;
+        }
+    */
+    public async getPowerShellVersionDetails(uuid: string = ""): Promise<IExternalPowerShellDetails> {
         if (!ExternalApiFeature.registeredExternalExtension.has(uuid)) {
             throw new Error(
-                "UUID provided was invalid, make sure you execute the 'PowerShell.GetPowerShellVersionDetails' command and pass in the UUID that it returns to subsequent command executions.");
+                "UUID provided was invalid, make sure you ran the 'powershellExtensionClient.registerExternalExtension(extensionId)' method and pass in the UUID that it returns to subsequent methods.");
         }
 
         // TODO: When we have more than one API version, make sure to include a check here.
@@ -137,9 +139,7 @@ export class ExternalApiFeature extends LanguageClientConsumer {
     }
 
     public dispose() {
-        for (const command of this.commands) {
-            command.dispose();
-        }
+        // Nothing to dispose.
     }
 }
 

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -23,7 +23,7 @@ suite("ISECompatibility feature", () => {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
             assert.notEqual(currently, iseSetting.value);
         }
-    });
+    }).timeout(10000);
     test("It leaves Theme after being changed after enabling ISE Mode", async () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
@@ -35,5 +35,5 @@ suite("ISECompatibility feature", () => {
             assert.notEqual(currently, iseSetting.value);
         }
         assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Dark+");
-    });
+    }).timeout(10000);
 });


### PR DESCRIPTION
## PR Summary

So my first attempt at doing an external API was _totally_ wrong.

Turns out, extensions can export things that other extensions can use... this is how the Test Explorer extension works:
https://github.com/hbenl/vscode-test-explorer/blob/82e7d339c5ef25c2e02ca5be8f63f46eadd07e8f/src/main.ts#L116-L123

Anyway, not much changes here besides how you access the API... simply:

```ts
const powershellExtension = vscode.extensions.getExtension<IPowerShellExtensionClient>("ms-vscode.PowerShell-Preview");
const powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
```

Then you're good to go:

```ts
const sessionId = powerShellExtensionClient.registerExternalExtension("ms-vscode.powershell-test-explorer");
const versionDetails = powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
```

I mentioned as a TODO in code that this should be wrapped in a simple npm package that hides the management of `sessionId` and checks for both PowerShell and PowerShell Preview extensions.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
