### PR TITLE
Session menu fails to open when PowerShell extension is starting

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -703,7 +703,7 @@ export class SessionManager implements Middleware {
             case SessionStatus.Stopping:
                 const currentPowerShellExe =
                 availablePowerShellExes
-                    .find((item) => item.displayName.toLowerCase() === this.PowerShellExeDetails.displayName);
+                    .find((item) => item.displayName.toLowerCase() === this.PowerShellExeDetails.displayName.toLowerCase());
 
                 const powerShellSessionName =
                     currentPowerShellExe ?


### PR DESCRIPTION
## PR Summary

This is the solution proposed by @GaelGirodon in Issue #2906 

There were no issues during the build and testing of this change, and the proper version of powershell was loaded and displayed in the task bar.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
