### PR TITLE
Fix base URI for PSScriptAnalyzer rule documentation

### DIFF
--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -34,7 +34,7 @@ export class CodeActionsFeature implements vscode.Disposable {
     }
 
     public showRuleDocumentation(ruleId: string) {
-        const pssaDocBaseURL = "https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation";
+        const pssaDocBaseURL = "https://github.com/PowerShell/PSScriptAnalyzer/blob/master/docs/Rules";
 
         if (!ruleId) {
             this.log.writeWarning("Cannot show documentation for code action, no ruleName was supplied.");


### PR DESCRIPTION
## PR Summary

PR PowerShell/PSScriptAnalyzer#1724 moved all documentation to a new
directory in the repo. Therefore when a rule violation is detected in
the editor and a user uses the code action to navigate to the rule's
documentation, they are brought to an invalid URI.

Fixing the base URI to rule documentation in the PSScriptAnalyzer repo.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress