### PR TITLE
Fix triggers for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,17 @@ name: "Code scanning - action"
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - v*
   pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
   schedule:
-    - cron: '0 19 * * 0'
+    - cron: '00 14 * * *' # Every morning at 7:00am PDT
 
 jobs:
   CodeQL-Build:
@@ -25,7 +33,7 @@ jobs:
     # the head of the pull request instead of the merge commit.
     - run: git checkout HEAD^2
       if: ${{ github.event_name == 'pull_request' }}
-      
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1


### PR DESCRIPTION
The push event should only be registered for the master branch and for tags. It was erroneously running on every branch, breaking Dependabot.  For PRs we exclude documentation changes only. The schedule was set to run once a week, but we may as well run every morning.

Resolves #3316.