### PR TITLE
Remove accidentally enabled commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,6 @@
     "onCommand:PowerShell.RestartSession",
     "onCommand:PowerShell.EnableISEMode",
     "onCommand:PowerShell.DisableISEMode",
-    "onCommand:PowerShell.RegisterExternalExtension",
-    "onCommand:PowerShell.UnregisterExternalExtension",
-    "onCommand:PowerShell.GetPowerShellVersionDetails",
     "onView:PowerShellCommands"
   ],
   "dependencies": {
@@ -300,21 +297,6 @@
           "light": "media/resources/light/MovePanelBottom.svg",
           "dark": "media/resources/dark/MovePanelBottom.svg"
         }
-      },
-      {
-        "command": "PowerShell.RegisterExternalExtension",
-        "title": "Register an external extension",
-        "category": "PowerShell"
-      },
-      {
-        "command": "PowerShell.UnregisterExternalExtension",
-        "title": "Unregister an external extension",
-        "category": "PowerShell"
-      },
-      {
-        "command": "PowerShell.GetPowerShellVersionDetails",
-        "title": "Get details about the PowerShell version that the PowerShell extension is using",
-        "category": "PowerShell"
       }
     ],
     "menus": {

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -125,7 +125,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
 
         // TODO: When we have more than one API version, make sure to include a check here.
         const extension = ExternalApiFeature.registeredExternalExtension.get(uuid);
-        this.log.writeDiagnostic(`Extension '${extension.id}' used command 'PowerShell.GetPowerShellVersionDetails'.`);
+        this.log.writeDiagnostic(`Extension '${extension.id}' called 'getPowerShellVersionDetails'`);
 
         await this.sessionManager.waitUntilStarted();
         const versionDetails = this.sessionManager.getPowerShellVersionDetails();


### PR DESCRIPTION
These were apparently an experiment from when the external API was being implemented. They ended up not being used, and are not hooked up to anything. However, they were left exposed to the user, and they fail when ran (of course), so we need to delete them.

Fixes #3105.