### PR TITLE
Clean up unit tests' descriptions and logical separation

### DIFF
--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -7,21 +7,21 @@ import * as path from "path";
 import * as vscode from "vscode";
 import utils = require("../utils");
 
-describe("Path assumptions", function() {
+describe("Path assumptions", function () {
     before(utils.ensureExtensionIsActivated);
 
     // TODO: This is skipped because it intereferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find
     // another way to test this.
-    it.skip("The examples folder can be opened (and exists)", async function() {
+    it.skip("Opens the examples folder at the expected path", async function () {
         assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
     });
 
-    it("The session folder is created in the right place", async function() {
+    it("Creates the session folder at the correct path", function () {
         assert(fs.existsSync(path.resolve(utils.rootPath, "sessions")));
     });
 
-    it("The logs folder is created in the right place", async function() {
+    it("Creates the log folder at the correct path", function () {
         assert(fs.existsSync(path.resolve(utils.rootPath, "logs")));
     });
 });

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -467,8 +467,8 @@ function setupTestEnvironment(testPlatform: ITestPlatform) {
     }
 }
 
-describe("Platform module", function() {
-    describe("PlatformDetails", function() {
+describe("Platform module", function () {
+    it("Gets the correct platform details", function () {
         const platformDetails: platform.IPlatformDetails = platform.getPlatformDetails();
         switch (process.platform) {
             case "darwin":
@@ -517,18 +517,18 @@ describe("Platform module", function() {
                 return;
 
             default:
-                assert.fail("Tests run on unsupported platform");
+                assert.fail("This platform is unsupported");
         }
     });
 
-    describe("Default PowerShell installation", function() {
-        afterEach(function() {
+    describe("Default PowerShell installation", function () {
+        afterEach(function () {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            it(`Default PowerShell path on ${testPlatform.name}`, function() {
+            it(`Finds it on ${testPlatform.name}`, function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -542,7 +542,7 @@ describe("Platform module", function() {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Extension startup fails gracefully on ${testPlatform.name}`, function() {
+            it(`Fails gracefully on ${testPlatform.name}`, function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -553,14 +553,14 @@ describe("Platform module", function() {
         }
     });
 
-    describe("Expected PowerShell installation list", function() {
-        afterEach(function() {
+    describe("Expected PowerShell installation list", function () {
+        afterEach(function () {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            it(`PowerShell installation list on ${testPlatform.name}`, function() {
+            it(`Finds them on ${testPlatform.name}`, function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -583,7 +583,7 @@ describe("Platform module", function() {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Extension startup fails gracefully on ${testPlatform.name}`, function() {
+            it(`Fails gracefully on ${testPlatform.name}`, function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
@@ -594,16 +594,16 @@ describe("Platform module", function() {
         }
     });
 
-    describe("Windows PowerShell path fix", function() {
-        afterEach(function() {
+    describe("Windows PowerShell path fix", function () {
+        afterEach(function () {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases
-                .filter((tp) => tp.platformDetails.operatingSystem === platform.OperatingSystem.Windows)) {
+            .filter((tp) => tp.platformDetails.operatingSystem === platform.OperatingSystem.Windows)) {
 
-            it(`Corrects the Windows PowerShell path on ${testPlatform.name}`, function() {
+            it(`Corrects the Windows PowerShell path on ${testPlatform.name}`, function () {
                 setupTestEnvironment(testPlatform);
 
                 function getWinPSPath(systemDir: string) {

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -5,36 +5,38 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import Settings = require("../../src/settings");
 
-describe("Settings module", function() {
-    it("Settings load without error", function() {
+describe("Settings module", function () {
+    it("Loads without error", function () {
         assert.doesNotThrow(Settings.load);
     });
 
-    it("Settings update correctly", async function() {
-        // then syntax
+    it("Updates correctly with 'then' syntax", async function () {
         Settings.change("helpCompletion", "BlockComment", false).then(() =>
             assert.strictEqual(Settings.load().helpCompletion, "BlockComment"));
+    });
 
-        // async/await syntax
+    it("Updates correctly with 'async/await' syntax", async function () {
         await Settings.change("helpCompletion", "LineComment", false);
         assert.strictEqual(Settings.load().helpCompletion, "LineComment");
     });
 
-    it("Settings that can only be user settings update correctly", async function() {
-        // set to false means it's set as a workspace-level setting so this should throw.
+    describe("User-only settings", async function () {
         const psExeDetails = [{
             versionName: "My PowerShell",
             exePath: "dummyPath",
         }];
 
-        assert.rejects(async () => await Settings.change("powerShellAdditionalExePaths", psExeDetails, false));
+        it("Throws when updating at workspace-level", async function () {
+            assert.rejects(async () => await Settings.change("powerShellAdditionalExePaths", psExeDetails, false /* workspace-level */));
+        });
 
-        // set to true means it's a user-level setting so this should not throw.
-        await Settings.change("powerShellAdditionalExePaths", psExeDetails, true);
-        assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
+        it("Doesn't throw when updating at user-level", async function () {
+            await Settings.change("powerShellAdditionalExePaths", psExeDetails, true /* user-level */);
+            assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
+        });
     });
 
-    it("Can get effective configuration target", async function() {
+    it("Gets the effective configuration target", async function () {
         await Settings.change("helpCompletion", "LineComment", false);
         let target = await Settings.getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -30,11 +30,10 @@ function convertToVSCodeResourceScheme(filePath: string): string {
     return vscode.Uri.file(filePath).toString().replace("file://", "vscode-resource://");
 }
 
-describe("CustomViews tests", function() {
+describe("CustomViews feature", function () {
     const testCases: IHtmlContentViewTestCase[] = [
-        // Basic test that has no js or css.
         {
-            name: "Basic",
+            name: "with no JavaScript or CSS",
             htmlContent: "hello",
             javaScriptFiles: [],
             cssFiles: [],
@@ -45,7 +44,7 @@ hello
 
         // A test that adds a js file.
         {
-            name: "With JavaScript file",
+            name: "with a JavaScript file but no CSS",
             htmlContent: "hello",
             javaScriptFiles: [
                 {
@@ -62,7 +61,7 @@ hello
 
         // A test that adds a js file in the current directory, and the parent directory.
         {
-            name: "With 2 JavaScript files in two different locations",
+            name: "with two JavaScript files in different locations, but no CSS",
             htmlContent: "hello",
             javaScriptFiles: [
                 {
@@ -84,7 +83,7 @@ hello
 
         // A test that adds a js file and a css file.
         {
-            name: "With JavaScript and CSS file",
+            name: "with a JavaScript and a CSS file",
             htmlContent: "hello",
             javaScriptFiles: [
                 {
@@ -98,8 +97,7 @@ hello
                     content: "body: { background-color: green; }",
                 },
             ],
-            expectedHtmlString: `<html><head><link rel="stylesheet" href="${
-                convertToVSCodeResourceScheme(path.join(__dirname, "testCustomViews.css"))}">
+            expectedHtmlString: `<html><head><link rel="stylesheet" href="${convertToVSCodeResourceScheme(path.join(__dirname, "testCustomViews.css"))}">
 </head><body>
 hello
 <script src="${convertToVSCodeResourceScheme(path.join(__dirname, "testCustomViews.js"))}"></script>
@@ -108,7 +106,7 @@ hello
     ];
 
     for (const testCase of testCases) {
-        it(`Can create an HtmlContentView and get its content - ${testCase.name}`, function() {
+        it(`Correctly creates an HtmlContentView ${testCase.name}`, function () {
             const htmlContentView = new HtmlContentView();
 
             const jsPaths = testCase.javaScriptFiles.map((jsFile) => {

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -5,93 +5,85 @@ import * as assert from "assert";
 import utils = require("../utils");
 import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 
-describe("ExternalApi feature - Registration API", function() {
-    let powerShellExtensionClient: IPowerShellExtensionClient;
-    before(async function() {
-        const powershellExtension = await utils.ensureExtensionIsActivated();
-        powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
-    });
-
-    it("It can register and unregister an extension", function() {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
-        assert.notStrictEqual(sessionId , "");
-        assert.notStrictEqual(sessionId , null);
-        assert.strictEqual(
-            powerShellExtensionClient.unregisterExternalExtension(sessionId),
-            true);
-    });
-
-    it("It can register and unregister an extension with a version", function() {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
-        assert.notStrictEqual(sessionId , "");
-        assert.notStrictEqual(sessionId , null);
-        assert.strictEqual(
-            powerShellExtensionClient.unregisterExternalExtension(sessionId),
-            true);
-    });
-
-    /*
-        NEGATIVE TESTS
-    */
-    it("API fails if not registered", async function() {
-        assert.rejects(
-            async () => await powerShellExtensionClient.getPowerShellVersionDetails(""))
-    });
-
-    it("It can't register the same extension twice", async function() {
-        const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
-        try {
-            assert.throws(
-                () => powerShellExtensionClient.registerExternalExtension(utils.extensionId),
-                {
-                    message: `The extension '${utils.extensionId}' is already registered.`
-                });
-        } finally {
-            powerShellExtensionClient.unregisterExternalExtension(sessionId);
-        }
-    });
-
-    it("It can't unregister an extension that isn't registered", async function() {
-        assert.throws(
-            () => powerShellExtensionClient.unregisterExternalExtension("not-real"),
-            {
-                message: `No extension registered with session UUID: not-real`
-            });
+describe("ExternalApi feature", function () {
+    describe("External extension registration", function () {
+        let powerShellExtensionClient: IPowerShellExtensionClient;
+        before(async function () {
+            const powershellExtension = await utils.ensureExtensionIsActivated();
+            powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
         });
-});
 
-describe("ExternalApi feature - Other APIs", () => {
-    let sessionId: string;
-    let powerShellExtensionClient: IPowerShellExtensionClient;
+        it("Registers and unregisters an extension", function () {
+            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+            assert.notStrictEqual(sessionId, "");
+            assert.notStrictEqual(sessionId, null);
+            assert.strictEqual(
+                powerShellExtensionClient.unregisterExternalExtension(sessionId),
+                true);
+        });
 
-    before(async function() {
-        const powershellExtension = await utils.ensureExtensionIsActivated();
-        powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
+        it("Registers and unregisters an extension with a version", function () {
+            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
+            assert.notStrictEqual(sessionId, "");
+            assert.notStrictEqual(sessionId, null);
+            assert.strictEqual(
+                powerShellExtensionClient.unregisterExternalExtension(sessionId),
+                true);
+        });
+
+        it("Rejects if not registered", async function () {
+            assert.rejects(
+                async () => await powerShellExtensionClient.getPowerShellVersionDetails(""))
+        });
+
+        it("Throws if attempting to register an extension more than once", async function () {
+            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+            try {
+                assert.throws(
+                    () => powerShellExtensionClient.registerExternalExtension(utils.extensionId),
+                    {
+                        message: `The extension '${utils.extensionId}' is already registered.`
+                    });
+            } finally {
+                powerShellExtensionClient.unregisterExternalExtension(sessionId);
+            }
+        });
+
+        it("Throws when unregistering an extension that isn't registered", async function () {
+            assert.throws(
+                () => powerShellExtensionClient.unregisterExternalExtension("not-real"),
+                {
+                    message: `No extension registered with session UUID: not-real`
+                });
+        });
     });
 
-    beforeEach(function() {
-        sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
-    });
+    describe("PowerShell version details", () => {
+        let sessionId: string;
+        let powerShellExtensionClient: IPowerShellExtensionClient;
 
-    afterEach(function() {
-        powerShellExtensionClient.unregisterExternalExtension(sessionId);
-    });
+        before(async function () {
+            const powershellExtension = await utils.ensureExtensionIsActivated();
+            powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
+            sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+        });
 
-    it("It can get PowerShell version details", async function() {
-        const versionDetails: IExternalPowerShellDetails = await powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
+        after(function () { powerShellExtensionClient.unregisterExternalExtension(sessionId); });
 
-        assert.notStrictEqual(versionDetails.architecture, "");
-        assert.notStrictEqual(versionDetails.architecture, null);
+        it("Gets non-empty version details from the PowerShell Editor Services", async function () {
+            const versionDetails: IExternalPowerShellDetails = await powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
 
-        assert.notStrictEqual(versionDetails.displayName, "");
-        assert.notStrictEqual(versionDetails.displayName, null);
+            assert.notStrictEqual(versionDetails.architecture, "");
+            assert.notStrictEqual(versionDetails.architecture, null);
 
-        assert.notStrictEqual(versionDetails.exePath, "");
-        assert.notStrictEqual(versionDetails.exePath, null);
+            assert.notStrictEqual(versionDetails.displayName, "");
+            assert.notStrictEqual(versionDetails.displayName, null);
 
-        assert.notStrictEqual(versionDetails.version, "");
-        assert.notStrictEqual(versionDetails.version, null);
+            assert.notStrictEqual(versionDetails.exePath, "");
+            assert.notStrictEqual(versionDetails.exePath, null);
 
-        // Start up can take some time...so set the timeout to 30 seconds.
+            assert.notStrictEqual(versionDetails.version, "");
+            assert.notStrictEqual(versionDetails.version, null);
+        });
     });
 });

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -6,56 +6,72 @@ import * as vscode from "vscode";
 import { ISECompatibilityFeature } from "../../src/features/ISECompatibility";
 import utils = require("../utils");
 
-describe("ISECompatibility feature", function() {
+describe("ISE compatibility feature", function () {
     let currentTheme: string;
 
-    before(async function() {
+    async function enableISEMode() { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); }
+    async function disableISEMode() { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); }
+
+    before(async function () {
         // Save user's current theme.
         currentTheme = await vscode.workspace.getConfiguration("workbench").get("colorTheme");
         await utils.ensureExtensionIsActivated();
     });
 
-    beforeEach(async function() { await vscode.commands.executeCommand("PowerShell.EnableISEMode"); });
-
-    afterEach(async function() { await vscode.commands.executeCommand("PowerShell.DisableISEMode"); });
-
-    after(async function() {
+    after(async function () {
         // Reset user's current theme.
         await vscode.workspace.getConfiguration("workbench").update("colorTheme", currentTheme, true);
         assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), currentTheme);
     });
 
-    it("It sets ISE Settings", async function() {
+    describe("EnableISEMode command", async function () {
+        before(enableISEMode);
+        after(disableISEMode);
         for (const iseSetting of ISECompatibilityFeature.settings) {
-            const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.strictEqual(currently, iseSetting.value);
+            it(`Sets ${iseSetting.name} correctly`, function () {
+                const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
+                assert.strictEqual(currently, iseSetting.value);
+            });
         }
     });
 
-    it("It unsets ISE Settings", async function() {
-        // Change state to something that DisableISEMode will change
-        await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
-        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
-
-        await vscode.commands.executeCommand("PowerShell.DisableISEMode");
+    describe("DisableISEMode command", async function () {
+        before(enableISEMode);
+        before(disableISEMode);
         for (const iseSetting of ISECompatibilityFeature.settings) {
-            const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.notStrictEqual(currently, iseSetting.value);
+            it(`Unsets ${iseSetting.name} correctly`, function () {
+                const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
+                assert.notStrictEqual(currently, iseSetting.value);
+            });
         }
     });
 
-    it("It doesn't change theme when disabled if theme was manually changed after being enabled", async function() {
-        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
+    describe("Color theme interactions", async function () {
+        beforeEach(enableISEMode);
 
-        // "Manually" change theme after enabling ISE mode. Use a built-in theme but not the default.
-        await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Monokai", true);
-        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
-
-        await vscode.commands.executeCommand("PowerShell.DisableISEMode");
-        for (const iseSetting of ISECompatibilityFeature.settings) {
-            const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
-            assert.notStrictEqual(currently, iseSetting.value);
+        function assertISESettings() {
+            for (const iseSetting of ISECompatibilityFeature.settings) {
+                const currently = vscode.workspace.getConfiguration(iseSetting.path).get(iseSetting.name);
+                assert.notStrictEqual(currently, iseSetting.value);
+            }
         }
-        assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
+
+        it("Changes the theme back from PowerShell ISE", async function () {
+            // Change state to something that DisableISEMode will change
+            await vscode.workspace.getConfiguration("workbench").update("colorTheme", "PowerShell ISE", true);
+            assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
+            await disableISEMode();
+            assertISESettings();
+        });
+
+        it("Doesn't change theme if it was manually changed", async function () {
+            assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "PowerShell ISE");
+            // "Manually" change theme after enabling ISE mode. Use a built-in theme but not the default.
+            await vscode.workspace.getConfiguration("workbench").update("colorTheme", "Monokai", true);
+            assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
+            await disableISEMode();
+            assertISESettings();
+            assert.strictEqual(vscode.workspace.getConfiguration("workbench").get("colorTheme"), "Monokai");
+        });
     });
 });

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -18,10 +18,10 @@ enum LaunchType {
     Run,
 }
 
-describe("RunCode tests", function() {
+describe("RunCode feature", function () {
     before(utils.ensureExtensionIsActivated);
 
-    it("Can create the launch config", function() {
+    it("Creates the launch config", function () {
         const commandToRun: string = "Invoke-Build";
         const args: string[] = ["Clean"];
 
@@ -42,13 +42,14 @@ describe("RunCode tests", function() {
         assert.deepStrictEqual(actual, expected);
     });
 
-    it("Can run Pester tests from file", async function() {
+    it("Runs Pester tests from a file", async function () {
         const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
         assert(fs.existsSync(pesterTests));
 
         // Open the PowerShell file with Pester tests and then wait a while for
         // the extension to finish connecting to the server.
         await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(pesterTests));
+        // TODO: Find a non-sleep way to wait for the connection to establish.
         await sleep(15000);
 
         // Now run the Pester tests, check the debugger started, wait a bit for

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -4,24 +4,19 @@
 import * as assert from "assert";
 import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";
 
-// Due to Azure DevOps using the same macOS instances, the macOS builds hit
-// the GitHub API rate limit often. Let's skip these tests on macOS until
-// they are hooked up to only run on release.
-if (process.env.TF_BUILD && process.platform === "win32") {
-    describe("UpdatePowerShell tests", function() {
-        it("Can get the latest version", async function() {
-            const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
-            assert.strictEqual(release.isPreview, false, "expected to not be preview.");
-            assert.strictEqual(
-                release.version.prerelease.length === 0, true, "expected to not have preview in version.");
-            assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
-        });
-
-        it("Can get the latest preview version", async function() {
-            const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(true);
-            assert.strictEqual(release.isPreview, true, "expected to be preview.");
-            assert.strictEqual(release.version.prerelease.length > 0, true, "expected to have preview in version.");
-            assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
-        });
+describe("UpdatePowerShell feature", function () {
+    it("Gets the latest version", async function () {
+        const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
+        assert.strictEqual(release.isPreview, false, "expected to not be preview.");
+        assert.strictEqual(
+            release.version.prerelease.length === 0, true, "expected to not have preview in version.");
+        assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
     });
-}
+
+    it("Gets the latest preview version", async function () {
+        const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(true);
+        assert.strictEqual(release.isPreview, true, "expected to be preview.");
+        assert.strictEqual(release.version.prerelease.length > 0, true, "expected to have preview in version.");
+        assert.strictEqual(release.assets.length > 0, true, "expected to have assets.");
+    });
+});


### PR DESCRIPTION
I read through all the tests in order to firstly understand fully what we're covering and secondly be able to write correct BDD-style descriptions. I also split tests up that could be for more logical separation, and formatted the files.