### PR TITLE
Change OS-architecture check to work with other locales

### DIFF
--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -170,7 +170,7 @@ gpgkey=https://packages.microsoft.com/keys/microsoft.asc
 
 function Test-IsOsArchX64 {
     if ($PSVersionTable.PSVersion.Major -lt 6) {
-        return (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture -eq '64-bit'
+        return (Get-CimInstance -ClassName Win32_OperatingSystem).OSArchitecture -match '64'
     }
 
     return [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq [System.Runtime.InteropServices.Architecture]::X64


### PR DESCRIPTION
Fixes  #3390

## PR Summary

Matching was done with literal equality check: `-eq '64-bit'`. This has been changed to Regex: `-match '64'`. This so it won't matter what the language of the OS is. For example this will match '64-bittinen', '64-bëssen'

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
