### PR TITLE
Replace `() =>` arrow lambdas with `function ()` for Mocha

### DIFF
--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -7,21 +7,21 @@ import * as path from "path";
 import * as vscode from "vscode";
 import utils = require("../utils");
 
-describe("Path assumptions", () => {
+describe("Path assumptions", function() {
     before(utils.ensureExtensionIsActivated);
 
     // TODO: This is skipped because it intereferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find
     // another way to test this.
-    it.skip("The examples folder can be opened (and exists)", async () => {
+    it.skip("The examples folder can be opened (and exists)", async function() {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
     });
 
-    it("The session folder is created in the right place", async () => {
+    it("The session folder is created in the right place", async function() {
         assert(fs.existsSync(path.resolve(utils.rootPath, "sessions")));
     });
 
-    it("The logs folder is created in the right place", async () => {
+    it("The logs folder is created in the right place", async function() {
         assert(fs.existsSync(path.resolve(utils.rootPath, "logs")));
     });
 });

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -467,8 +467,8 @@ function setupTestEnvironment(testPlatform: ITestPlatform) {
     }
 }
 
-describe("Platform module", () => {
-    describe("PlatformDetails", () => {
+describe("Platform module", function() {
+    describe("PlatformDetails", function() {
         const platformDetails: platform.IPlatformDetails = platform.getPlatformDetails();
         switch (process.platform) {
             case "darwin":
@@ -521,14 +521,14 @@ describe("Platform module", () => {
         }
     });
 
-    describe("Default PowerShell installation", () => {
-        afterEach(() => {
+    describe("Default PowerShell installation", function() {
+        afterEach(function() {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            it(`Default PowerShell path on ${testPlatform.name}`, () => {
+            it(`Default PowerShell path on ${testPlatform.name}`, function() {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -542,7 +542,7 @@ describe("Platform module", () => {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
+            it(`Extension startup fails gracefully on ${testPlatform.name}`, function() {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -553,14 +553,14 @@ describe("Platform module", () => {
         }
     });
 
-    describe("Expected PowerShell installation list", () => {
-        afterEach(() => {
+    describe("Expected PowerShell installation list", function() {
+        afterEach(function() {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            it(`PowerShell installation list on ${testPlatform.name}`, () => {
+            it(`PowerShell installation list on ${testPlatform.name}`, function() {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -583,7 +583,7 @@ describe("Platform module", () => {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Extension startup fails gracefully on ${testPlatform.name}`, () => {
+            it(`Extension startup fails gracefully on ${testPlatform.name}`, function() {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -594,8 +594,8 @@ describe("Platform module", () => {
         }
     });
 
-    describe("Windows PowerShell path fix", () => {
-        afterEach(() => {
+    describe("Windows PowerShell path fix", function() {
+        afterEach(function() {
             sinon.restore();
             mockFS.restore();
         });
@@ -603,7 +603,7 @@ describe("Platform module", () => {
         for (const testPlatform of successTestCases
                 .filter((tp) => tp.platformDetails.operatingSystem === platform.OperatingSystem.Windows)) {
 
-            it(`Corrects the Windows PowerShell path on ${testPlatform.name}`, () => {
+            it(`Corrects the Windows PowerShell path on ${testPlatform.name}`, function() {
                 setupTestEnvironment(testPlatform);
 
                 function getWinPSPath(systemDir: string) {

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -5,12 +5,12 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import Settings = require("../../src/settings");
 
-describe("Settings module", () => {
-    it("Settings load without error", () => {
+describe("Settings module", function() {
+    it("Settings load without error", function() {
         assert.doesNotThrow(Settings.load);
     });
 
-    it("Settings update correctly", async () => {
+    it("Settings update correctly", async function() {
         // then syntax
         Settings.change("helpCompletion", "BlockComment", false).then(() =>
             assert.strictEqual(Settings.load().helpCompletion, "BlockComment"));
@@ -20,7 +20,7 @@ describe("Settings module", () => {
         assert.strictEqual(Settings.load().helpCompletion, "LineComment");
     });
 
-    it("Settings that can only be user settings update correctly", async () => {
+    it("Settings that can only be user settings update correctly", async function() {
         // set to false means it's set as a workspace-level setting so this should throw.
         const psExeDetails = [{
             versionName: "My PowerShell",
@@ -34,7 +34,7 @@ describe("Settings module", () => {
         assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
     });
 
-    it("Can get effective configuration target", async () => {
+    it("Can get effective configuration target", async function() {
         await Settings.change("helpCompletion", "LineComment", false);
         let target = await Settings.getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -30,7 +30,7 @@ function convertToVSCodeResourceScheme(filePath: string): string {
     return vscode.Uri.file(filePath).toString().replace("file://", "vscode-resource://");
 }
 
-describe("CustomViews tests", () => {
+describe("CustomViews tests", function() {
     const testCases: IHtmlContentViewTestCase[] = [
         // Basic test that has no js or css.
         {
@@ -108,7 +108,7 @@ hello
     ];
 
     for (const testCase of testCases) {
-        it(`Can create an HtmlContentView and get its content - ${testCase.name}`, () => {
+        it(`Can create an HtmlContentView and get its content - ${testCase.name}`, function() {
             const htmlContentView = new HtmlContentView();
 
             const jsPaths = testCase.javaScriptFiles.map((jsFile) => {

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -5,14 +5,14 @@ import * as assert from "assert";
 import utils = require("../utils");
 import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 
-describe("ExternalApi feature - Registration API", () => {
+describe("ExternalApi feature - Registration API", function() {
     let powerShellExtensionClient: IPowerShellExtensionClient;
-    before(async () => {
+    before(async function() {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
-    it("It can register and unregister an extension", () => {
+    it("It can register and unregister an extension", function() {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
@@ -21,7 +21,7 @@ describe("ExternalApi feature - Registration API", () => {
             true);
     });
 
-    it("It can register and unregister an extension with a version", () => {
+    it("It can register and unregister an extension with a version", function() {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
         assert.notStrictEqual(sessionId , "");
         assert.notStrictEqual(sessionId , null);
@@ -33,12 +33,12 @@ describe("ExternalApi feature - Registration API", () => {
     /*
         NEGATIVE TESTS
     */
-    it("API fails if not registered", async () => {
+    it("API fails if not registered", async function() {
         assert.rejects(
             async () => await powerShellExtensionClient.getPowerShellVersionDetails(""))
     });
 
-    it("It can't register the same extension twice", async () => {
+    it("It can't register the same extension twice", async function() {
         const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
         try {
             assert.throws(
@@ -51,7 +51,7 @@ describe("ExternalApi feature - Registration API", () => {
         }
     });
 
-    it("It can't unregister an extension that isn't registered", async () => {
+    it("It can't unregister an extension that isn't registered", async function() {
         assert.throws(
             () => powerShellExtensionClient.unregisterExternalExtension("not-real"),
             {
@@ -64,20 +64,20 @@ describe("ExternalApi feature - Other APIs", () => {
     let sessionId: string;
     let powerShellExtensionClient: IPowerShellExtensionClient;
 
-    before(async () => {
+    before(async function() {
         const powershellExtension = await utils.ensureExtensionIsActivated();
         powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
     });
 
-    beforeEach(() => {
+    beforeEach(function() {
         sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
     });
 
-    afterEach(() => {
+    afterEach(function() {
         powerShellExtensionClient.unregisterExternalExtension(sessionId);
     });
 
-    it("It can get PowerShell version details", async () => {
+    it("It can get PowerShell version details", async function() {
         const versionDetails: IExternalPowerShellDetails = await powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
 
         assert.notStrictEqual(versionDetails.architecture, "");

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -6,33 +6,33 @@ import * as vscode from "vscode";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
-describe("ISECompatibility feature", () => {
+describe("ISECompatibility feature", function() {
     let currentTheme: string;
 
-    before(async () => {
+    before(async function() {
         // Save user's current theme.
         currentTheme = await vscode.workspace.getConfiguration("workbench").get("colorTheme");
         await utils.ensureExtensionIsActivated();
     });
 
-    beforeEach(async () => { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
+    beforeEach(async function() { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
 
-    afterEach(async () => { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
+    afterEach(async function() { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
 
-    after(async () => {
+    after(async function() {
         // Reset user's current theme.
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", currentTheme, true);
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), currentTheme);
     });
 
-    it("It sets ISE Settings", async () => {
+    it("It sets ISE Settings", async function() {
         for (const iseSetting of ISECompatibilityFeature.settings) {
             const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
             assert.strictEqual(currently, iseSetting.value);
         }
     });
 
-    it("It unsets ISE Settings", async () => {
+    it("It unsets ISE Settings", async function() {
         // Change state to something that DisableISEMode will change
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
@@ -44,7 +44,7 @@ describe("ISECompatibility feature", () => {
         }
     });
 
-    it("It doesn't change theme when disabled if theme was manually changed after being enabled", async () => {
+    it("It doesn't change theme when disabled if theme was manually changed after being enabled", async function() {
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
 
         // "Manually" change theme after enabling ISE mode. Use a built-in theme but not the default.

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -18,10 +18,10 @@ enum LaunchType {
     Run,
 }
 
-describe("RunCode tests", () => {
+describe("RunCode tests", function() {
     before(utils.ensureExtensionIsActivated);
 
-    it("Can create the launch config", () => {
+    it("Can create the launch config", function() {
         const commandToRun: string = "Invoke-Build";
         const args: string[] = ["Clean"];
 
@@ -42,7 +42,7 @@ describe("RunCode tests", () => {
         assert.deepStrictEqual(actual, expected);
     });
 
-    it("Can run Pester tests from file", async () => {
+    it("Can run Pester tests from file", async function() {
         const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
         assert(fs.existsSync(pesterTests));
 

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -8,8 +8,8 @@ import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";
 // the GitHub API rate limit often. Let's skip these tests on macOS until
 // they are hooked up to only run on release.
 if (process.env.TF_BUILD && process.platform === "win32") {
-    describe("UpdatePowerShell tests", () => {
-        it("Can get the latest version", async () => {
+    describe("UpdatePowerShell tests", function() {
+        it("Can get the latest version", async function() {
             const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
             assert.strictEqual(release.isPreview, false, "expected to not be preview.");
             assert.strictEqual(
@@ -17,7 +17,7 @@ if (process.env.TF_BUILD && process.platform === "win32") {
             assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
         });
 
-        it("Can get the latest preview version", async () => {
+        it("Can get the latest preview version", async function() {
             const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(true);
             assert.strictEqual(release.isPreview, true, "expected to be preview.");
             assert.strictEqual(release.version.prerelease.length > 0, true, "expected to have preview in version.");

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
         "indent": [true, "spaces", 4],
         "max-classes-per-file": false,
         "object-literal-sort-keys": false,
+        "only-arrow-functions": false,
         "file-header": [
           true,
           {


### PR DESCRIPTION
The former lexically binds `this` and so prevents access to Mocha's test context, hence its documentation advises the use of `function ()` instead. This allows access to the context for skipping, parameterization, etc.

Part of #3596.