### PR TITLE
Support Untitled files and automatic *.Notebook.ps1 files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     "onCommand:PowerShell.UnregisterExternalExtension",
     "onCommand:PowerShell.GetPowerShellVersionDetails",
     "onView:PowerShellCommands",
-    "onNotebookEditor:PowerShellNotebookMode"
+    "onNotebook:PowerShellNotebookModeDefault",
+    "onNotebookEditor:PowerShellNotebookModeDefault",
+    "onNotebook:PowerShellNotebookModeOption",
+    "onNotebookEditor:PowerShellNotebookModeOption"
   ],
   "dependencies": {
     "node-fetch": "^2.6.0",
@@ -113,10 +116,21 @@
     },
     "notebookProvider": [
       {
-        "viewType": "PowerShellNotebookMode",
+        "viewType": "PowerShellNotebookModeDefault",
         "displayName": "Powershell Notebook",
         "selector": [
           {
+            "filenamePattern": "*.Notebook.ps1"
+          }
+        ],
+        "priority": "default"
+      },
+      {
+        "viewType": "PowerShellNotebookModeOption",
+        "displayName": "Powershell Notebook",
+        "selector": [
+          {
+            "excludeFileNamePattern": "*.Notebook.ps1",
             "filenamePattern": "*.ps1"
           }
         ],

--- a/test/features/PowerShellNotebooks.test.ts
+++ b/test/features/PowerShellNotebooks.test.ts
@@ -34,6 +34,8 @@ const notebookSimpleLineComments = vscode.Uri.file(
     path.join(...notebookDir,"simpleLineComments.ps1"));
 const notebookSimpleMixedComments = vscode.Uri.file(
     path.join(...notebookDir,"simpleMixedComments.ps1"));
+const notebookSimpleDotNotebook = vscode.Uri.file(
+    path.join(...notebookDir,"simple.Notebook.ps1"));
 
 const notebookTestData = new Map<vscode.Uri, vscode.NotebookCellData[]>();
 
@@ -343,7 +345,7 @@ suite("PowerShellNotebooks tests", () => {
         }
 
         // Open an existing notebook ps1.
-        await vscode.commands.executeCommand("vscode.openWith", notebookSimpleMixedComments, "PowerShellNotebookMode");
+        await vscode.commands.executeCommand("vscode.openWith", notebookSimpleMixedComments, "PowerShellNotebookModeOption");
 
         // Allow some time to pass to render the Notebook
         await utils.sleep(5000);
@@ -369,7 +371,7 @@ suite("PowerShellNotebooks tests", () => {
         }
 
         // Open an existing notebook ps1.
-        await vscode.commands.executeCommand("vscode.openWith", notebookBlockCommentsWithTextOnSameLine, "PowerShellNotebookMode");
+        await vscode.commands.executeCommand("vscode.openWith", notebookBlockCommentsWithTextOnSameLine, "PowerShellNotebookModeOption");
 
         // Allow some time to pass to render the Notebook
         await utils.sleep(5000);
@@ -384,5 +386,29 @@ suite("PowerShellNotebooks tests", () => {
 
         // Verify that saving does not mutate result.
         assert.strictEqual(contentOfBackingFileBefore, contentOfBackingFileAfter);
+    }).timeout(20000);
+
+    test("Can open an untitled Notebook", async () => {
+        const doc = await vscode.workspace.openTextDocument({
+            language: "powershell",
+            content: `# asdf
+gci`,
+        });
+
+        const notebookData = await notebookContentProvider.openNotebook(doc.uri, {});
+        assert.strictEqual(notebookData.cells.length, 2);
+        assert.strictEqual(notebookData.cells[0].cellKind, vscode.CellKind.Markdown);
+        assert.strictEqual(notebookData.cells[0].source, "asdf");
+        assert.strictEqual(notebookData.cells[1].cellKind, vscode.CellKind.Code);
+        assert.strictEqual(notebookData.cells[1].source, "gci");
+    }).timeout(20000);
+
+    test(".Notebook.ps1 files are opened automatically", async () => {
+        await vscode.commands.executeCommand("vscode.open", notebookSimpleDotNotebook);
+        assert.strictEqual(vscode.notebook.activeNotebookEditor.document.cells.length, 2);
+        assert.strictEqual(vscode.notebook.activeNotebookEditor.document.cells[0].cellKind, vscode.CellKind.Markdown);
+        assert.strictEqual(vscode.notebook.activeNotebookEditor.document.cells[0].document.getText(), "asdf");
+        assert.strictEqual(vscode.notebook.activeNotebookEditor.document.cells[1].cellKind, vscode.CellKind.Code);
+        assert.strictEqual(vscode.notebook.activeNotebookEditor.document.cells[1].document.getText(), "gci\n");
     }).timeout(20000);
 });

--- a/test/features/testNotebookFiles/simple.Notebook.ps1
+++ b/test/features/testNotebookFiles/simple.Notebook.ps1
@@ -1,0 +1,2 @@
+# asdf
+gci


### PR DESCRIPTION
## PR Summary

Fixes #2866 
Fixes #2901
Fixes #2865

This enables the following features:

* Untitled file support - now you can open untitled PowerShell files in Notebook mode, when you save the untitled notebook the experience is what you expect (saves to ps1 and opens that ps1 in notebook mode)
* Automatic Notebooks - if you create a file with *.Notebook.ps1, it will automatically open in Notebook mode. In order to do this, I needed to register 2 different viewTypes with the same underlying implementation. It's a little clunky from the dev experience (I'll probably open an issue) but the UX feels nice. You can still go back to text editor mode from a *.Notebook.ps1 if you want

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
