### PR TITLE
Automate more of the release

### DIFF
--- a/.vsts-ci/azure-pipelines-release.yml
+++ b/.vsts-ci/azure-pipelines-release.yml
@@ -31,8 +31,8 @@ jobs:
 - job: 'ReleaseBuild'
   displayName: 'Build release'
   pool:
-    name: 'Package ES Standard Build'
-    demands: DotNetFramework
+    name: '1ES'
+    demands: ImageOverride -equals MMS2019
   variables:
   - group: ESRP
   steps:

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,10 +68,6 @@ Import-Module ./tools/ReleaseTools.psm1
 Update-Changelog -RepositoryName PowerShellEditorServices -Version <version>
 Update-Changelog -RepositoryName vscode-powershell -Version <version>
 # Amend changelog as necessary
-Update-Version -RepositoryName PowerShellEditorServices
-Update-Version -RepositoryName vscode-powershell
-# Push branches to GitHub and ADO
-# Open PRs for review
 # Download and test assets (assert correct PSES is included)
 New-DraftRelease -RepositoryName PowerShellEditorServices -Assets "PowerShellEditorServices.zip"
 New-DraftRelease -RepositoryName vscode-powershell -Assets "powershell-YYYY.M.X.vsix", "Install-VSCode.ps1"
@@ -134,5 +130,4 @@ use the same code which includes dependencies).
 
 * `Update-Changelog` should verify the version is in the correct format
 * `Update-Changelog` could be faster by not downloading _every_ PR
-* `Update-Version` could be run by `Update-Changelog`
 * A `Publish-Binaries` function could be written to push the binaries out

--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,7 @@ For PowerShellEditor Services, we simply follow semantic versioning, e.g.
 generally used directly: it's a library consumed by other projects which
 themselves use preview releases for beta testing.
 
-For the VS Code PowerShell Extension, our version follows `vYYYY.MM.X`, that is:
+For the VS Code PowerShell Extension, our version follows `vYYYY.M.X`, that is:
 current year, current month, and patch version (not day). This is not semantic
 versioning because of issues with how the VS Code marketplace and extension
 hosting API itself uses our version number. This scheme _does not_ mean we
@@ -137,7 +137,5 @@ use the same code which includes dependencies).
 
 * `Update-Changelog` should verify the version is in the correct format
 * `Update-Changelog` could be faster by not downloading _every_ PR
-* `Update-Changelog` should use exactly two emoji and in the right order
 * `Update-Version` could be run by `Update-Changelog`
-* The build should emit an appropriately named VSIX instead of us manually renaming it
 * A `Publish-Binaries` function could be written to push the binaries out

--- a/docs/development.md
+++ b/docs/development.md
@@ -73,13 +73,10 @@ Update-Version -RepositoryName vscode-powershell
 # Push branches to GitHub and ADO
 # Open PRs for review
 # Download and test assets (assert correct PSES is included)
-New-DraftRelease -RepositoryName PowerShellEditorServices
-New-DraftRelease -RepositoryName vscode-powershell
-# Point releases to branches for automatic tagging
-# Upload PowerShellEditorServices.zip (for other extensions)
-# Upload VSIX and Install-VSCode.ps1
-# Publish draft releases and merge (don't squash!) branches
+New-DraftRelease -RepositoryName PowerShellEditorServices -Assets "PowerShellEditorServices.zip"
+New-DraftRelease -RepositoryName vscode-powershell -Assets "powershell-YYYY.M.X.vsix", "Install-VSCode.ps1"
 # Check telemetry for stability before releasing
+# Publish draft releases and merge (don't squash!) branches
 vsce publish --packagePath ./PowerShell-<version>.vsix
 # Update Install-VSCode.ps1 on gallery
 Publish-Script -Path ./Install-VSCode.ps1 -NuGetApiKey (Get-Secret "PowerShell Gallery API Key" -AsPlainText)

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -37,10 +37,13 @@ function Get-Bullets {
             'TylerLeonhardt'
         )
 
-        $LabelEmoji = @{
+        $IssueEmojis = @{
             'Issue-Enhancement'         = '✨'
             'Issue-Bug'                 = '🐛'
             'Issue-Performance'         = '⚡️'
+        }
+
+        $AreaEmojis = @{
             'Area-Build & Release'      = '👷'
             'Area-Code Formatting'      = '💎'
             'Area-Configuration'        = '🔧'
@@ -81,12 +84,9 @@ function Get-Bullets {
     process {
         $PullRequests | ForEach-Object {
             # Map all the labels to emoji (or use a default).
-            # NOTE: Whitespacing here is weird.
-            $emoji = if ($_.labels) {
-                $LabelEmoji[$_.labels.LabelName] -join ""
-            } else {
-                '#️⃣ 🙏'
-            }
+            $labels = if ($_.labels) { $_.labels.LabelName } else { "" }
+            $issueEmoji = $IssueEmojis[$labels] + "#️⃣" | Select-Object -First 1
+            $areaEmoji = $AreaEmojis[$labels] + "🙏" | Select-Object -First 1
 
             # Get a linked issue number if it exists (or use the PR).
             $link = if ($_.body -match $IssueRegex) {
@@ -105,7 +105,7 @@ function Get-Bullets {
             }
 
             # Put the bullet point together.
-            ("-", $emoji, "[$link]($($_.html_url))", "-", "$($_.title).", $thanks -join " ").Trim()
+            ("-", $issueEmoji, $areaEmoji, "[$link]($($_.html_url))", "-", "$($_.title).", $thanks -join " ").Trim()
         }
     }
 }
@@ -250,18 +250,18 @@ function Update-Changelog {
 .DESCRIPTION
   Note that our Git tags and changelog prefix all versions with `v`.
 
-  PowerShellEditorServices: version is `x.y.z-preview.d`
+  PowerShellEditorServices: version is `X.Y.Z-preview`
 
   - PowerShellEditorServices.psd1:
-    - `ModuleVersion` variable with `'x.y.z'` string, no pre-release info
+    - `ModuleVersion` variable with `'X.Y.Z'` string, no pre-release info
   - PowerShellEditorServices.Common.props:
-    - `VersionPrefix` field with `x.y.z`
+    - `VersionPrefix` field with `X.Y.Z`
     - `VersionSuffix` field with pre-release portion excluding hyphen
 
-  vscode-powershell: version is `yyyy.mm.x-preview`
+  vscode-powershell: version is `YYYY.M.X-preview`
 
   - package.json:
-    - `version` field with `"x.y.z"` and no prefix or suffix
+    - `version` field with `"X.Y.Z"` and no prefix or suffix
     - `preview` field set to `true` or `false` if version is a preview
     - `name` field has `-preview` appended similarly
     - `displayName` field has ` Preview` appended similarly

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -344,7 +344,7 @@ function New-DraftRelease {
         [ValidateSet([RepoNames])]
         [string]$RepositoryName,
 
-        [Parameter(ValueFromPipeline)]
+        [Parameter()]
         [string[]]$Assets
     )
     $Version = Get-Version -RepositoryName $RepositoryName
@@ -362,5 +362,7 @@ function New-DraftRelease {
     }
 
     $Release = New-GitHubRelease @ReleaseParams
+    Write-Output "Draft release URL: $($Release.html_url)"
+    Write-Output "Uploading assets..."
     $Assets | New-GitHubReleaseAsset -Release $Release.Id
 }


### PR DESCRIPTION
This makes the `ReleaseTools` module almost entirely automated, which sets us up for modifying our release pipelines to create the GitHub releases and upload the assets/binaries directly.