### PR TITLE
Fix `EnableISEMode` for Azure Data Studio

### DIFF
--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -42,7 +42,15 @@ export class ISECompatibilityFeature implements vscode.Disposable {
 
     private async EnableISEMode() {
         for (const iseSetting of ISECompatibilityFeature.settings) {
-            await vscode.workspace.getConfiguration(iseSetting.path).update(iseSetting.name, iseSetting.value, true);
+            try {
+                await vscode.workspace.getConfiguration(iseSetting.path).update(iseSetting.name, iseSetting.value, true);
+            } catch {
+                // The `update` call can fail if the setting doesn't exist. This
+                // happens when the extension runs in Azure Data Studio, which
+                // doesn't have a debugger, so the `debug` setting can't be
+                // updated. Unless we catch this exception and allow the
+                // function to continue, it throws an error to the user.
+            }
         }
 
         // Show the PowerShell Command Explorer


### PR DESCRIPTION
Because ADS stripped out VS Code's debugger, the `debug` settings don't
exist, causing our `update()` call for the debug setting to throw an
error to the user when they run `EnableISEMode`. I couldn't find a
reliable way to test if the extension is running in the ADS fork instead
of the upstream VS Code, but a simple `try {} catch {}` that allows the
funciton to continue is a reliable fix, as we can't do anything about
this setting regardless.

Resolves #3709.