### PR TITLE
Remove unused feature commands

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -25,7 +25,6 @@ export class DebugSessionFeature extends LanguageClientConsumer
     implements DebugConfigurationProvider, vscode.DebugAdapterDescriptorFactory {
 
     private sessionCount: number = 1;
-    private command: vscode.Disposable;
     private tempDebugProcess: PowerShellProcess;
     private tempSessionDetails: utils.IEditorServicesSessionDetails;
 
@@ -49,10 +48,6 @@ export class DebugSessionFeature extends LanguageClientConsumer
         debugAdapter.start();
 
         return new vscode.DebugAdapterInlineImplementation(debugAdapter);
-    }
-
-    public dispose() {
-        this.command.dispose();
     }
 
     public setLanguageClient(languageClient: LanguageClient) {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -50,6 +50,9 @@ export class DebugSessionFeature extends LanguageClientConsumer
         return new vscode.DebugAdapterInlineImplementation(debugAdapter);
     }
 
+    public dispose() {
+    }
+
     public setLanguageClient(languageClient: LanguageClient) {
         languageClient.onNotification(
             StartDebuggerNotificationType,

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -50,6 +50,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         return new vscode.DebugAdapterInlineImplementation(debugAdapter);
     }
 
+    // tslint:disable-next-line:no-empty
     public dispose() {
     }
 

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -11,7 +11,6 @@ export const ShowHelpNotificationType =
 
 export class ShowHelpFeature extends LanguageClientConsumer {
     private command: vscode.Disposable;
-    private deprecatedCommand: vscode.Disposable;
 
     constructor(private log: Logger) {
         super();
@@ -34,7 +33,6 @@ export class ShowHelpFeature extends LanguageClientConsumer {
 
     public dispose() {
         this.command.dispose();
-        this.deprecatedCommand.dispose();
     }
 
 }


### PR DESCRIPTION
## PR Summary

Issue report is https://github.com/PowerShell/vscode-powershell/issues/3586. These two commands are unused except a `dispose()` call (I suppose these are the remnants of some historical refactoring?) In the generated js file, the declarations are gone, but the calls to `dispose()` remain, which causes the extension's `dispose()` to fail.

I suppose alternatively we could tweak how js files are generated and not optimize out unused variables, but that could have way more footprint than removing them. However, if these variables are still used in some way, you guy decide how to proceed.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [`NA`] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
