### PR TITLE
Fix migration of `codeFormatting.addWhitespaceAroundPipe` setting

### DIFF
--- a/src/features/RemoteFiles.ts
+++ b/src/features/RemoteFiles.ts
@@ -38,7 +38,7 @@ export class RemoteFilesFeature extends LanguageClientConsumer {
         this.closeRemoteFiles();
 
         vscode.workspace.onDidSaveTextDocument((doc) => {
-            if (this.languageClient && this.isDocumentRemote(doc)) {
+            if (this.isDocumentRemote(doc) && this.languageClient) {
                 this.languageClient.sendNotification(
                     DidSaveTextDocumentNotificationType,
                     {

--- a/src/session.ts
+++ b/src/session.ts
@@ -332,11 +332,11 @@ export class SessionManager implements Middleware {
         const deprecatedSetting = 'codeFormatting.whitespaceAroundPipe'
         const newSetting = 'codeFormatting.addWhitespaceAroundPipe'
         const configurationTargetOfNewSetting = await Settings.getEffectiveConfigurationTarget(newSetting);
-        if (configuration.has(deprecatedSetting) && configurationTargetOfNewSetting === null) {
-            const configurationTarget = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
-            const value = configuration.get(deprecatedSetting, configurationTarget)
-            await Settings.change(newSetting, value, configurationTarget);
-            await Settings.change(deprecatedSetting, undefined, configurationTarget);
+        const configurationTargetOfOldSetting = await Settings.getEffectiveConfigurationTarget(deprecatedSetting);
+        if (configurationTargetOfOldSetting !== null && configurationTargetOfNewSetting === null) {
+            const value = configuration.get(deprecatedSetting, configurationTargetOfOldSetting)
+            await Settings.change(newSetting, value, configurationTargetOfOldSetting);
+            await Settings.change(deprecatedSetting, undefined, configurationTargetOfOldSetting);
         }
     }
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -3,7 +3,7 @@
  *--------------------------------------------------------*/
 
 import * as assert from "assert";
-import { IPowerShellExeDetails } from "../src/platform";
+import * as vscode from "vscode";
 import Settings = require("../src/settings");
 
 suite("Settings module", () => {
@@ -33,5 +33,15 @@ suite("Settings module", () => {
         // set to true means it's a user-level setting so this should not throw.
         await Settings.change("powerShellAdditionalExePaths", psExeDetails, true);
         assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
+    });
+
+    test("Can get effective configuration target", async () => {
+        await Settings.change("helpCompletion", "LineComment", false);
+        let target = await Settings.getEffectiveConfigurationTarget("helpCompletion");
+        assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
+
+        await Settings.change("helpCompletion", undefined, false);
+        target = await Settings.getEffectiveConfigurationTarget("helpCompletion");
+        assert.strictEqual(target, null);
     });
 });


### PR DESCRIPTION
## PR Summary

Fixes #2842 

This will properly migrate `codeFormatting.whitespaceAroundPipe` to `codeFormatting.addWhitespaceAroundPipe`.

Also, the saving of file triggered the `this.languageClient` to cause a warning to show because PSES wasn't finished initializing so I've just swapped the conditional now. Later I could do something different (like a `this.isLanguageClientConnected` but I'll defer that)

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
