### PR TITLE
Fixed crash when running pester older than 3.4.5

### DIFF
--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -100,7 +100,7 @@ function Get-InvokePesterParams {
         # -PesterOption was introduced before 3.4.0, and VSCodeMarker in 4.0.3-rc,
         # but because no-one checks the integrity of this hashtable we can call
         # all of the versions down to 3.4.0 like this
-        $invokePesterParams.Add("PesterOption", @{IncludeVSCodeMarker=$true})
+        $invokePesterParams.Add("PesterOption", @{ IncludeVSCodeMarker = $true })
     }
 
     if ($pesterModule.Version -ge '3.4.5') {

--- a/InvokePesterStub.ps1
+++ b/InvokePesterStub.ps1
@@ -102,6 +102,7 @@ function Get-InvokePesterParams {
         # all of the versions down to 3.4.0 like this
         $invokePesterParams.Add("PesterOption", @{IncludeVSCodeMarker=$true})
     }
+
     if ($pesterModule.Version -ge '3.4.5') {
         # -Show was introduced in 3.4.5
         $invokePesterParams.Add("Show", $pester4Output)


### PR DESCRIPTION
## PR Summary

Calling Invoke-Pester with the -show param would
throw and exception if running a version of pester
older than 3.4.5

Moved logic for building spalt to call
invoke-pester into a function and only added the
show parameter if running pester 3.4.5 or newer

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] `NA` PR has tests
    - InvokePesterStub did not appear to have tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
