### PR TITLE
Explicitly disable extension for untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -895,6 +895,11 @@
         }
       }
     },
+    "capabilities": {
+      "untrustedWorkspaces": {
+        "supported": false
+      }
+    },
     "configurationDefaults": {
       "[powershell]": {
         "debug.saveBeforeStart": "nonUntitledEditorsInActiveGroup",


### PR DESCRIPTION
This extension can read and execute code from a workspace folder, therefore it
is a potential security risk to run the extension in an untrusted workspace.
Until we can put more effort into partial support of safe features, we will
explicitly disable this extension when the workspace is untrusted.

Resolves #3334.