### PR TITLE
Update LSP Client to work with vscode-languageclient ^7.0.0-next.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "semver": "^7.3.2",
     "uuid": "^8.3.0",
     "vscode-extension-telemetry": "~0.1.6",
-    "vscode-languageclient": "~6.1.3"
+    "vscode-languageclient": "^7.0.0-next.8",
+    "vscode-languageserver-protocol": "^3.16.0-next.6"
   },
   "devDependencies": {
     "@types/glob": "^7.1.3",

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -3,7 +3,8 @@
  *--------------------------------------------------------*/
 
 import vscode = require("vscode");
-import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
+import { NotificationType, RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { ICheckboxQuickPickItem, showCheckboxQuickPick } from "../controls/checkboxQuickPick";
 import { Logger } from "../logging";
 import Settings = require("../settings");

--- a/src/features/CustomViews.ts
+++ b/src/features/CustomViews.ts
@@ -4,7 +4,8 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
-import { LanguageClient, RequestType } from "vscode-languageclient";
+import { RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 export class CustomViewsFeature extends LanguageClientConsumer {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -5,7 +5,8 @@
 import vscode = require("vscode");
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider,
     ExtensionContext, WorkspaceFolder } from "vscode";
-import { LanguageClient, NotificationType, RequestType } from "vscode-languageclient";
+import { NotificationType, RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { getPlatformDetails, OperatingSystem } from "../platform";
 import { PowerShellProcess} from "../process";
 import { SessionManager, SessionStatus } from "../session";

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -6,8 +6,9 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
-import { LanguageClient, NotificationType, NotificationType0,
+import { NotificationType, NotificationType0,
     Position, Range, RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
 import Settings = require("../settings");
 import { LanguageClientConsumer } from "../languageClientConsumer";

--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -2,7 +2,8 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 import * as vscode from "vscode";
-import { LanguageClient, RequestType0 } from "vscode-languageclient";
+import { RequestType0 } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -4,7 +4,8 @@
 
 import { Disposable, EndOfLine, Position, Range, SnippetString,
     TextDocument, TextDocumentChangeEvent, window, workspace } from "vscode";
-import { LanguageClient, RequestType } from "vscode-languageclient";
+import { RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
 import Settings = require("../settings");
 import { LanguageClientConsumer } from "../languageClientConsumer";

--- a/src/features/NewFileOrProject.ts
+++ b/src/features/NewFileOrProject.ts
@@ -3,7 +3,8 @@
  *--------------------------------------------------------*/
 
 import vscode = require("vscode");
-import { LanguageClient, RequestType } from "vscode-languageclient";
+import { RequestType } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 export class NewFileOrProjectFeature extends LanguageClientConsumer {

--- a/src/features/PowerShellNotebooks.ts
+++ b/src/features/PowerShellNotebooks.ts
@@ -8,7 +8,7 @@ import { EvaluateRequestType } from "./Console";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 import Settings = require("../settings");
 import { ILogger } from "../logging";
-import { LanguageClient } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 
 export class PowerShellNotebooksFeature extends LanguageClientConsumer {
 

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -11,7 +11,8 @@ import * as semver from "semver";
 import * as stream from "stream";
 import * as util from "util";
 import { MessageItem, ProgressLocation, window } from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+
+import { LanguageClient } from "vscode-languageclient/node";
 import { SessionManager } from "../session";
 import * as Settings from "../settings";
 import { isMacOS, isWindows } from "../utils";

--- a/src/languageClientConsumer.ts
+++ b/src/languageClientConsumer.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import { window } from "vscode";
-import { LanguageClient } from "vscode-languageclient";
+import { LanguageClient } from "vscode-languageclient/node";
 
 export abstract class LanguageClientConsumer {
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -15,9 +15,10 @@ import Settings = require("./settings");
 import utils = require("./utils");
 
 import {
-    CloseAction, DocumentSelector, ErrorAction, LanguageClient, LanguageClientOptions,
+    CloseAction, DocumentSelector, ErrorAction, LanguageClientOptions,
     Middleware, NotificationType, RequestType0,
-    ResolveCodeLensSignature, RevealOutputChannelOn, StreamInfo } from "vscode-languageclient";
+    ResolveCodeLensSignature, RevealOutputChannelOn } from "vscode-languageclient";
+import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 
 import { GitHubReleaseInformation, InvokePowerShellUpdateCheck } from "./features/UpdatePowerShell";
 import {


### PR DESCRIPTION
## PR Summary
The newest version of vscode-languageclient (^7.0.0) is needed for the new semantic tokens protocol, and certain modules have moved around.

Also see: https://github.com/PowerShell/PowerShellEditorServices/pull/1343

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests (NA)
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
