### PR TITLE
Fix path regressions and cover with tests

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -46,6 +46,7 @@ steps:
   inputs:
     targetType: inline
     script: |
+      Get-Module -ListAvailable Pester
       Install-Module InvokeBuild -Scope CurrentUser -Force
       Invoke-Build
       Write-Host "##vso[task.setvariable variable=vsixPath]$(Resolve-Path powershell-*.vsix)"

--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -1,25 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as fs from "fs";
 import path = require("path");
+import utils = require("../utils")
 import vscode = require("vscode");
 
 export class ExamplesFeature implements vscode.Disposable {
     private command: vscode.Disposable;
-    private examplesPath: string;
+    private examplesPath: vscode.Uri;
 
     constructor() {
-        this.examplesPath = path.resolve(__dirname, "../examples");
+        this.examplesPath = vscode.Uri.file(path.resolve(__dirname, "../examples"));
         this.command = vscode.commands.registerCommand("PowerShell.OpenExamplesFolder", () => {
-            vscode.commands.executeCommand(
-                "vscode.openFolder",
-                vscode.Uri.file(this.examplesPath),
-                true);
-
+            vscode.commands.executeCommand("vscode.openFolder", this.examplesPath, true);
             // Return existence of the path for testing. The `vscode.openFolder`
             // command should do this, but doesn't (yet).
-            return fs.existsSync(this.examplesPath)
+            return utils.fileExists(this.examplesPath);
         });
     }
 

--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import * as fs from "fs";
 import path = require("path");
 import vscode = require("vscode");
 
@@ -15,6 +16,10 @@ export class ExamplesFeature implements vscode.Disposable {
                 "vscode.openFolder",
                 vscode.Uri.file(this.examplesPath),
                 true);
+
+            // Return existence of the path for testing. The `vscode.openFolder`
+            // command should do this, but doesn't (yet).
+            return fs.existsSync(this.examplesPath)
         });
     }
 

--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -9,7 +9,7 @@ export class ExamplesFeature implements vscode.Disposable {
     private examplesPath: string;
 
     constructor() {
-        this.examplesPath = path.resolve(__dirname, "../../examples");
+        this.examplesPath = path.resolve(__dirname, "../examples");
         this.command = vscode.commands.registerCommand("PowerShell.OpenExamplesFolder", () => {
             vscode.commands.executeCommand(
                 "vscode.openFolder",

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -18,7 +18,7 @@ export class PesterTestsFeature implements vscode.Disposable {
     private invokePesterStubScriptPath: string;
 
     constructor(private sessionManager: SessionManager) {
-        this.invokePesterStubScriptPath = path.resolve(__dirname, "../../modules/PowerShellEditorServices/InvokePesterStub.ps1");
+        this.invokePesterStubScriptPath = path.resolve(__dirname, "../modules/PowerShellEditorServices/InvokePesterStub.ps1");
 
         // File context-menu command - Run Pester Tests
         this.command = vscode.commands.registerCommand(

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import * as path from "path";
-import * as fs from "fs";
 import vscode = require("vscode");
 import { SessionManager } from "../session";
 import Settings = require("../settings");
@@ -144,7 +143,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         //
         // Ensure the necessary script exists (for testing). The debugger will
         // start regardless, but we also pass its success along.
-        return fs.existsSync(this.invokePesterStubScriptPath)
+        return utils.fileExists(this.invokePesterStubScriptPath)
             && vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
     }
 }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as path from "path";
+import * as fs from "fs";
 import vscode = require("vscode");
 import { SessionManager } from "../session";
 import Settings = require("../settings");
@@ -24,19 +25,19 @@ export class PesterTestsFeature implements vscode.Disposable {
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTestsFromFile",
             (fileUri) => {
-                this.launchAllTestsInActiveEditor(LaunchType.Run, fileUri);
+                return this.launchAllTestsInActiveEditor(LaunchType.Run, fileUri);
             });
         // File context-menu command - Debug Pester Tests
         this.command = vscode.commands.registerCommand(
             "PowerShell.DebugPesterTestsFromFile",
             (fileUri) => {
-                this.launchAllTestsInActiveEditor(LaunchType.Debug, fileUri);
+                return this.launchAllTestsInActiveEditor(LaunchType.Debug, fileUri);
             });
         // This command is provided for usage by PowerShellEditorServices (PSES) only
         this.command = vscode.commands.registerCommand(
             "PowerShell.RunPesterTests",
             (uriString, runInDebugger, describeBlockName?, describeBlockLineNumber?, outputPath?) => {
-                this.launchTests(uriString, runInDebugger, describeBlockName, describeBlockLineNumber, outputPath);
+                return this.launchTests(uriString, runInDebugger, describeBlockName, describeBlockLineNumber, outputPath);
             });
     }
 
@@ -44,10 +45,13 @@ export class PesterTestsFeature implements vscode.Disposable {
         this.command.dispose();
     }
 
-    private launchAllTestsInActiveEditor(launchType: LaunchType, fileUri: vscode.Uri) {
+    private async launchAllTestsInActiveEditor(
+        launchType: LaunchType,
+        fileUri: vscode.Uri): Promise<boolean> {
+
         const uriString = (fileUri || vscode.window.activeTextEditor.document.uri).toString();
         const launchConfig = this.createLaunchConfig(uriString, launchType);
-        this.launch(launchConfig);
+        return this.launch(launchConfig);
     }
 
     private async launchTests(
@@ -55,11 +59,11 @@ export class PesterTestsFeature implements vscode.Disposable {
         runInDebugger: boolean,
         describeBlockName?: string,
         describeBlockLineNumber?: number,
-        outputPath?: string) {
+        outputPath?: string): Promise<boolean> {
 
         const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
         const launchConfig = this.createLaunchConfig(uriString, launchType, describeBlockName, describeBlockLineNumber, outputPath);
-        this.launch(launchConfig);
+        return this.launch(launchConfig);
     }
 
     private createLaunchConfig(
@@ -126,9 +130,9 @@ export class PesterTestsFeature implements vscode.Disposable {
         return launchConfig;
     }
 
-    private launch(launchConfig) {
+    private async launch(launchConfig): Promise<boolean> {
         // Create or show the interactive console
-        // TODO #367: Check if "newSession" mode is configured
+        // TODO: #367 Check if "newSession" mode is configured
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
@@ -137,6 +141,10 @@ export class PesterTestsFeature implements vscode.Disposable {
             this.sessionManager.getSessionDetails());
 
         // TODO: Update to handle multiple root workspaces.
-        vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
+        //
+        // Ensure the necessary script exists (for testing). The debugger will
+        // start regardless, but we also pass its success along.
+        return fs.existsSync(this.invokePesterStubScriptPath)
+            && vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -157,6 +157,8 @@ export function load(): ISettings {
 
     const defaultDeveloperSettings: IDeveloperSettings = {
         featureFlags: [],
+        // From `<root>/out/main.js` we go to the directory before <root> and
+        // then into the other repo.
         bundledModulesPath: "../../PowerShellEditorServices/module",
         editorServicesLogLevel: "Normal",
         editorServicesWaitForDebugger: false,
@@ -234,7 +236,7 @@ export function load(): ISettings {
         promptToUpdatePackageManagement:
             configuration.get<boolean>("promptToUpdatePackageManagement", true),
         bundledModulesPath:
-            "../modules",
+            "../modules", // Because the extension is always at `<root>/out/main.js`
         useX86Host:
             configuration.get<boolean>("useX86Host", false),
         enableProfileLoading:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,7 +45,7 @@ export interface IEditorServicesSessionDetails {
 
 export type IReadSessionFileCallback = (details: IEditorServicesSessionDetails) => void;
 
-const sessionsFolder = path.resolve(__dirname, "..", "..", "sessions/");
+const sessionsFolder = path.resolve(__dirname, "../sessions");
 const sessionFilePathPrefix = path.resolve(sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID);
 
 // Create the sessions path if it doesn't exist already

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,12 +6,14 @@
 import fs = require("fs");
 import os = require("os");
 import path = require("path");
+import vscode = require("vscode");
 
 export const PowerShellLanguageId = "powershell";
 
-export function ensurePathExists(targetPath: string) {
+export function ensurePathExists(targetPath: string): void {
     // Ensure that the path exists
     try {
+        // TODO: Use vscode.workspace.fs
         fs.mkdirSync(targetPath);
     } catch (e) {
         // If the exception isn't to indicate that the folder exists already, rethrow it.
@@ -19,6 +21,23 @@ export function ensurePathExists(targetPath: string) {
             throw e;
         }
     }
+}
+
+// Check that the file exists in an asynchronous manner that relies solely on the VS Code API, not Node's fs library.
+export async function fileExists(targetPath: string | vscode.Uri): Promise<boolean> {
+    try {
+            await vscode.workspace.fs.stat(
+                targetPath instanceof vscode.Uri
+                    ? targetPath
+                    : vscode.Uri.file(targetPath));
+        return true;
+    } catch (e) {
+        if (e instanceof vscode.FileSystemError.FileNotFound) {
+            return false;
+        }
+        throw e;
+    }
+
 }
 
 export function getPipePath(pipeName: string) {

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import { before } from "mocha";
+
+// This lets us test the rest of our path assumptions against the baseline of
+// this test file existing at `<root>/out/test/core/paths.test.ts`.
+const rootPath = path.resolve(__dirname, "../../../")
+// tslint:disable-next-line: no-var-requires
+const packageJSON: any = require(path.resolve(rootPath, "package.json"));
+const extensionId = `${packageJSON.publisher}.${packageJSON.name}`;
+
+suite("Path assumptions", () => {
+    before(async () => {
+        const extension = vscode.extensions.getExtension(extensionId);
+        if (!extension.isActive) { await extension.activate(); }
+    });
+
+    test("The examples folder can be opened (and exists)", async () => {
+        assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
+    });
+
+    test("The session folder is created in the right place", async () => {
+        assert(fs.existsSync(path.resolve(rootPath, "sessions")));
+    });
+
+    test("The logs folder is created in the right place", async () => {
+        assert(fs.existsSync(path.resolve(rootPath, "logs")));
+    });
+});

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -11,7 +11,10 @@ import utils = require("../utils");
 suite("Path assumptions", () => {
     suiteSetup(utils.ensureExtensionIsActivated);
 
-    test("The examples folder can be opened (and exists)", async () => {
+    // TODO: This is skipped because it intereferes with other tests. Either
+    // need to find a way to close the opened folder via a Code API, or find
+    // another way to test this.
+    test.skip("The examples folder can be opened (and exists)", async () => {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
     });
 

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -6,29 +6,20 @@ import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
 import { before } from "mocha";
-
-// This lets us test the rest of our path assumptions against the baseline of
-// this test file existing at `<root>/out/test/core/paths.test.ts`.
-const rootPath = path.resolve(__dirname, "../../../")
-// tslint:disable-next-line: no-var-requires
-const packageJSON: any = require(path.resolve(rootPath, "package.json"));
-const extensionId = `${packageJSON.publisher}.${packageJSON.name}`;
+import utils = require("../utils");
 
 suite("Path assumptions", () => {
-    before(async () => {
-        const extension = vscode.extensions.getExtension(extensionId);
-        if (!extension.isActive) { await extension.activate(); }
-    });
+    before(async () => { await utils.ensureExtensionIsActivated(); });
 
     test("The examples folder can be opened (and exists)", async () => {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
     });
 
     test("The session folder is created in the right place", async () => {
-        assert(fs.existsSync(path.resolve(rootPath, "sessions")));
+        assert(fs.existsSync(path.resolve(utils.rootPath, "sessions")));
     });
 
     test("The logs folder is created in the right place", async () => {
-        assert(fs.existsSync(path.resolve(rootPath, "logs")));
+        assert(fs.existsSync(path.resolve(utils.rootPath, "logs")));
     });
 });

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -5,11 +5,11 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { before } from "mocha";
+import { suiteSetup } from "mocha";
 import utils = require("../utils");
 
 suite("Path assumptions", () => {
-    before(async () => { await utils.ensureExtensionIsActivated(); });
+    suiteSetup(utils.ensureExtensionIsActivated);
 
     test("The examples folder can be opened (and exists)", async () => {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -129,7 +129,7 @@ hello
                 styleSheetPaths: cssPaths,
             };
             try {
-                assert.equal(htmlContentView.getContent(), testCase.expectedHtmlString);
+                assert.strictEqual(htmlContentView.getContent(), testCase.expectedHtmlString);
             } finally {
                 jsPaths.forEach((jsPath) => fs.unlinkSync(vscode.Uri.parse(jsPath).fsPath));
                 cssPaths.forEach((cssPath) => fs.unlinkSync(vscode.Uri.parse(cssPath).fsPath));

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -70,7 +70,7 @@ hello
                     content: "console.log('asdf');",
                 },
                 {
-                    fileName: "../../testCustomViews.js",
+                    fileName: "../testCustomViews.js",
                     content: "console.log('asdf');",
                 },
             ],
@@ -78,7 +78,7 @@ hello
             expectedHtmlString: `<html><head></head><body>
 hello
 <script src="${convertToVSCodeResourceScheme(path.join(__dirname, "testCustomViews.js"))}"></script>
-<script src="${convertToVSCodeResourceScheme(path.join(__dirname, "../../testCustomViews.js"))}"></script>
+<script src="${convertToVSCodeResourceScheme(path.join(__dirname, "../testCustomViews.js"))}"></script>
 </body></html>`,
         },
 

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -2,27 +2,19 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import * as vscode from "vscode";
 import { before, beforeEach, afterEach } from "mocha";
+import utils = require("../utils");
 import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../src/features/ExternalApi";
-
-// tslint:disable-next-line: no-var-requires
-const PackageJSON: any = require("../../../package.json");
-const testExtensionId = `${PackageJSON.publisher}.${PackageJSON.name}`;
 
 suite("ExternalApi feature - Registration API", () => {
     let powerShellExtensionClient: IPowerShellExtensionClient;
     before(async () => {
-        const powershellExtension = vscode.extensions.getExtension<IPowerShellExtensionClient>(testExtensionId);
-        if (!powershellExtension.isActive) {
-            powerShellExtensionClient = await powershellExtension.activate();
-            return;
-        }
+        const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
     test("It can register and unregister an extension", () => {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(testExtensionId);
+        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
         assert.strictEqual(
@@ -31,7 +23,7 @@ suite("ExternalApi feature - Registration API", () => {
     });
 
     test("It can register and unregister an extension with a version", () => {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(testExtensionId, "v2");
+        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
         assert.strictEqual(
@@ -48,12 +40,12 @@ suite("ExternalApi feature - Registration API", () => {
     });
 
     test("It can't register the same extension twice", async () => {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(testExtensionId);
+        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         try {
             assert.throws(
-                () => powerShellExtensionClient.registerExternalExtension(testExtensionId),
+                () => powerShellExtensionClient.registerExternalExtension(utils.extensionId),
                 {
-                    message: `The extension '${testExtensionId}' is already registered.`
+                    message: `The extension '${utils.extensionId}' is already registered.`
                 });
         } finally {
             powerShellExtensionClient.unregisterExternalExtension(sessionId);
@@ -74,16 +66,12 @@ suite("ExternalApi feature - Other APIs", () => {
     let powerShellExtensionClient: IPowerShellExtensionClient;
 
     before(async () => {
-        const powershellExtension = vscode.extensions.getExtension<IPowerShellExtensionClient>(testExtensionId);
-        if (!powershellExtension.isActive) {
-            powerShellExtensionClient = await powershellExtension.activate();
-            return;
-        }
+        const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
     beforeEach(() => {
-        sessionId = powerShellExtensionClient.registerExternalExtension(testExtensionId);
+        sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
     });
 
     afterEach(() => {

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -105,6 +105,6 @@ suite("ExternalApi feature - Other APIs", () => {
         assert.notStrictEqual(versionDetails.version, "");
         assert.notStrictEqual(versionDetails.version, null);
 
-        // Start up can take some time... so set the time out to 30s
+        // Start up can take some time...so set the timeout to 30 seconds.
     }).timeout(30000);
 });

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { before, beforeEach, afterEach } from "mocha";
+import { suiteSetup, setup, teardown } from "mocha";
 import utils = require("../utils");
 import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 
 suite("ExternalApi feature - Registration API", () => {
     let powerShellExtensionClient: IPowerShellExtensionClient;
-    before(async () => {
+    suiteSetup(async () => {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
@@ -65,16 +65,16 @@ suite("ExternalApi feature - Other APIs", () => {
     let sessionId: string;
     let powerShellExtensionClient: IPowerShellExtensionClient;
 
-    before(async () => {
+    suiteSetup(async () => {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
-    beforeEach(() => {
+    setup(() => {
         sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
     });
 
-    afterEach(() => {
+    teardown(() => {
         powerShellExtensionClient.unregisterExternalExtension(sessionId);
     });
 

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -3,12 +3,12 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { before } from "mocha";
+import { suiteSetup } from "mocha";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
 suite("ISECompatibility feature", () => {
-    before(async () => { await utils.ensureExtensionIsActivated(); } );
+    suiteSetup(utils.ensureExtensionIsActivated);
 
     test("It sets ISE Settings", async () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -3,15 +3,16 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { suiteSetup } from "mocha";
+import { suiteSetup, setup, teardown } from "mocha";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
 suite("ISECompatibility feature", () => {
     suiteSetup(utils.ensureExtensionIsActivated);
+    setup(async () => { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
+    teardown(async () => { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
 
     test("It sets ISE Settings", async () => {
-        await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
             assert.strictEqual(currently, iseSetting.value);
@@ -31,7 +32,6 @@ suite("ISECompatibility feature", () => {
     }).timeout(10000);
 
     test("It leaves Theme after being changed after enabling ISE Mode", async () => {
-        await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Dark+", true);

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -14,32 +14,32 @@ suite("ISECompatibility feature", () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.equal(currently, iseSetting.value);
+            assert.strictEqual(currently, iseSetting.value);
         }
     });
 
     test("It unsets ISE Settings", async () => {
         // Change state to something that DisableISEMode will change
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
-        assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
         await vscode.commands.executeCommand("PowerShell.DisableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.notEqual(currently, iseSetting.value);
+            assert.notStrictEqual(currently, iseSetting.value);
         }
     }).timeout(10000);
 
     test("It leaves Theme after being changed after enabling ISE Mode", async () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");
-        assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Dark+", true);
         await vscode.commands.executeCommand("PowerShell.DisableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.notEqual(currently, iseSetting.value);
+            assert.notStrictEqual(currently, iseSetting.value);
         }
-        assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Dark+");
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Dark+");
     }).timeout(10000);
 });

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -3,9 +3,13 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
+import { before } from "mocha";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
+import utils = require("../utils");
 
 suite("ISECompatibility feature", () => {
+    before(async () => { await utils.ensureExtensionIsActivated(); } );
+
     test("It sets ISE Settings", async () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
@@ -13,6 +17,7 @@ suite("ISECompatibility feature", () => {
             assert.equal(currently, iseSetting.value);
         }
     });
+
     test("It unsets ISE Settings", async () => {
         // Change state to something that DisableISEMode will change
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
@@ -24,6 +29,7 @@ suite("ISECompatibility feature", () => {
             assert.notEqual(currently, iseSetting.value);
         }
     }).timeout(10000);
+
     test("It leaves Theme after being changed after enabling ISE Mode", async () => {
         await vscode.commands.executeCommand("PowerShell.EnableISEMode");
         assert.equal(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -3,14 +3,28 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { suiteSetup, setup, teardown } from "mocha";
+import { suiteSetup, setup, suiteTeardown, teardown } from "mocha";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
 suite("ISECompatibility feature", () => {
-    suiteSetup(utils.ensureExtensionIsActivated);
+    let currentTheme: string;
+
+    suiteSetup(async () => {
+        // Save user's current theme.
+        currentTheme = await vscode.workspace.getConfiguration("workbench").get("colorTheme");
+        await utils.ensureExtensionIsActivated();
+    });
+
     setup(async () => { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
+
     teardown(async () => { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
+
+    suiteTeardown(async () => {
+        // Reset user's current theme.
+        await vscode.workspace.getConfiguration("workbench").update("colorTheme", currentTheme, true);
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), currentTheme);
+    });
 
     test("It sets ISE Settings", async () => {
         for (const iseSetting of ISECompatibilityFeature.settings) {
@@ -31,15 +45,18 @@ suite("ISECompatibility feature", () => {
         }
     }).timeout(10000);
 
-    test("It leaves Theme after being changed after enabling ISE Mode", async () => {
+    test("It doesn't change theme when disabled if theme was manually changed after being enabled", async () => {
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
-        await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Dark+", true);
+        // "Manually" change theme after enabling ISE mode. Use a built-in theme but not the default.
+        await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Monokai", true);
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
+
         await vscode.commands.executeCommand("PowerShell.DisableISEMode");
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
             assert.notStrictEqual(currently, iseSetting.value);
         }
-        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Dark+");
+        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
     }).timeout(10000);
 });

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -39,7 +39,7 @@ suite("RunCode tests", () => {
 
         const actual: object = createLaunchConfig(LaunchType.Debug, commandToRun, args);
 
-        assert.deepEqual(actual, expected);
+        assert.deepStrictEqual(actual, expected);
     });
 
     test("Can run Pester tests from file", async () => {

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
-import { before } from "mocha";
+import { suiteSetup } from "mocha";
 import rewire = require("rewire");
 import vscode = require("vscode");
 import utils = require("../utils");
@@ -19,7 +19,7 @@ enum LaunchType {
 }
 
 suite("RunCode tests", () => {
-    before(async () => { await utils.ensureExtensionIsActivated(); } );
+    suiteSetup(utils.ensureExtensionIsActivated);
 
     test("Can create the launch config", () => {
         const commandToRun: string = "Invoke-Build";

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 import rewire = require("rewire");
 import vscode = require("vscode");
 
@@ -35,4 +37,12 @@ suite("RunCode tests", () => {
 
         assert.deepEqual(actual, expected);
     });
+
+    test("Can run Pester tests from file", async () => {
+        const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
+        assert(fs.existsSync(pesterTests));
+        await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(pesterTests));
+        assert(await vscode.commands.executeCommand("PowerShell.RunPesterTestsFromFile"));
+        // Start up can take some time...so set the timeout to 30 seconds.
+    }).timeout(30000);
 });

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -4,10 +4,11 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
-import { suiteSetup } from "mocha";
 import rewire = require("rewire");
 import vscode = require("vscode");
 import utils = require("../utils");
+import { sleep } from "../../src/utils";
+import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 
 // Setup function that is not exported.
 const customViews = rewire("../../src/features/RunCode");
@@ -19,8 +20,6 @@ enum LaunchType {
 }
 
 suite("RunCode tests", () => {
-    suiteSetup(utils.ensureExtensionIsActivated);
-
     test("Can create the launch config", () => {
         const commandToRun: string = "Invoke-Build";
         const args: string[] = ["Clean"];
@@ -42,11 +41,33 @@ suite("RunCode tests", () => {
         assert.deepStrictEqual(actual, expected);
     });
 
-    test("Can run Pester tests from file", async () => {
+    test("Can run Pester tests from file", async function() {
+        // PowerShell can take a while and is flaky, so try three times and set
+        // the timeout to thirty seconds each.
+        this.retries(3);
+        this.timeout(30000);
+
         const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
         assert(fs.existsSync(pesterTests));
+
+        // Get interface to extension.
+        const extension = await utils.ensureExtensionIsActivated();
+        const client = extension!.exports as IPowerShellExtensionClient;
+        const sessionId = client.registerExternalExtension(utils.extensionId);
+
+        // Force PowerShell extension to finish connecting. This is necessary
+        // because we can't start the PowerShell debugger until the session is
+        // connected, which is different from the extension being activated. We
+        // also need to open the file so the command has it as its argument.
         await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(pesterTests));
+        await client.getPowerShellVersionDetails(sessionId);
+        client.unregisterExternalExtension(sessionId);
+
+        // Now run the Pester tests, check the debugger started, wait a bit for
+        // it to run, and then kill it for safety's sake.
         assert(await vscode.commands.executeCommand("PowerShell.RunPesterTestsFromFile"));
-        // Start up can take some time...so set the timeout to 30 seconds.
-    }).timeout(30000);
+        assert(vscode.debug.activeDebugSession !== undefined);
+        await sleep(5000);
+        await vscode.debug.stopDebugging();
+    });
 });

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -4,8 +4,10 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
+import { before } from "mocha";
 import rewire = require("rewire");
 import vscode = require("vscode");
+import utils = require("../utils");
 
 // Setup function that is not exported.
 const customViews = rewire("../../src/features/RunCode");
@@ -17,6 +19,8 @@ enum LaunchType {
 }
 
 suite("RunCode tests", () => {
+    before(async () => { await utils.ensureExtensionIsActivated(); } );
+
     test("Can create the launch config", () => {
         const commandToRun: string = "Invoke-Build";
         const args: string[] = ["Clean"];

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -29,7 +29,7 @@ async function main() {
         });
     } catch (err) {
         // tslint:disable-next-line:no-console
-        console.error("Failed to run tests");
+        console.error(`Failed to run tests: ${err}`);
         process.exit(1);
     }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+"use strict";
+
+import * as path from "path";
+import * as vscode from "vscode";
+
+// This lets us test the rest of our path assumptions against the baseline of
+// this test file existing at `<root>/out/test/utils.js`.
+export const rootPath = path.resolve(__dirname, "../../")
+// tslint:disable-next-line: no-var-requires
+const packageJSON: any = require(path.resolve(rootPath, "package.json"));
+export const extensionId = `${packageJSON.publisher}.${packageJSON.name}`;
+
+export async function ensureExtensionIsActivated(): Promise<vscode.Extension<any>> {
+    const extension = vscode.extensions.getExtension(extensionId);
+    if (!extension.isActive) { await extension.activate(); }
+    return extension;
+}


### PR DESCRIPTION
This is hard to get right, and harder to test.

So the path on disk for _all the code_ (because of bundling) is:

```
~/.vscode/extensions/ms-vscode.powershell-preview-2021.9.1/out/main.js
```

Hence, `path.resolve(__dirname, "../")` moves us to:

```
~/.vscode/extensions/ms-vscode.powershell-preview-2021.9.1
```

Because `__dirname` is the folder containing `main.js` (that is, `out`). And that's what has:

```
> ls ~/.vscode/extensions/ms-vscode.powershell-preview-2021.9.1
 CHANGELOG.md               docs       modules        test-results.xml
 LICENSE.txt                examples   out            themes
 README.md                  logs       package.json
'Third Party Notices.txt'   media      snippets
```

But wow, getting a test written to cover this is nigh-impossible due to the design.

When I bundled I was relying on successful compilation and tests, since there were a number of paths. I shouldn't have solely relied on that. I spent the better part of today trying to write a test to cover this, and took three different approaches just to check that the path used for `OpenExamplesFolder` is correct. But I cannot see how to test it sufficiently.