### PR TITLE
Fix `ReleaseTools` issue matcher regex

### DIFF
--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -108,7 +108,9 @@ function Get-Bullets {
             'resolved'
         )
 
-        $IssueRegex = '(' + ($CloseKeywords -join '|') + ')\s+(?<repo>\D+)(?<number>\d+)'
+        # NOTE: The URL matcher must be explicit because the body of a PR may
+        # contain other URLs with digits (like an image asset).
+        $IssueRegex = '(' + ($CloseKeywords -join '|') + ')\s+((https://github.com/PowerShell/(?<repo>(' + ([RepoNames]::Values -join '|') + '))/issues/)|#)(?<number>\d+)'
     }
 
     process {


### PR DESCRIPTION
The simpler "anything but a digit" logic failed on an edge case with a recent PR that had another URL with digits in it after the word "Fix" so we had to make this more explicit.