### PR TITLE
Convert Mocha unit tests to BDD style

### DIFF
--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -5,24 +5,23 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
-import { suiteSetup } from "mocha";
 import utils = require("../utils");
 
-suite("Path assumptions", () => {
-    suiteSetup(utils.ensureExtensionIsActivated);
+describe("Path assumptions", () => {
+    before(utils.ensureExtensionIsActivated);
 
     // TODO: This is skipped because it intereferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find
     // another way to test this.
-    test.skip("The examples folder can be opened (and exists)", async () => {
+    it.skip("The examples folder can be opened (and exists)", async () => {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
     });
 
-    test("The session folder is created in the right place", async () => {
+    it("The session folder is created in the right place", async () => {
         assert(fs.existsSync(path.resolve(utils.rootPath, "sessions")));
     });
 
-    test("The logs folder is created in the right place", async () => {
+    it("The logs folder is created in the right place", async () => {
         assert(fs.existsSync(path.resolve(utils.rootPath, "logs")));
     });
 });

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -467,8 +467,8 @@ function setupTestEnvironment(testPlatform: ITestPlatform) {
     }
 }
 
-suite("Platform module", () => {
-    suite("PlatformDetails", () => {
+describe("Platform module", () => {
+    describe("PlatformDetails", () => {
         const platformDetails: platform.IPlatformDetails = platform.getPlatformDetails();
         switch (process.platform) {
             case "darwin":
@@ -521,14 +521,14 @@ suite("Platform module", () => {
         }
     });
 
-    suite("Default PowerShell installation", () => {
-        teardown(() => {
+    describe("Default PowerShell installation", () => {
+        afterEach(() => {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            test(`Default PowerShell path on ${testPlatform.name}`, () => {
+            it(`Default PowerShell path on ${testPlatform.name}`, () => {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -542,7 +542,7 @@ suite("Platform module", () => {
         }
 
         for (const testPlatform of errorTestCases) {
-            test(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
+            it(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -553,14 +553,14 @@ suite("Platform module", () => {
         }
     });
 
-    suite("Expected PowerShell installation list", () => {
-        teardown(() => {
+    describe("Expected PowerShell installation list", () => {
+        afterEach(() => {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            test(`PowerShell installation list on ${testPlatform.name}`, () => {
+            it(`PowerShell installation list on ${testPlatform.name}`, () => {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -583,7 +583,7 @@ suite("Platform module", () => {
         }
 
         for (const testPlatform of errorTestCases) {
-            test(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
+            it(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -594,8 +594,8 @@ suite("Platform module", () => {
         }
     });
 
-    suite("Windows PowerShell path fix", () => {
-        teardown(() => {
+    describe("Windows PowerShell path fix", () => {
+        afterEach(() => {
             sinon.restore();
             mockFS.restore();
         });
@@ -603,7 +603,7 @@ suite("Platform module", () => {
         for (const testPlatform of successTestCases
                 .filter((tp) => tp.platformDetails.operatingSystem === platform.OperatingSystem.Windows)) {
 
-            test(`Corrects the Windows PowerShell path on ${testPlatform.name}`, () => {
+            it(`Corrects the Windows PowerShell path on ${testPlatform.name}`, () => {
                 setupTestEnvironment(testPlatform);
 
                 function getWinPSPath(systemDir: string) {

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -5,12 +5,12 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import Settings = require("../../src/settings");
 
-suite("Settings module", () => {
-    test("Settings load without error", () => {
+describe("Settings module", () => {
+    it("Settings load without error", () => {
         assert.doesNotThrow(Settings.load);
     });
 
-    test("Settings update correctly", async () => {
+    it("Settings update correctly", async () => {
         // then syntax
         Settings.change("helpCompletion", "BlockComment", false).then(() =>
             assert.strictEqual(Settings.load().helpCompletion, "BlockComment"));
@@ -20,7 +20,7 @@ suite("Settings module", () => {
         assert.strictEqual(Settings.load().helpCompletion, "LineComment");
     });
 
-    test("Settings that can only be user settings update correctly", async () => {
+    it("Settings that can only be user settings update correctly", async () => {
         // set to false means it's set as a workspace-level setting so this should throw.
         const psExeDetails = [{
             versionName: "My PowerShell",
@@ -34,7 +34,7 @@ suite("Settings module", () => {
         assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
     });
 
-    test("Can get effective configuration target", async () => {
+    it("Can get effective configuration target", async () => {
         await Settings.change("helpCompletion", "LineComment", false);
         let target = await Settings.getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -30,7 +30,7 @@ function convertToVSCodeResourceScheme(filePath: string): string {
     return vscode.Uri.file(filePath).toString().replace("file://", "vscode-resource://");
 }
 
-suite("CustomViews tests", () => {
+describe("CustomViews tests", () => {
     const testCases: IHtmlContentViewTestCase[] = [
         // Basic test that has no js or css.
         {
@@ -108,7 +108,7 @@ hello
     ];
 
     for (const testCase of testCases) {
-        test(`Can create an HtmlContentView and get its content - ${testCase.name}`, () => {
+        it(`Can create an HtmlContentView and get its content - ${testCase.name}`, () => {
             const htmlContentView = new HtmlContentView();
 
             const jsPaths = testCase.javaScriptFiles.map((jsFile) => {

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -2,18 +2,17 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
-import { suiteSetup, setup, teardown } from "mocha";
 import utils = require("../utils");
 import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 
-suite("ExternalApi feature - Registration API", () => {
+describe("ExternalApi feature - Registration API", () => {
     let powerShellExtensionClient: IPowerShellExtensionClient;
-    suiteSetup(async () => {
+    before(async () => {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
-    test("It can register and unregister an extension", () => {
+    it("It can register and unregister an extension", () => {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
@@ -22,7 +21,7 @@ suite("ExternalApi feature - Registration API", () => {
             true);
     });
 
-    test("It can register and unregister an extension with a version", () => {
+    it("It can register and unregister an extension with a version", () => {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
@@ -34,12 +33,12 @@ suite("ExternalApi feature - Registration API", () => {
     /*
         NEGATIVE TESTS
     */
-    test("API fails if not registered", async () => {
+    it("API fails if not registered", async () => {
         assert.rejects(
             async () => await powerShellExtensionClient.getPowerShellVersionDetails(""))
     });
 
-    test("It can't register the same extension twice", async () => {
+    it("It can't register the same extension twice", async () => {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         try {
             assert.throws(
@@ -52,7 +51,7 @@ suite("ExternalApi feature - Registration API", () => {
         }
     });
 
-    test("It can't unregister an extension that isn't registered", async () => {
+    it("It can't unregister an extension that isn't registered", async () => {
         assert.throws(
             () => powerShellExtensionClient.unregisterExternalExtension("not-real"),
             {
@@ -61,24 +60,24 @@ suite("ExternalApi feature - Registration API", () => {
         });
 });
 
-suite("ExternalApi feature - Other APIs", () => {
+describe("ExternalApi feature - Other APIs", () => {
     let sessionId: string;
     let powerShellExtensionClient: IPowerShellExtensionClient;
 
-    suiteSetup(async () => {
+    before(async () => {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
-    setup(() => {
+    beforeEach(() => {
         sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
     });
 
-    teardown(() => {
+    afterEach(() => {
         powerShellExtensionClient.unregisterExternalExtension(sessionId);
     });
 
-    test("It can get PowerShell version details", async () => {
+    it("It can get PowerShell version details", async () => {
         const versionDetails: IExternalPowerShellDetails = await powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
 
         assert.notStrictEqual(versionDetails.architecture, "");

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -3,37 +3,36 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { suiteSetup, setup, suiteTeardown, teardown } from "mocha";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
-suite("ISECompatibility feature", () => {
+describe("ISECompatibility feature", () => {
     let currentTheme: string;
 
-    suiteSetup(async () => {
+    before(async () => {
         // Save user's current theme.
         currentTheme = await vscode.workspace.getConfiguration("workbench").get("colorTheme");
         await utils.ensureExtensionIsActivated();
     });
 
-    setup(async () => { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
+    beforeEach(async () => { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
 
-    teardown(async () => { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
+    afterEach(async () => { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
 
-    suiteTeardown(async () => {
+    after(async () => {
         // Reset user's current theme.
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", currentTheme, true);
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), currentTheme);
     });
 
-    test("It sets ISE Settings", async () => {
+    it("It sets ISE Settings", async () => {
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
             assert.strictEqual(currently, iseSetting.value);
         }
     });
 
-    test("It unsets ISE Settings", async () => {
+    it("It unsets ISE Settings", async () => {
         // Change state to something that DisableISEMode will change
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
@@ -45,7 +44,7 @@ suite("ISECompatibility feature", () => {
         }
     });
 
-    test("It doesn't change theme when disabled if theme was manually changed after being enabled", async () => {
+    it("It doesn't change theme when disabled if theme was manually changed after being enabled", async () => {
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
         // "Manually" change theme after enabling ISE mode. Use a built-in theme but not the default.

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -6,7 +6,6 @@ import * as fs from "fs";
 import * as path from "path";
 import rewire = require("rewire");
 import vscode = require("vscode");
-import { suiteSetup } from "mocha";
 import utils = require("../utils");
 import { sleep } from "../../src/utils";
 
@@ -19,10 +18,10 @@ enum LaunchType {
     Run,
 }
 
-suite("RunCode tests", () => {
-    suiteSetup(utils.ensureExtensionIsActivated);
+describe("RunCode tests", () => {
+    before(utils.ensureExtensionIsActivated);
 
-    test("Can create the launch config", () => {
+    it("Can create the launch config", () => {
         const commandToRun: string = "Invoke-Build";
         const args: string[] = ["Clean"];
 
@@ -43,7 +42,7 @@ suite("RunCode tests", () => {
         assert.deepStrictEqual(actual, expected);
     });
 
-    test("Can run Pester tests from file", async () => {
+    it("Can run Pester tests from file", async () => {
         const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
         assert(fs.existsSync(pesterTests));
 

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -8,8 +8,8 @@ import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";
 // the GitHub API rate limit often. Let's skip these tests on macOS until
 // they are hooked up to only run on release.
 if (process.env.TF_BUILD && process.platform === "win32") {
-    suite("UpdatePowerShell tests", () => {
-        test("Can get the latest version", async () => {
+    describe("UpdatePowerShell tests", () => {
+        it("Can get the latest version", async () => {
             const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
             assert.strictEqual(release.isPreview, false, "expected to not be preview.");
             assert.strictEqual(
@@ -17,7 +17,7 @@ if (process.env.TF_BUILD && process.platform === "win32") {
             assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
         });
 
-        test("Can get the latest preview version", async () => {
+        it("Can get the latest preview version", async () => {
             const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(true);
             assert.strictEqual(release.isPreview, true, "expected to be preview.");
             assert.strictEqual(release.version.prerelease.length > 0, true, "expected to have preview in version.");

--- a/test/index.ts
+++ b/test/index.ts
@@ -11,7 +11,6 @@ import * as glob from "glob";
 export function run(): Promise<void> {
     // Create the mocha test
     const mocha = new Mocha({
-        ui: "tdd",
         color: !process.env.TF_BUILD, // colored output from test results
         reporter: "mocha-multi-reporters",
         timeout: 30000, // 30s because PowerShell startup is slow!


### PR DESCRIPTION
Part of #3596. Simplifies code too because now the hooks don't have to be explicitly imported.