### PR TITLE
Remove Windows Server 2016 from CI

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -22,15 +22,6 @@ resources:
     ref: master
 
 jobs:
-- job: PS51_Win2016
-  displayName: PowerShell 5.1 - Windows Server 2016
-  pool:
-    vmImage: vs2017-win2016
-  steps:
-  - template: templates/ci-general.yml
-    parameters:
-      pwsh: false
-
 - job: PS51_Win2019
   displayName: PowerShell 5.1 - Windows Server 2019
   pool:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The extension _should_ work anywhere VS Code itself and PowerShell Core 7 or hig
 PowerShell Core 6 is end-of-life and so not supported. Our test matrix includes the
 following:
 
-- **Windows Server 2016 and 2019** with Windows PowerShell 5.1 and PowerShell Core 7.1.4
-- **macOS 10.15** with PowerShell Core 7.1.4
-- **Ubuntu 20.04** with PowerShell Core 7.1.4
+- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.1.5
+- **macOS 10.15** with PowerShell Core 7.1.5
+- **Ubuntu 20.04** with PowerShell Core 7.1.5
 
 [supported]: https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle?view=powershell-7.1#supported-platforms
 

--- a/docs/azure_data_studio/README_FOR_MARKETPLACE.md
+++ b/docs/azure_data_studio/README_FOR_MARKETPLACE.md
@@ -28,9 +28,9 @@ The extension _should_ work anywhere ADS itself and PowerShell Core 7 or higher 
 PowerShell Core 6 is end-of-life and so not supported. Our test matrix includes the
 following:
 
-- **Windows Server 2016 and 2019** with Windows PowerShell 5.1 and PowerShell Core 7.1.4
-- **macOS 10.15** with PowerShell Core 7.1.4
-- **Ubuntu 20.04** with PowerShell Core 7.1.4
+- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.1.5
+- **macOS 10.15** with PowerShell Core 7.1.5
+- **Ubuntu 20.04** with PowerShell Core 7.1.5
 
 [supported]: https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle?view=powershell-7.1#supported-platforms
 


### PR DESCRIPTION
The image has been deprecated and will soon be removed from Azure DevOps. Furthermore Microsoft's support for Windows Server 2016 itself ends in January 2022 (less than two months away).