### PR TITLE
Exclude `-` and `$` from PowerShell `wordSeparators`

### DIFF
--- a/package.json
+++ b/package.json
@@ -895,6 +895,11 @@
         }
       }
     },
+    "configurationDefaults": {
+      "[powershell]": {
+        "editor.wordSeparators": "`~!@#%^&*()=+[{]}\\|;:'\",.<>/?"
+      }
+    },
     "themes": [
       {
         "label": "PowerShell ISE",


### PR DESCRIPTION
This is only a supplied default, so users can easily override it.

This suggestion came from a "Getting Started with VS Code for PowerShell" presentation by @FriedrichWeinmann, thanks!