### PR TITLE
Allow PowerShell session to start and stop the debugger interface

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,21 +17,6 @@
       "preLaunchTask": "Build"
     },
     {
-      "name": "Launch Extension (Build client only)",
-      "type": "extensionHost",
-      "request": "launch",
-      "runtimeExecutable": "${execPath}",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
-      ],
-      "stopOnEntry": false,
-      "sourceMaps": true,
-      "outFiles": [
-        "${workspaceFolder}/out/src/**/*.js"
-      ],
-      "preLaunchTask": "Build"
-    },
-    {
       "name": "Launch Extension Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -40,28 +40,33 @@
       "label": "Restore",
       "type": "shell",
       "command": "Invoke-Build Restore",
+      "problemMatcher": []
     },
     {
       "label": "Clean",
       "type": "shell",
       "command": "Invoke-Build Clean",
+      "problemMatcher": []
     },
     {
       "label": "Build",
       "type": "shell",
       "command": "Invoke-Build Build",
-      "group": "build",
+      "problemMatcher": [],
+      "group": "build"
     },
     {
       "label": "Test",
       "type": "shell",
       "command": "Invoke-Build Test",
-      "group": "test",
+      "problemMatcher": [],
+      "group": "test"
     },
     {
       "label": "Package",
       "type": "shell",
       "command": "Invoke-Build Package",
+      "problemMatcher": [],
       "group": "build"
     }
   ]

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -18,6 +18,9 @@ import { LanguageClientConsumer } from "../languageClientConsumer";
 export const StartDebuggerNotificationType =
     new NotificationType<void>("powerShell/startDebugger");
 
+export const StopDebuggerNotificationType =
+    new NotificationType<void>("powerShell/stopDebugger");
+
 export class DebugSessionFeature extends LanguageClientConsumer
     implements DebugConfigurationProvider, vscode.DebugAdapterDescriptorFactory {
 
@@ -61,6 +64,12 @@ export class DebugSessionFeature extends LanguageClientConsumer
                     type: "PowerShell",
                     name: "PowerShell Interactive Session",
         }));
+
+        languageClient.onNotification(
+            StopDebuggerNotificationType,
+            () =>
+                vscode.debug.stopDebugging(undefined)
+        );
     }
 
     public async provideDebugConfigurations(


### PR DESCRIPTION
Used to indicate the PowerShell debugger has stopped and so the connected debugger interface in the extension should also stop (as in detach and quit, not break). Along with https://github.com/PowerShell/PowerShellEditorServices/pull/1570, resolves #3522.