### PR TITLE
Update troubleshooting and contacts

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Editor Syntax Colorization bug report 🌈
-    url:  https://github.com/PowerShell/EditorSyntax/issues/new
-    about: Editor syntax colorization bugs are tracked in a separate GitHub repo.
-  - name: Script analysis or formatting bug report 🚦🖌️
-    url: https://github.com/PowerShell/PSScriptAnalyzer/issues/new/choose
-    about: Script analysis and formatting are provided by PSScriptAnalyzer. Before submitting an issue, check to see whether the issue lies with PSScriptAnalyzer or with the VSCode PowerShell extension.
-  - name: General question?
-    url: https://aka.ms/psdiscord
-    about: "You can also ask general Visual Studio Code questions in the #vscode channel of the PowerShell community Discord. Slack is also available at https://aka.ms/psslack"
+  - name: 🙋 Ask a question
+    url: https://aka.ms/powershell-vscode-discord
+    about: "Find us in #vscode on the PowerShell Community Discord"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://dev.azure.com/powershell/vscode-powershell/_apis/build/status/PowerShell.vscode-powershell?branchName=master)](https://dev.azure.com/powershell/vscode-powershell/_build/latest?definitionId=51&branchName=master)
 [![Version](https://vsmarketplacebadge.apphb.com/version/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
-[![Discord](https://img.shields.io/discord/180528040881815552.svg?label=%23vscode&logo=discord&logoColor=white)](https://aka.ms/psdiscord)
+[![Discord](https://img.shields.io/discord/180528040881815552.svg?label=%23vscode&logo=discord&logoColor=white)](https://aka.ms/powershell-vscode-discord)
 [![Join the chat at https://gitter.im/PowerShell/vscode-powershell](https://badges.gitter.im/PowerShell/vscode-powershell.svg)](https://gitter.im/PowerShell/vscode-powershell?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This extension provides rich PowerShell language support for [Visual Studio Code](https://github.com/Microsoft/vscode).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,6 +16,20 @@ Instead syntax highlighting for VSCode, Atom, SublimeText and even GitHub is
 provided by the [Editor Syntax] repository on GitHub. Please open any
 [syntax highlighting issues there].
 
+However, with the introduction of [Semantic Highlighting] in [v2021.2.2], the
+chosen colors may be different because this is applied at a layer above [Editor
+Syntax]. To disable semantic highlighting and so restore the colors as they
+were, set:
+
+```json
+"[powershell]": {
+    "editor.semanticHighlighting.enabled": false
+}
+```
+
+If you leave it enabled, you can customize the colors used for the various
+tokens. See [#3221] for more info and to leave suggestions.
+
 ## VSCode is not working like the ISE
 
 The PowerShell extension does not aim to perfectly recreate
@@ -30,7 +44,6 @@ Bear in mind that many of the UI/UX aspects of VSCode are driven by
 VSCode itself and can't be changed by the extension.
 The VSCode maintainers are quite reasonable though,
 and you can ask for new features [in their repository](https://github.com/Microsoft/vscode).
-
 
 ## Known Issues in the Extension
 
@@ -47,7 +60,7 @@ and you can ask for new features [in their repository](https://github.com/Micros
     Please give the privilege management software feedback.
     For some,
     [updating to the latest version has fixed the issue](https://github.com/PowerShell/vscode-powershell/issues/2526#issuecomment-638329157).
-- Intellisense is slow
+- IntelliSense is slow
   - This is a known issue that we've been chipping away at. There doesn't seem
     to be any one performance drain, but we've been trying to incrementally
     improve performance bit-by-bit everywhere. Currently we are focusing on [this issue](https://github.com/PowerShell/PowerShellEditorServices/issues/1295).
@@ -332,7 +345,9 @@ an issue on GitHub is appropriate.
 [open an issue on us on GitHub]: https://github.com/PowerShell/vscode-powershell/issues/new/choose
 [Reporting Problems]: ../README.md#reporting-problems
 [syntax highlighting issues there]: https://github.com/PowerShell/EditorSyntax/issues/new
-[tackling an issue]:./development.md
+[semantic highlighting]: https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide
+[tackling an issue]: ./development.md
+[v2021.2.2]: https://github.com/PowerShell/vscode-powershell/releases/tag/v2021.2.2
 [VSCode issue]: https://github.com/Microsoft/vscode/issues/42356
 [VSCode Settings]: https://code.visualstudio.com/docs/getstarted/settings
 [will break this compatibility]: https://github.com/PowerShell/vscode-powershell/issues/1310
@@ -350,3 +365,4 @@ an issue on GitHub is appropriate.
 [#550]: https://github.com/PowerShell/vscode-powershell/issues/550
 [#647]: https://github.com/PowerShell/vscode-powershell/issues/647
 [#984]: https://github.com/PowerShell/vscode-powershell/issues/984
+[#3221]: https://github.com/PowerShell/vscode-powershell/issues/3221#issuecomment-810563456


### PR DESCRIPTION
I created an `aka.ms` link to a Discord invite to the #vscode channel under our ownership and updated our links. Because semantic highlighting now exists on top of editor syntax, I removed that from the contact links and instead updated the troubleshooting document to reflect that. I pulled these changes out of #3332 (where the new bug report issue form will directly link to and ask folks to review the troubleshooting guide).