### PR TITLE
Add braces to PSCustomObject snippet

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -924,7 +924,7 @@
 		]
     },
     "PSCustomObject": {
-        "prefix": "PSCustomObject",
+        "prefix": "[PSCustomObject]",
         "body": [
             "[PSCustomObject]@{",
             "\t${1:Name} = ${2:Value}",


### PR DESCRIPTION
## PR Summary

This will fix an outstanding issue where when you accept the PSCustomObject snippet, there is an extra `]` on the right of the snippet. More details here https://github.com/microsoft/vscode/issues/104952

This requires this fix in VS Code to go in: https://github.com/microsoft/vscode/pull/114235

but personally, I don't think it hurts the experience if this PR went in before the next stable release of VS Code with the vscode fix.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
