### PR TITLE
Remove "All Rights Reserved" from copyright notices

### DIFF
--- a/examples/SampleModule.psd1
+++ b/examples/SampleModule.psd1
@@ -41,7 +41,7 @@ Author = '<name>'
 CompanyName = 'Unknown'
 
 # Copyright statement for this module
-Copyright = '(c) 2016 <name>. All rights reserved.'
+Copyright = '(c) 2021 <name>.'
 
 # Description of the functionality provided by this module
 Description = 'Some description.  This is required by the PowerShell Gallery'

--- a/src/controls/animatedStatusBar.ts
+++ b/src/controls/animatedStatusBar.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import {
     Disposable,

--- a/src/controls/checkboxQuickPick.ts
+++ b/src/controls/checkboxQuickPick.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import { connect, Socket } from "net";
 import { DebugAdapter, Event, DebugProtocolMessage, EventEmitter } from "vscode";

--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import Window = vscode.window;

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import { NotificationType, RequestType } from "vscode-languageclient";

--- a/src/features/CustomViews.ts
+++ b/src/features/CustomViews.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as path from "path";
 import * as vscode from "vscode";

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import { CancellationToken, DebugConfiguration, DebugConfigurationProvider,

--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import path = require("path");
 import vscode = require("vscode");

--- a/src/features/ExpandAlias.ts
+++ b/src/features/ExpandAlias.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import Window = vscode.window;

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as fs from "fs";
 import * as os from "os";

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -1,6 +1,6 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as vscode from "vscode";
 import { v4 as uuidv4 } from 'uuid';
 import { LanguageClientConsumer } from "../languageClientConsumer";

--- a/src/features/FindModule.ts
+++ b/src/features/FindModule.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import { RequestType } from "vscode-languageclient";

--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import os = require("os");
 import vscode = require("vscode");

--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -1,6 +1,6 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as vscode from "vscode";
 import { RequestType0 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import { Disposable, EndOfLine, Position, Range, SnippetString,
     TextDocument, TextDocumentChangeEvent, window, workspace } from "vscode";

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -1,6 +1,6 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as vscode from "vscode";
 import * as Settings from "../settings";
 

--- a/src/features/NewFileOrProject.ts
+++ b/src/features/NewFileOrProject.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import { RequestType } from "vscode-languageclient";

--- a/src/features/OpenInISE.ts
+++ b/src/features/OpenInISE.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import ChildProcess = require("child_process");
 import vscode = require("vscode");

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as path from "path";
 import vscode = require("vscode");

--- a/src/features/RemoteFiles.ts
+++ b/src/features/RemoteFiles.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import os = require("os");
 import path = require("path");

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as path from "path";
 import vscode = require("vscode");

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import vscode = require("vscode");
 import { NotificationType } from "vscode-languageclient";

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import { spawn } from "child_process";
 import * as fs from "fs";

--- a/src/languageClientConsumer.ts
+++ b/src/languageClientConsumer.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import { window } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import fs = require("fs");
 import os = require("os");

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 "use strict";
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as child_process from "child_process";
 import * as fs from "fs";

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import cp = require("child_process");
 import fs = require("fs");

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import fs = require("fs");
 import net = require("net");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 "use strict";
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 "use strict";
 

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as assert from "assert";
 import fs = require("fs");

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -1,6 +1,6 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { before, beforeEach, afterEach } from "mocha";

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -1,6 +1,6 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as assert from "assert";
 import rewire = require("rewire");

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as assert from "assert";
 import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as assert from "assert";
 import mockFS = require("mock-fs");

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as path from "path";
 

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as assert from "assert";
 import * as vscode from "vscode";

--- a/test/testRunner.ts
+++ b/test/testRunner.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import * as glob from "glob";
 import * as Mocha from "mocha";

--- a/test/test_utils.ts
+++ b/test/test_utils.ts
@@ -1,6 +1,5 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 import { ILogger } from "../src/logging";
 

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,13 @@
         "indent": [true, "spaces", 4],
         "max-classes-per-file": false,
         "object-literal-sort-keys": false,
-        "file-header": [true, "Copyright \\(C\\) Microsoft Corporation. All rights reserved."]
+        "file-header": [
+          true,
+          {
+            "allow-single-line-comments": true,
+            "match": "Copyright \\(c\\) Microsoft Corporation."
+          }
+        ]
     },
     "rulesDirectory": []
 }


### PR DESCRIPTION
Per Microsoft policy at:
https://docs.opensource.microsoft.com/content/releasing/copyright-headers.html

All copyright notices no longer include "All Rights Reserved" and the comment style has been updated to be consistent with policy.

Resolves #2896

Also double-checked that all `*.ts` files have a copyright notice.