### PR TITLE
Fix PowerShell MSIX (Store) detection

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -268,7 +268,7 @@ export class PowerShellExeFinder {
         // Find the base directory for MSIX application exe shortcuts
         const msixAppDir = path.join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps");
 
-        if (!fs.existsSync(msixAppDir)) {
+        if (!fileExistsSync(msixAppDir)) {
             return null;
         }
 
@@ -310,7 +310,13 @@ export class PowerShellExeFinder {
         const powerShellInstallBaseDir = path.join(programFilesPath, "PowerShell");
 
         // Ensure the base directory exists
-        if (!(fs.existsSync(powerShellInstallBaseDir) && fs.lstatSync(powerShellInstallBaseDir).isDirectory())) {
+        try {
+            const powerShellInstallBaseDirLStat = fs.lstatSync(powerShellInstallBaseDir);
+            if (!powerShellInstallBaseDirLStat.isDirectory())
+            {
+                return null;
+            }
+        } catch {
             return null;
         }
 
@@ -469,6 +475,17 @@ export function getWindowsSystemPowerShellPath(systemFolderName: string) {
         "powershell.exe");
 }
 
+function fileExistsSync(filePath: string): boolean {
+    try {
+        // This will throw if the path does not exist,
+        // and otherwise returns a value that we don't care about
+        fs.lstatSync(filePath);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 interface IPossiblePowerShellExe extends IPowerShellExeDetails {
     exists(): boolean;
 }
@@ -491,7 +508,7 @@ class PossiblePowerShellExe implements IPossiblePowerShellExe {
 
     public exists(): boolean {
         if (this.knownToExist === undefined) {
-            this.knownToExist = fs.existsSync(this.exePath);
+            this.knownToExist = fileExistsSync(this.exePath);
         }
         return this.knownToExist;
     }


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/vscode-powershell/issues/3181.

The MSIX exe is a symlink and node's file test API returns false for those.

This fixes that so we now detect the PowerShell MSIX installation properly again.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
