### PR TITLE
(#3499) Remove msjsdiag.debugger-for-chrome suggestion

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "editorconfig.editorconfig",
-    "msjsdiag.debugger-for-chrome",
     "ms-azure-devops.azure-pipelines",
     "ms-vscode.powershell",
     "ms-vscode.vscode-typescript-tslint-plugin",


### PR DESCRIPTION
## PR Summary

Remove extension `msjsdiag.debugger-for-chrome` suggestion from the vscode
extensions suggestions.

This extension has been deprecated as vscode includes native javascript
debugging.

Fixes #3499 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
