### PR TITLE
Remove Rob from Dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,3 @@ updates:
     timezone: America/Los_Angeles
   reviewers:
     - "andschwa"
-    - "rjmholt"


### PR DESCRIPTION
Because it errors now that he no longer has write permissions (though I'm granting those again).