### PR TITLE
Document the trace server setting is valid (despite Code's warning)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -263,6 +263,8 @@ In some cases, getting to the bottom of a bug will require looking at the payloa
   ```json
   "powershell editor services.trace.server":"verbose"
   ```
+  
+> NOTE: While VSCode will not recognize and highlight it, it is a valid option and enables tracer logs on the server.
 
 - Restart Visual Studio Code and reproduce the issue.
 


### PR DESCRIPTION
## PR Summary

I propose this additional note as VSCode does not recognize the `"powershell editor services.trace.server":"verbose"` setting. The result is: `Unknown Configuration Setting`, which leads to unnecessary consternation.

https://github.com/PowerShell/vscode-powershell/issues/3543#issuecomment-912820273

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests `NA`
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
