### PR TITLE
Update examples-module to use Pester 5

### DIFF
--- a/examples/Tests/PathProcessing.Tests.ps1
+++ b/examples/Tests/PathProcessing.Tests.ps1
@@ -8,102 +8,105 @@
 # test task runner defined in .vscode\tasks.json.
 
 # This (empty) file is required by some of the tests.
-$null = New-Item -Path "$PSScriptRoot\foo[1].txt" -Force
 
-Import-Module $PSScriptRoot\..\SampleModule.psd1
+BeforeAll {
+    $null = New-Item -Path "$PSScriptRoot\foo[1].txt" -Force
 
-$WorkspaceRoot = Convert-Path $PSScriptRoot/..
-Set-Location $WorkspaceRoot
+    Import-Module $PSScriptRoot\..\SampleModule.psd1
+    
+    $WorkspaceRoot = Convert-Path $PSScriptRoot/..
+    Set-Location $WorkspaceRoot
+}
 
 Describe 'Verify Path Processing for Non-existing Paths Allowed Impl' {
     It 'Processes non-wildcard absolute path to non-existing file via -Path param' {
-        New-File -Path $WorkspaceRoot\ReadmeNew.md | Should Be "$WorkspaceRoot\READMENew.md"
+        New-File -Path $WorkspaceRoot\ReadmeNew.md | Should -Be "$WorkspaceRoot\READMENew.md"
     }
     It 'Processes multiple absolute paths via -Path param' {
         New-File -Path $WorkspaceRoot\Readme.md, $WorkspaceRoot\XYZZY.ps1 |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\XYZZY.ps1")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\XYZZY.ps1")
     }
     It 'Processes relative path via -Path param' {
-        New-File -Path ..\Examples\READMENew.md | Should Be "$WorkspaceRoot\READMENew.md"
+        New-File -Path ..\Examples\READMENew.md | Should -Be "$WorkspaceRoot\READMENew.md"
     }
     It 'Processes multiple relative path via -Path param' {
         New-File -Path ..\Examples\README.md, XYZZY.ps1 |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\XYZZY.ps1")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\XYZZY.ps1")
     }
 
     It 'Should accept pipeline input to Path' {
-        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | New-File | Should Be "$PSScriptRoot\foo[1].txt"
+        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | New-File | Should -Be "$PSScriptRoot\foo[1].txt"
     }
 }
 
 Describe 'Verify Path Processing for NO Wildcards Allowed Impl' {
     It 'Processes non-wildcard absolute path via -Path param' {
-        Import-FileNoWildcard -Path $WorkspaceRoot\Readme.md | Should Be "$WorkspaceRoot\README.md"
+        Import-FileNoWildcard -Path $WorkspaceRoot\Readme.md | Should -Be "$WorkspaceRoot\README.md"
     }
     It 'Processes multiple absolute paths via -Path param' {
         Import-FileNoWildcard -Path $WorkspaceRoot\Readme.md, $WorkspaceRoot\PathProcessingWildcards.ps1 |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\PathProcessingWildcards.ps1")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\PathProcessingWildcards.ps1")
     }
     It 'Processes relative path via -Path param' {
-        Import-FileNoWildcard -Path ..\examples\README.md | Should Be "$WorkspaceRoot\README.md"
+        Import-FileNoWildcard -Path ..\examples\README.md | Should -Be "$WorkspaceRoot\README.md"
     }
     It 'Processes multiple relative path via -Path param' {
         Import-FileNoWildcard -Path ..\examples\README.md, .vscode\launch.json |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\.vscode\launch.json")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\.vscode\launch.json")
     }
 
     It 'Should accept pipeline input to Path' {
-        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | Import-FileNoWildcard | Should Be "$PSScriptRoot\foo[1].txt"
+        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | Import-FileNoWildcard | Should -Be "$PSScriptRoot\foo[1].txt"
     }
 }
 
 Describe 'Verify Path Processing for Wildcards Allowed Impl' {
     It 'Processes non-wildcard absolute path via -Path param' {
-        Import-FileWildcard -Path $WorkspaceRoot\Readme.md | Should Be "$WorkspaceRoot\README.md"
+        Import-FileWildcard -Path $WorkspaceRoot\Readme.md | Should -Be "$WorkspaceRoot\README.md"
     }
     It 'Processes multiple absolute paths via -Path param' {
         Import-FileWildcard -Path $WorkspaceRoot\Readme.md, $WorkspaceRoot\PathProcessingWildcards.ps1 |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\PathProcessingWildcards.ps1")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\PathProcessingWildcards.ps1")
     }
     It 'Processes wildcard absolute path via -Path param' {
         $files = Import-FileWildcard -Path $WorkspaceRoot\*.psd1
-        $files.Count | Should Be 2
-        $files[0] | Should Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
-        $files[1] | Should Be "$WorkspaceRoot\SampleModule.psd1"
+        $files.Count | Should -Be 2
+        $files[0] | Should -Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
+        $files[1] | Should -Be "$WorkspaceRoot\SampleModule.psd1"
     }
     It 'Processes wildcard relative path via -Path param' {
         $files = Import-FileWildcard -Path *.psd1
-        $files.Count | Should Be 2
-        $files[0] | Should Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
-        $files[1] | Should Be "$WorkspaceRoot\SampleModule.psd1"
+        $files.Count | Should -Be 2
+        $files[0] | Should -Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
+        $files[1] | Should -Be "$WorkspaceRoot\SampleModule.psd1"
     }
     It 'Processes relative path via -Path param' {
-        Import-FileWildcard -Path ..\examples\README.md | Should Be "$WorkspaceRoot\README.md"
+        Import-FileWildcard -Path ..\examples\README.md | Should -Be "$WorkspaceRoot\README.md"
     }
     It 'Processes multiple relative path via -Path param' {
         Import-FileWildcard -Path ..\examples\README.md, .vscode\launch.json |
-            Should Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\.vscode\launch.json")
+            Should -Be @("$WorkspaceRoot\README.md", "$WorkspaceRoot\.vscode\launch.json")
     }
 
-    It 'DefaultParameterSet should be Path' {
+    It 'DefaultParameterSet should -be Path' {
         $files = Import-FileWildcard *.psd1
-        $files.Count | Should Be 2
-        $files[0] | Should Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
-        $files[1] | Should Be "$WorkspaceRoot\SampleModule.psd1"
+        $files.Count | Should -Be 2
+        $files[0] | Should -Be "$WorkspaceRoot\PSScriptAnalyzerSettings.psd1"
+        $files[1] | Should -Be "$WorkspaceRoot\SampleModule.psd1"
     }
 
     It 'Should process absolute literal paths via -LiteralPath param'{
-        Import-FileWildcard -LiteralPath "$PSScriptRoot\foo[1].txt" | Should Be "$PSScriptRoot\foo[1].txt"
+        Import-FileWildcard -LiteralPath "$PSScriptRoot\foo[1].txt" | Should -Be "$PSScriptRoot\foo[1].txt"
     }
     It 'Should process relative literal paths via -LiteralPath param'{
-        Import-FileWildcard -LiteralPath "..\examples\Tests\foo[1].txt" | Should Be "$PSScriptRoot\foo[1].txt"
+        Import-FileWildcard -LiteralPath "..\examples\Tests\foo[1].txt" | Should -Be "$PSScriptRoot\foo[1].txt"
     }
     It 'Should process multiple literal paths via -LiteralPath param'{
         Import-FileWildcard -LiteralPath "..\examples\Tests\foo[1].txt", "$WorkspaceRoot\README.md" |
-            Should Be @("$PSScriptRoot\foo[1].txt", "$WorkspaceRoot\README.md")
+            Should -Be @("$PSScriptRoot\foo[1].txt", "$WorkspaceRoot\README.md")
     }
 
     It 'Should accept pipeline input to LiteralPath' {
-        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | Import-FileWildcard | Should Be "$PSScriptRoot\foo[1].txt"
+        Get-ChildItem -LiteralPath "$WorkspaceRoot\Tests\foo[1].txt" | Import-FileWildcard | Should -Be "$PSScriptRoot\foo[1].txt"
     }
 }

--- a/examples/Tests/SampleModule.Tests.ps1
+++ b/examples/Tests/SampleModule.Tests.ps1
@@ -1,9 +1,10 @@
-$ModuleManifestName = 'SampleModule.psd1'
-Import-Module $PSScriptRoot\..\$ModuleManifestName
-
+BeforeAll {
+    $ModuleManifestName = 'SampleModule.psd1'
+    Import-Module $PSScriptRoot\..\$ModuleManifestName
+}
 Describe 'Module Manifest Tests' {
     It 'Passes Test-ModuleManifest' {
         Test-ModuleManifest -Path $PSScriptRoot\..\$ModuleManifestName
-        $? | Should Be $true
+        $? | Should -Be $true
     }
 }


### PR DESCRIPTION
This resolves #3049. Only real changes needed were wrapping the initialization in a `BeforeAll` block and changing `Be` to `-Be`. 