### PR TITLE
Introduce `Debug` and `Release` configurations

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -48,7 +48,7 @@ steps:
     script: |
       Get-Module -ListAvailable Pester
       Install-Module InvokeBuild -Scope CurrentUser -Force
-      Invoke-Build
+      Invoke-Build -Configuration Release
       Write-Host "##vso[task.setvariable variable=vsixPath]$(Resolve-Path powershell-*.vsix)"
     workingDirectory: $(Build.SourcesDirectory)/vscode-powershell
     pwsh: ${{ parameters.pwsh }}

--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -88,7 +88,7 @@
         "options": {
           "cwd": "${workspaceFolder:Client}"
         },
-        "command": "Invoke-Build LinkEditorServices,Build",
+        "command": "Invoke-Build Build",
         "problemMatcher": [
           "$msCompile",
           "$tsc"
@@ -104,7 +104,7 @@
         "options": {
           "cwd": "${workspaceFolder:Client}"
         },
-        "command": "Invoke-Build LinkEditorServices,Test",
+        "command": "Invoke-Build Test",
         "problemMatcher": [
           "$msCompile",
           "$tsc"
@@ -156,7 +156,6 @@
         "options": [
           "Restore",
           "Clean",
-          "LinkEditorServices",
           "Build",
           "Test",
           "Package"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "main": "./out/main.js",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
-    "build": "tsc --project tsconfig.json && esbuild ./src/main.ts --outdir=out --sourcemap --bundle --minify --external:vscode --platform=node",
+    "build": "tsc --project tsconfig.json && esbuild ./src/main.ts --outdir=out --bundle --external:vscode --platform=node",
     "test": "node ./out/test/runTests.js",
     "package": "vsce package --no-gitHubIssueLinking",
     "publish": "vsce publish"


### PR DESCRIPTION
The debug build creates a symlink to PSES, rebuilds PSES, does not
minify the extension, and generates a TypeScript sourcemap. The release
build deletes the symlink if it exists and copies PSES, only builds PSES
if not already copied, minifies the extension, and does not generate a
TypeScript sourcemap. This removes the manual `LinkEditorServices` step
and ensures that the developer debugging experience works well.