### PR TITLE
Update download host of vscode

### DIFF
--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -375,7 +375,7 @@ function Get-CodePlatformInformation {
         ExePath = $exePath
         Platform = $platform
         Channel = $channel
-        FileUri = "https://vscode-update.azurewebsites.net/latest/$platform/$channel"
+        FileUri = "https://update.code.visualstudio.com/latest/$platform/$channel"
         Extension = $ext
     }
 


### PR DESCRIPTION
## PR Summary
Host for vscode downloads has changed from  `https://vscode-update.azurewebsites.net/` to `https://update.code.visualstudio.com/`, therefore the install script has been adjusted.

Installation worked afterwards fine.
<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests **NA?**
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
