### PR TITLE
Add magic marker to `specifyScriptArgs` to disable argument escaping

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -378,7 +378,13 @@ export class SpecifyScriptArgsFeature implements vscode.Disposable {
         if (text !== undefined) {
             this.context.workspaceState.update(powerShellDbgScriptArgsKey, text);
         }
-        return text;
+
+        // Add magic marker to denote we won't escape this argument, enabling it
+        // to be a multi-argument string. This is necessary because Code's API
+        // means that this command can only return a string, not a list of
+        // strings, and so multiple arguments will exist in a single string and
+        // we need PSES to not quote the string due to it containing spaces.
+        return "__psEditorServices_NoEscape_" + text;
     }
 }
 


### PR DESCRIPTION
Coupled with a change to PSES, this enables us to workaround VS Code's
API limitations where our interactive "get user's arguments" command can
only return a string, not an array of strings, which is then passed as a
single argument to PSES. Because it likely contains spaces (and multiple
arguments), we need to instruct PSES to not quote the string in this
special case. It would be easier if we could just pass a list of string
arguments, but so it goes.

Coupled with https://github.com/PowerShell/PowerShellEditorServices/pull/1702, this fixes https://github.com/PowerShell/vscode-powershell/issues/3770.