### PR TITLE
Prevent `Update Notebook dts` action from triggering on forked repositories

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ jobs:
 
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
+    if: github.repository == 'PowerShell/vscode-powershell'
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/updateNotebookApi.yml
+++ b/.github/workflows/updateNotebookApi.yml
@@ -13,6 +13,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    if: github.repository == 'PowerShell/vscode-powershell'
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -80,7 +81,7 @@ jobs:
         Remove-Item ./old.vscode.proposed.d.ts -Force
 
     - name: Create Pull Request
-      if: ${{ github.event_name == 'schedule' && github.repository == 'PowerShell/vscode-powershell' }}
+      if: github.event_name == 'schedule'
       id: cpr
       uses: peter-evans/create-pull-request@v2
       env:

--- a/.github/workflows/updateNotebookApi.yml
+++ b/.github/workflows/updateNotebookApi.yml
@@ -80,7 +80,7 @@ jobs:
         Remove-Item ./old.vscode.proposed.d.ts -Force
 
     - name: Create Pull Request
-      if: github.event_name == 'schedule' && github.repository == 'PowerShell/vscode-powershell'
+      if: ${{ github.event_name == 'schedule' && github.repository == 'PowerShell/vscode-powershell' }}
       id: cpr
       uses: peter-evans/create-pull-request@v2
       env:

--- a/.github/workflows/updateNotebookApi.yml
+++ b/.github/workflows/updateNotebookApi.yml
@@ -80,7 +80,7 @@ jobs:
         Remove-Item ./old.vscode.proposed.d.ts -Force
 
     - name: Create Pull Request
-      if: github.event_name == 'schedule'
+      if: github.event_name == 'schedule' && github.repository == 'PowerShell/vscode-powershell'
       id: cpr
       uses: peter-evans/create-pull-request@v2
       env:


### PR DESCRIPTION
Similar to https://github.com/PowerShell/PowerShell/pull/12763

## PR Summary

Update GitHub Actions Workflow to only trigger on the main vscode-powershell repository.

Note: I have not tested this, merely modeled it after the [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-contexts) and the PowerShell PR.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
