### PR TITLE
Setting to Disable Pester Code Lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -840,7 +840,7 @@
         "powershell.pester.useLegacyCodeLens": {
           "type": "boolean",
           "default": true,
-          "description": "Use code lens that is compatible with Pester 4. Disabling this will show 'Run Tests' on all It, Describe and Context blocks, and will correctly work only with Pester 5 and newer."
+          "description": "Use a CodeLens that is compatible with Pester 4. Disabling this will show 'Run Tests' on all It, Describe and Context blocks, and will correctly work only with Pester 5 and newer."
         },
         "powershell.pester.codeLens": {
           "type": "boolean",


### PR DESCRIPTION
Allows the Pester Codelens to be disabled so as not to confuse users who want to use an alternate Pester Test Runner

Correlated PSES PR: https://github.com/PowerShell/PowerShellEditorServices/pull/1585

Resolves #3430 

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
