### PR TITLE
Add `LinkEditorServices` task for developers

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,11 @@ This will compile the TypeScript files in the project to JavaScript files.
 Invoke-Build Build
 ```
 
+As a developer, you may want to use `Invoke-Build LinkEditorServices` to setup a symbolic
+link to its modules instead of copying the files. This will mean the built extension will
+always have the latest version of your PowerShell Editor Services build, but this cannot
+be used to package the extension into a VSIX. So it is a manual step.
+
 ### Launching the extension
 
 #### From Visual Studio Code

--- a/modules/README.md
+++ b/modules/README.md
@@ -1,8 +1,0 @@
-## `modules` folder README
-
-This folder contains modules that are bundled with the vscode-powershell extension.
-All subfolders are not included in our GitHub repository, they are added here just
-before the module is published to the Visual Studio Marketplace.
-
-This file serves as a placeholder so that the `modules` folder will be included
-in our Git repository.


### PR DESCRIPTION
This allows developers to use a symbolic link to their PowerShell Editor Services build instead of copying it, resulting in much faster extension build times.