### PR TITLE
Support debugging without a workspace

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -144,6 +144,6 @@ export class PesterTestsFeature implements vscode.Disposable {
         // Ensure the necessary script exists (for testing). The debugger will
         // start regardless, but we also pass its success along.
         return utils.fileExists(this.invokePesterStubScriptPath)
-            && vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
+            && vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
     }
 }

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -49,7 +49,7 @@ export class RunCodeFeature implements vscode.Disposable {
             this.sessionManager.getSessionDetails());
 
         // TODO: Update to handle multiple root workspaces.
-        vscode.debug.startDebugging(vscode.workspace.workspaceFolders[0], launchConfig);
+        vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
     }
 }
 


### PR DESCRIPTION
The existing code assumed there was always at least one workspace folder, but this led to an error if there were zero. This can be reproduced by calling "Close Workspace" if one is open and then running Pester tests. Since the `vscode.debug.startDebugging()` interface does not require a workspace folder, and in fact expects "undefined" if none is available, we simply use TypeScript's "optional chaining" (AKA conditional access) operator to return undefined if `workspaceFolders` is null, and otherwise return the first workspace folder.

Fixes #3713.