### PR TITLE
Fix `PowerShell.Debug.Start` to just launch current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,7 +442,7 @@
               "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
-              "cwd": "^\"\\${workspaceFolder}\""
+              "cwd": "^\"\\${file}\""
             }
           },
           {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -175,10 +175,10 @@ export class DebugSessionFeature extends LanguageClientConsumer
         const settings = Settings.load();
 
         // If the createTemporaryIntegratedConsole field is not specified in the launch config, set the field using
-        // the value from the corresponding setting.  Otherwise, the launch config value overrides the setting.
-        if (config.createTemporaryIntegratedConsole === undefined) {
-            config.createTemporaryIntegratedConsole = settings.debugging.createTemporaryIntegratedConsole;
-        }
+        // the value from the corresponding setting. Otherwise, the launch config value overrides the setting.
+        config.createTemporaryIntegratedConsole =
+            config.createTemporaryIntegratedConsole ??
+            settings.debugging.createTemporaryIntegratedConsole;
 
         if (config.request === "attach") {
             const platformDetails = getPlatformDetails();
@@ -300,6 +300,9 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 }
             }
 
+            // NOTE: There is a tight coupling to a weird setting in
+            // `package.json` for the Launch Current File configuration where
+            // the default cwd is set to ${file}.
             if ((currentDocument !== undefined) && (config.cwd === "${file}")) {
                 config.cwd = currentDocument.fileName;
             }

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -215,16 +215,25 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
         });
 
         this.command3 = vscode.commands.registerCommand('PowerShell.ClosePanel',
-            async () => { await vscode.commands.executeCommand('workbench.action.closePanel'); }),
+            () => { vscode.commands.executeCommand('workbench.action.closePanel'); }),
 
         this.command4 = vscode.commands.registerCommand('PowerShell.PositionPanelLeft',
-            async () => { await vscode.commands.executeCommand('workbench.action.positionPanelLeft'); }),
+            () => { vscode.commands.executeCommand('workbench.action.positionPanelLeft'); }),
 
         this.command5 = vscode.commands.registerCommand('PowerShell.PositionPanelBottom',
-            async () => { await vscode.commands.executeCommand('workbench.action.positionPanelBottom'); }),
+            () => { vscode.commands.executeCommand('workbench.action.positionPanelBottom'); }),
 
         this.command6 = vscode.commands.registerCommand('PowerShell.Debug.Start',
-            async () => { await vscode.commands.executeCommand('workbench.action.debug.start'); })
+            () => {
+                // TODO: Use a named debug configuration.
+                vscode.debug.startDebugging(undefined, {
+                    name: "PowerShell: Launch Current File",
+                    type: "PowerShell",
+                    request: "launch",
+                    script: "${file}",
+                    cwd: "${file}",
+                })
+            })
     }
 
     public setLanguageClient(languageclient: LanguageClient) {


### PR DESCRIPTION
This command previously used a private API
`workbench.action.debug.start` which led to bad behavior. Namely it
meant that while a PowerShell file was opened, if the triangular "Start"
button was pressed, it would start Code's currently selected launch
configuration which is often not what the user intended.

1. If there was no `launch.json` this worked accidentally in that we
   resolved a default configuration to launch the current file.
2. If a working PowerShell configuration was selected, it may work as
   intended, unless that configuration was to attach.
3. If any other configuration was selected, the user would be left
   bewildered as to why, say, a Python debugger was started for a
   PowerShell file.

Instead we call the public API to start the debugger and give it a copy
of our "Launch Current File" configuration, which is what the user
intended do when clicking the "Start" button on a PowerShell file.

This may introduce some breaking behavior if the user was relying on
this button to start their current correctly configured (and selected)
launch configuration with possible extra customizations. However, in
that the case the user can use Code's built-in options to call the
private API we were calling preivously, namely F5 or the triangular
start button in the debugger workbench (instead of our button).

Fixes #3710, cleans up some files, and reverts a bug introduced in #3518.