### PR TITLE
Fix another bug in `ReleaseTools`

### DIFF
--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -125,10 +125,12 @@ function Get-FirstChangelog {
         [string]$RepositoryName
     )
     $Changelog = Get-Content -Path "$PSScriptRoot/../../$RepositoryName/$ChangelogFile"
+    # NOTE: The space after the header marker is important! Otherwise ### matches.
+    $Header = $Changelog.Where({$_.StartsWith("## ")}, "First")
     $Changelog.Where(
-        { $_.StartsWith("##") }, "SkipUntil"
+        { $_ -eq $Header }, "SkipUntil"
     ).Where(
-        { $_.StartsWith("##") }, "Until"
+        { $_.StartsWith("## ") -and $_ -ne $Header }, "Until"
     )
 }
 
@@ -355,5 +357,3 @@ function New-DraftRelease {
     Get-GitHubRepository -OwnerName PowerShell -RepositoryName $RepositoryName |
         New-GitHubRelease @ReleaseParams
 }
-
-Export-ModuleMember -Function Update-Changelog, Update-Version, New-DraftRelease

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -137,41 +137,6 @@ task UpdateReadme -If { $script:IsPreviewExtension } {
     }
 }
 
-task UpdatePackageJson {
-    if ($script:IsPreviewExtension) {
-        $script:PackageJson.name = "powershell-preview"
-        $script:PackageJson.displayName = "PowerShell Preview"
-        $script:PackageJson.description = "(Preview) Develop PowerShell modules, commands and scripts in Visual Studio Code!"
-        $script:PackageJson.preview = $true
-    } else {
-        $script:PackageJson.name = "powershell"
-        $script:PackageJson.displayName = "PowerShell"
-        $script:PackageJson.description = "Develop PowerShell modules, commands and scripts in Visual Studio Code!"
-        $script:PackageJson.preview = $false
-    }
-
-    $currentVersion = [version](($script:PackageJson.version -split "-")[0])
-    $currentDate = Get-Date
-
-    $revision = if ($currentDate.Month -eq $currentVersion.Minor) {
-        $currentVersion.Build + 1
-    } else {
-        0
-    }
-
-    $script:PackageJson.version = "$($currentDate.ToString('yyyy.M')).$revision"
-
-    if ($env:TF_BUILD) {
-        $script:PackageJson.version += "-CI.$env:BUILD_BUILDID"
-    }
-
-    $Utf8NoBomEncoding = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::WriteAllLines(
-        (Resolve-Path "$PSScriptRoot/package.json").Path,
-        ($script:PackageJson | ConvertTo-Json -Depth 100),
-        $Utf8NoBomEncoding)
-}
-
 task Package UpdateReadme, {
     if ($script:psesBuildScriptPath -or $env:TF_BUILD) {
         Write-Host "`n### Copying PowerShellEditorServices module files" -ForegroundColor Green
@@ -197,4 +162,4 @@ task Package UpdateReadme, {
 # The set of tasks for a release
 task Release Clean, Build, Package
 # The default task is to run the entire CI build
-task . CleanAll, BuildAll, Test, UpdatePackageJson, Package, UploadArtifacts
+task . CleanAll, BuildAll, Test, Package, UploadArtifacts


### PR DESCRIPTION
The typo we fixed in review actually broke it (because it was already misbehaving, but in a working way). Also stop exporting functions.