### PR TITLE
Bump VSCE version to 2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "sinon": "~12.0.1",
     "tslint": "~6.1.3",
     "typescript": "~4.4.4",
-    "vsce": "~1.103.1"
+    "vsce": "~2.2"
   },
   "extensionDependencies": [
     "vscode.powershell"


### PR DESCRIPTION


## PR Summary

VSCE warns that you are not at the latest version. The 2.x stream only breaking change is requiring NodeJS 14, which this extension uses, so it is safe to bump.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
