### PR TITLE
Improve test stability with `ensureEditorServicesIsConnected`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -175,6 +175,7 @@ export function activate(context: vscode.ExtensionContext): IPowerShellExtension
         registerExternalExtension: (id: string, apiVersion: string = 'v1') => externalApi.registerExternalExtension(id, apiVersion),
         unregisterExternalExtension: uuid => externalApi.unregisterExternalExtension(uuid),
         getPowerShellVersionDetails: uuid => externalApi.getPowerShellVersionDetails(uuid),
+        waitUntilStarted: uuid => externalApi.waitUntilStarted(uuid),
     };
 }
 

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -8,7 +8,7 @@ import * as vscode from "vscode";
 import utils = require("../utils");
 
 describe("Path assumptions", function () {
-    before(utils.ensureExtensionIsActivated);
+    before(utils.ensureEditorServicesIsConnected);
 
     // TODO: This is skipped because it intereferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -15,7 +15,7 @@ describe("ISE compatibility feature", function () {
     before(async function () {
         // Save user's current theme.
         currentTheme = await vscode.workspace.getConfiguration("workbench").get("colorTheme");
-        await utils.ensureExtensionIsActivated();
+        await utils.ensureEditorServicesIsConnected();
     });
 
     after(async function () {

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -19,7 +19,7 @@ enum LaunchType {
 }
 
 describe("RunCode feature", function () {
-    before(utils.ensureExtensionIsActivated);
+    before(utils.ensureEditorServicesIsConnected);
 
     it("Creates the launch config", function () {
         const commandToRun: string = "Invoke-Build";
@@ -49,8 +49,6 @@ describe("RunCode feature", function () {
         // Open the PowerShell file with Pester tests and then wait a while for
         // the extension to finish connecting to the server.
         await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(pesterTests));
-        // TODO: Find a non-sleep way to wait for the connection to establish.
-        await sleep(15000);
 
         // Now run the Pester tests, check the debugger started, wait a bit for
         // it to run, and then kill it for safety's sake.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -5,6 +5,7 @@
 
 import * as path from "path";
 import * as vscode from "vscode";
+import { IPowerShellExtensionClient } from "../src/features/ExternalApi";
 
 // This lets us test the rest of our path assumptions against the baseline of
 // this test file existing at `<root>/out/test/utils.js`.
@@ -17,4 +18,12 @@ export async function ensureExtensionIsActivated(): Promise<vscode.Extension<any
     const extension = vscode.extensions.getExtension(extensionId);
     if (!extension.isActive) { await extension.activate(); }
     return extension;
+}
+
+export async function ensureEditorServicesIsConnected(): Promise<void> {
+    const powershellExtension = await ensureExtensionIsActivated();
+    const client = powershellExtension!.exports as IPowerShellExtensionClient;
+    const sessionId = client.registerExternalExtension(extensionId);
+    await client.waitUntilStarted(sessionId);
+    client.unregisterExternalExtension(sessionId);
 }


### PR DESCRIPTION
This uses a newly added `ExternalApi` function `waitUntilStarted` that ensures the LSP server (PowerShell session) is started after manually activating the extension.