### PR TITLE
Skip `UpdatePowerShell` tests in CI

### DIFF
--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -5,6 +5,11 @@ import * as assert from "assert";
 import { GitHubReleaseInformation } from "../../src/features/UpdatePowerShell";
 
 describe("UpdatePowerShell feature", function () {
+    before(function () {
+        // NOTE: GitHub API is rate limited in CI
+        if (process.env.TF_BUILD) { this.skip(); }
+    });
+
     it("Gets the latest version", async function () {
         const release: GitHubReleaseInformation = await GitHubReleaseInformation.FetchLatestRelease(false);
         assert.strictEqual(release.isPreview, false, "expected to not be preview.");


### PR DESCRIPTION
The rate limiting is in fact hit, though not on macOS as the previous comment indicated, but on Windows, as the previous code indicated. To be honest, it's not a super important test, but it's now failing CI.