### PR TITLE
Fix path to TypeScript SDK

### DIFF
--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -34,15 +34,15 @@
     "markdownlint.config": {
       "MD024": false // no-duplicate-header
     },
-    // Lock the TypeScript SDK path to the version we use
-    "typescript.tsdk": "${workspaceFolder:Client}/node_modules/typescript/lib",
     "powershell.codeFormatting.autoCorrectAliases": true,
     "powershell.codeFormatting.newLineAfterCloseBrace": false,
     "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
     "powershell.codeFormatting.useCorrectCasing": true,
     "powershell.codeFormatting.whitespaceBeforeOpenBrace": false,
     "powershell.codeFormatting.whitespaceBetweenParameters": true,
-    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline"
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    // Lock the TypeScript SDK path to the version we use
+    "typescript.tsdk": "Client/node_modules/typescript/lib"
   },
   "tasks": {
     "version": "2.0.0",


### PR DESCRIPTION
Apparently the variable is not substituted, but [because](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions):

> VS Code will automatically detect workspace versions of TypeScript that are installed under node_modules in the root of your workspace.

I was able to run that command to select it, and that resulted in the workspace configuration automatically being updated with this path, which I have confirmed works.