### PR TITLE
Rewrite release signing pipeline

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
   "recommendations": [
     "editorconfig.editorconfig",
     "msjsdiag.debugger-for-chrome",
+    "ms-azure-devops.azure-pipelines",
     "ms-vscode.powershell",
     "ms-vscode.vscode-typescript-tslint-plugin",
     "davidanson.vscode-markdownlint"

--- a/.vsts-ci/azure-pipelines-release.yml
+++ b/.vsts-ci/azure-pipelines-release.yml
@@ -32,12 +32,21 @@ trigger:
       - /LICENSE
       - /CODE_OF_CONDUCT.md
 
+resources:
+  repositories:
+  - repository: ComplianceRepo
+    type: github
+    endpoint: ComplianceGHRepo
+    name: PowerShell/Compliance
+
 jobs:
 
 - job: 'ReleaseBuild'
   displayName: 'Build release'
   pool:
-    name: 'Package ES CodeHub Lab E'
+    name: 'Package ES Standard Build'
     demands: DotNetFramework
+  variables:
+  - group: ESRP
   steps:
   - template: templates/release-general.yml

--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -28,6 +28,7 @@ steps:
       git clone --single-branch --branch $env:PSES_BRANCH https://github.com/$env:PSES_FORK/PowerShellEditorServices.git ../PowerShellEditorServices
       Install-Module InvokeBuild -Scope CurrentUser -Force
       Install-Module PlatyPS -Scope CurrentUser -Force
+      New-Item -ItemType Directory $(Build.ArtifactStagingDirectory)/vscode-powershell
   # Build
   - pwsh: Invoke-Build
   - task: PublishTestResults@2
@@ -38,7 +39,7 @@ steps:
   - task: PublishBuildArtifacts@1
     inputs:
       ArtifactName: vscode-powershell
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)/vscode-powershell'
   # Rich Navigation
   - task: RichCodeNavIndexer@0
     # Note, for now, this is Windows only.

--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -17,6 +17,7 @@ steps:
     targetType: filePath
     filePath: ./vscode-powershell/tools/releaseBuild/setVstsVariables.ps1
 
+# TODO: Replace this with an upstream trigger.
 - task: PowerShell@2
   displayName: 'Find PowerShellEditorServices build'
   env:
@@ -25,17 +26,17 @@ steps:
     targetType: filePath
     filePath: ./vscode-powershell/tools/releaseBuild/findPsesBuild.ps1
 
-- task: DownloadBuildArtifacts@0
-  displayName: 'Download Build Artifacts from PowerShell Editor Services'
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download Artifacts from PowerShell Editor Services'
   inputs:
-    buildType: specific
+    source: specific
     project: '8e2735c1-3674-408a-bcab-87f089ea29d5'
     pipeline: 1056
-    buildVersionToDownload: specific
-    buildId: '$(PSES_BUILDID)'
-    downloadType: single
-    artifactName: 'PowerShellEditorServices'
-    downloadPath: '$(Build.SourcesDirectory)'
+    preferTriggeringPipeline: true
+    runVersion: specific
+    runId: '$(PSES_BUILDID)'
+    artifact: 'PowerShellEditorServices'
+    path: '$(Build.SourcesDirectory)/PowerShellEditorServices/module/'
 
 - pwsh: |
     New-Item -ItemType Directory $(Build.ArtifactStagingDirectory)/vscode-powershell

--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -1,18 +1,5 @@
 steps:
-- powershell: |
-    Write-Host "Installing pwsh..."
-    if (Get-Command pwsh -ErrorAction Ignore)
-    {
-        Write-Host "pwsh already installed, skipping"
-        return
-    }
-    $powerShellPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'powershell'
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1 -outfile ./install-powershell.ps1
-    ./install-powershell.ps1 -Destination $powerShellPath
-    $vstsCommandString = "vso[task.setvariable variable=PATH]$powerShellPath;$env:PATH"
-    Write-Host "sending " + $vstsCommandString
-    Write-Host "##$vstsCommandString"
-  displayName: Install PowerShell Core
+- checkout: self
 
 - pwsh: Write-Host "##vso[build.updatebuildnumber]$env:BUILD_SOURCEBRANCHNAME-$env:BUILD_SOURCEVERSION-$((get-date).ToString("yyyyMMddhhmmss"))"
   displayName: Set Build Name for Non-PR
@@ -23,17 +10,12 @@ steps:
   displayName: Capture environment
   condition: succeededOrFailed()
 
-- task: PkgESSetupBuild@10
-  displayName: 'Package ES - Setup Build'
-  inputs:
-    productName: vscode-powershell
-    useDFS: false
-
+# TODO: Use modern resources for these variables.
 - task: PowerShell@2
   displayName: 'Set environment variables for VSTS (Phase 1)'
   inputs:
     targetType: filePath
-    filePath: ./tools/releaseBuild/setVstsVariables.ps1
+    filePath: ./vscode-powershell/tools/releaseBuild/setVstsVariables.ps1
 
 - task: PowerShell@2
   displayName: 'Find PowerShellEditorServices build'
@@ -41,7 +23,7 @@ steps:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
   inputs:
     targetType: filePath
-    filePath: ./tools/releaseBuild/findPsesBuild.ps1
+    filePath: ./vscode-powershell/tools/releaseBuild/findPsesBuild.ps1
 
 - task: DownloadBuildArtifacts@0
   displayName: 'Download Build Artifacts from PowerShell Editor Services'
@@ -56,8 +38,10 @@ steps:
     downloadPath: '$(Build.SourcesDirectory)'
 
 - pwsh: |
+    New-Item -ItemType Directory $(Build.ArtifactStagingDirectory)/vscode-powershell
     Install-Module InvokeBuild -Force
     Invoke-Build Release
+  workingDirectory: '$(Build.SourcesDirectory)/vscode-powershell'
 
 - task: PublishTestResults@2
   inputs:
@@ -65,80 +49,44 @@ steps:
     testResultsFiles: '**/test-results.xml'
   condition: succeededOrFailed()
 
-- task: PkgESCodeSign@10
-  displayName: 'CodeSign tools/releaseBuild/signing.xml'
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-  inputs:
-    signConfigXml: tools/releaseBuild/signing.xml
-    inPathRoot: '$(Build.ArtifactStagingDirectory)'
-    outPathRoot: '$(Build.ArtifactStagingDirectory)\Signed'
+- checkout: ComplianceRepo
 
-- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  displayName: 'Component Detection'
+- template: EsrpSign.yml@ComplianceRepo
+  parameters:
+    buildOutputPath: '$(Build.ArtifactStagingDirectory)/vscode-powershell'
+    signOutputPath: '$(Build.ArtifactStagingDirectory)/ScriptSigned'
+    alwaysCopy: true # So publishing works
+    certificateId: 'CP-230012' # Authenticode certificate
+    useMinimatch: true # This enables the use of globbing
+    pattern: |
+      Install-VSCode.ps1
 
-- task: AntiMalware@3
-  inputs:
-    InputType: 'Basic'
-    ScanType: 'CustomScan'
-    FileDirPath: '$(Build.ArtifactStagingDirectory)'
-    EnableServices: false
-    SupportLogOnError: false
-    TreatSignatureUpdateFailureAs: 'Warning'
-    SignatureFreshness: 'UpToDate'
-    TreatStaleSignatureAs: 'Error'
+- template: EsrpSign.yml@ComplianceRepo
+  parameters:
+    buildOutputPath: '$(Build.ArtifactStagingDirectory)/ScriptSigned'
+    signOutputPath: '$(Build.ArtifactStagingDirectory)/ExtensionSigned'
+    alwaysCopy: true # So publishing works
+    certificateId: 'CP-233016' # Microsoft OPC Publisher (VSIX) certificate
+    useMinimatch: true # This enables the use of globbing
+    pattern: |
+      PowerShell-insiders.vsix
 
-- task: PoliCheck@1
-  condition: succeededOrFailed()
-  inputs:
-    targetType: F
-    optionsFC: 0
-    optionsXS: 0
-    optionsPE: '1|2|3|4'
-    optionsHMENABLE: 0
-    optionsFTPATH: '$(Build.SourcesDirectory)\tools\terms\FileTypeSet.xml'
-    # toolVersion: 5.8.2.1
+- publish: $(Build.ArtifactsDirectory)/ExtensionSigned
+  artifact: vscode-powershell
+  displayName: 'Publish signed (and unsigned) artifacts'
 
-- pwsh: |
-    Get-ChildItem -Exclude node_modules | Get-ChildItem -Recurse | ForEach-Object FullName > "$env:BUILD_SOURCESDIRECTORY/credscan.tsv"
-  displayName: Create credscan.tsv as the list of files to scan
-
-- task: CredScan@2
-  condition: succeededOrFailed()
-  inputs:
-    debugMode: false
-    scanFolder: '$(Build.SourcesDirectory)/credscan.tsv'
-
-# Publish results as artifacts
-- task: PublishSecurityAnalysisLogs@3
-  condition: succeededOrFailed()
-  inputs:
-    ArtifactName: 'CodeAnalysisLogs'
-    ArtifactType: 'Container'
-
-# Publish to TSA server
-- task: TSAUpload@1
-  condition: succeededOrFailed()
-  continueOnError: true
-  inputs:
-    tsaVersion: 'TsaV2'
-    codebase: 'Existing'
-    tsaEnvironment: 'PROD'
-    codeBaseName: 'PowerShell_PowerShellEditorServices_20190917'
-    uploadAPIScan: false
-    uploadBinSkim: false
-    uploadCredScan: true
-    uploadFortifySCA: false
-    uploadFxCop: false
-    uploadModernCop: false
-    uploadPoliCheck: true
-    uploadPREfast: false
-    uploadRoslyn: false
-    uploadTSLint: false
-    uploadAsync: true
-
-- task: PowerShell@1
-  displayName: 'Upload artifacts'
-  inputs:
-    scriptType: inlineScript
-    inlineScript: 'Write-Host "##vso[artifact.upload containerfolder=vscode-powershell;artifactname=vscode-powershell]$(System.ArtifactsDirectory)\Signed"'
+- template: script-module-compliance.yml@ComplianceRepo
+  parameters:
+    # component-governance
+    sourceScanPath: '$(Build.SourcesDirectory)/vscode-powershell'
+    # credscan
+    suppressionsFile: '$(Build.SourcesDirectory)/vscode-powershell/tools/credScan/suppress.json'
+    # TermCheck AKA PoliCheck
+    targetArgument: '$(Build.SourcesDirectory)/vscode-powershell'
+    optionsUEPATH: '$(Build.SourcesDirectory)/vscode-powershell/tools/terms/UserExclusions.xml'
+    optionsRulesDBPath: ''
+    optionsFTPath: '$(Build.SourcesDirectory)/vscode-powershell/tools/terms/FileTypeSet.xml'
+    # tsa-upload
+    codeBaseName: 'PowerShell_PowerShellEditorServices_20210201'
+    # We don't use any Windows APIs directly, so we don't need API scan
+    APIScan: false

--- a/.vsts-ci/templates/release-general.yml
+++ b/.vsts-ci/templates/release-general.yml
@@ -55,24 +55,21 @@ steps:
 - template: EsrpSign.yml@ComplianceRepo
   parameters:
     buildOutputPath: '$(Build.ArtifactStagingDirectory)/vscode-powershell'
-    signOutputPath: '$(Build.ArtifactStagingDirectory)/ScriptSigned'
+    signOutputPath: '$(Build.ArtifactStagingDirectory)/Signed'
     alwaysCopy: true # So publishing works
     certificateId: 'CP-230012' # Authenticode certificate
     useMinimatch: true # This enables the use of globbing
+    # NOTE: Code AKA *.vsix files are not signed
     pattern: |
       Install-VSCode.ps1
 
-- template: EsrpSign.yml@ComplianceRepo
+- template: EsrpScan.yml@ComplianceRepo
   parameters:
-    buildOutputPath: '$(Build.ArtifactStagingDirectory)/ScriptSigned'
-    signOutputPath: '$(Build.ArtifactStagingDirectory)/ExtensionSigned'
-    alwaysCopy: true # So publishing works
-    certificateId: 'CP-233016' # Microsoft OPC Publisher (VSIX) certificate
-    useMinimatch: true # This enables the use of globbing
-    pattern: |
-      PowerShell-insiders.vsix
+      scanPath: $(Build.ArtifactStagingDirectory)/Signed
+      pattern: |
+        *.vsix
 
-- publish: $(Build.ArtifactsDirectory)/ExtensionSigned
+- publish: $(Build.ArtifactStagingDirectory)/Signed
   artifact: vscode-powershell
   displayName: 'Publish signed (and unsigned) artifacts'
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,48 +5,52 @@
 You'll need to clone two repositories and set up your development environment
 to before you can proceed.
 
-1. [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [vscode-powershell repository](https://github.com/PowerShell/vscode-powershell)
+1. [Fork and clone][fork] the [vscode-powershell repository](https://github.com/PowerShell/vscode-powershell)
 
-2. [Fork and clone](https://help.github.com/articles/fork-a-repo/) the [PowerShell Editor Services (PSES) repository](https://github.com/PowerShell/PowerShellEditorServices)
+2. [Fork and clone][fork] the [PowerShell Editor Services (PSES) repository](https://github.com/PowerShell/PowerShellEditorServices)
+   > The `vscode-powershell` folder and the `PowerShellEditorServices` folder should be next to each other on the file
+   > system. Code in `vscode-powershell` looks for PSES at `../PowerShellEditorServices` if you're building locally so
+   > PSES must be in that location.
 
-> NOTE: the `vscode-powershell` folder and the `PowerShellEditorServices` folder should be next to each other on the file system. Code in `vscode-powershell` looks for PSES at `../PowerShellEditorServices` if you're building locally so PSES must be in that location.
-
-3. Follow the [development instructions](https://github.com/PowerShell/PowerShellEditorServices#development) for PowerShell Editor Services. **You will need to complete this step before proceeding**.
+3. Follow the [development instructions](https://github.com/PowerShell/PowerShellEditorServices#development) for
+   PowerShell Editor Services. **You will need to complete this step before proceeding**.
 
 4. Install the latest [Visual Studio Code Insiders release](https://code.visualstudio.com/insiders)
-    - You can also use the [standard Visual Studio Code release](https://code.visualstudio.com/). Both will work, but using VSCode
-    Insiders means the extension can be developed ready for new features
-    and changes in the next VSCode release.
+   > You can also use the [standard Visual Studio Code release](https://code.visualstudio.com/). Both will work, but
+   > using VSCode Insiders means the extension can be developed ready for new features and changes in the next VSCode
+   > release.
 
 5. Install [Node.js](https://nodejs.org/en/) 10.x or higher.
 
-## Building the Code
+[fork]: https://help.github.com/articles/fork-a-repo/
 
-#### From Visual Studio Code:
+### Building the Code
 
-Press <kbd>Ctrl</kbd>+<kbd>P</kbd> and type `task build`
+#### From Visual Studio Code
+
+> Press <kbd>Ctrl</kbd>+<kbd>P</kbd> and type `task build`
 
 This will compile the TypeScript files in the project to JavaScript files.
 
-#### From a PowerShell prompt:
+#### From a PowerShell prompt
 
-```
+```powershell
 Invoke-Build Build
 ```
 
-## Launching the extension
+### Launching the extension
 
-#### From Visual Studio Code:
+#### From Visual Studio Code
 
-To debug the extension, press <kbd>F5</kbd>.  To run the extension without debugging,
-press <kbd>Ctrl</kbd>+<kbd>F5</kbd> or <kbd>Cmd</kbd>+<kbd>F5</kbd> on macOS.
+> To debug the extension, press <kbd>F5</kbd>.  To run the extension without debugging, press
+> <kbd>Ctrl</kbd>+<kbd>F5</kbd> or <kbd>Cmd</kbd>+<kbd>F5</kbd> on macOS.
 
-#### From a command prompt:
+#### From a command prompt
 
-```
+```cmd
 code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
 ```
 
 ## Contributing Snippets
 
-For more information on contributing snippets please read our [snippet requirements](https://github.com/PowerShell/vscode-powershell/blob/master/docs/community_snippets.md#contributing). 
+For more information on contributing snippets please read our [snippet requirements](https://github.com/PowerShell/vscode-powershell/blob/master/docs/community_snippets.md#contributing).

--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -9,7 +9,8 @@
     ],
   "settings": {
     "files.associations": {
-      "**/snippets/*.json": "jsonc"
+      "**/snippets/*.json": "jsonc",
+      "**/.vsts-ci/**/*.yml": "azure-pipelines",
     },
     "typescript.tsdk": "./node_modules/typescript/lib"
   }

--- a/tools/credScan/suppress.json
+++ b/tools/credScan/suppress.json
@@ -1,0 +1,13 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "folder": "node_modules",
+      "_justification": "Third-party code must not be scanned"
+    },
+    {
+      "folder": "PSScriptAnalyzer",
+      "_justification": "Bundled upstream project with false-positives"
+    }
+  ]
+}

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<SignConfigXML>
-  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="vscode powershell" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\PowerShell-insiders.vsix" signType="100040160"
-      dest="__OUTPATHROOT__\PowerShell-insiders.vsix" />
-    <file src="__INPATHROOT__\Install-VSCode.ps1" signType="AuthenticodeFormer"
-      dest="__OUTPATHROOT__\Install-VSCode.ps1" />
-  </job>
-</SignConfigXML>

--- a/tools/terms/UserExclusions.xml
+++ b/tools/terms/UserExclusions.xml
@@ -1,0 +1,12 @@
+<PoliCheckExclusions>
+  <!-- All strings must be UPPER CASE -->
+  <!--Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
+  <!--<Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion>-->
+  <Exclusion Type="FolderPathFull">.GIT|NODE_MODULES</Exclusion>
+  <!--Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
+  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
+  <!--Each of these file types will be completely skipped for the entire scan -->
+  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
+  <!--The specified file names will be skipped during the scan regardless which folder they are in -->
+  <!--<Exclusion Type="FileName">ABC.TXT|XYZ.CS</Exclusion>-->
+</PoliCheckExclusions>

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -14,6 +14,7 @@ Write-Host "`n### Extension Version: $($script:PackageJson.version) Extension Na
 
 #region Utility tasks
 
+# TODO: This needs to be a function, not a task.
 task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices, TestEditorServices, Package {
 
     $script:psesRepoPath = `
@@ -24,7 +25,7 @@ task ResolveEditorServicesPath -Before CleanEditorServices, BuildEditorServices,
             "$PSScriptRoot/../PowerShellEditorServices/"
         }
 
-    if (!(Test-Path $script:psesRepoPath)) {
+    if (!(Test-Path "$script:psesRepoPath/PowerShellEditorServices.build.ps1")) {
         # Clear the path so that it won't be used
         Write-Warning "`nThe PowerShellEditorServices repo cannot be found at path $script:psesRepoPath`n"
         $script:psesRepoPath = $null
@@ -172,14 +173,9 @@ task UpdatePackageJson {
 }
 
 task Package UpdateReadme, {
-
-    if ($script:psesBuildScriptPath) {
+    if ($script:psesBuildScriptPath -or $env:TF_BUILD) {
         Write-Host "`n### Copying PowerShellEditorServices module files" -ForegroundColor Green
         Copy-Item -Recurse -Force ..\PowerShellEditorServices\module\* .\modules
-    } elseif (Test-Path .\PowerShellEditorServices) {
-        Write-Host "`n### Moving PowerShellEditorServices module files" -ForegroundColor Green
-        Move-Item -Force .\PowerShellEditorServices\* .\modules
-        Remove-Item -Force .\PowerShellEditorServices
     } else {
         throw "Unable to find PowerShell EditorServices"
     }

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -191,8 +191,8 @@ task Package UpdateReadme, {
     Move-Item -Force .\$($script:PackageJson.name)-$($script:PackageJson.version).vsix .\PowerShell-insiders.vsix
 
     if ($env:TF_BUILD) {
-        Copy-Item -Verbose -Recurse "./PowerShell-insiders.vsix" "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/PowerShell-insiders.vsix"
-        Copy-Item -Verbose -Recurse "./scripts/Install-VSCode.ps1" "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/Install-VSCode.ps1"
+        Copy-Item -Verbose -Recurse "./PowerShell-insiders.vsix" "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/vscode-powershell/PowerShell-insiders.vsix"
+        Copy-Item -Verbose -Recurse "./scripts/Install-VSCode.ps1" "$env:BUILD_ARTIFACTSTAGINGDIRECTORY/vscode-powershell/Install-VSCode.ps1"
     }
 }
 


### PR DESCRIPTION
This changes a bunch of internal stuff to use "ESRP" signing instead of "Package ES" signing, which only matters to Microsoft folks.

Just like https://github.com/PowerShell/PowerShellEditorServices/pull/1408 but downstream.

Resolves #3160.