### PR TITLE
Remove `-NonInteractive` from PowerShell startup sequence

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -73,7 +73,6 @@ export class PowerShellProcess {
         }
 
         powerShellArgs.push("-NoProfile");
-        powerShellArgs.push("-NonInteractive");
 
         // Only add ExecutionPolicy param on Windows
         if (utils.isWindows) {


### PR DESCRIPTION
This command-line flag sets a low-level configuration within PowerShell
that prevents Windows PowerShell from using interactive parameters in
scripts (such as in `Get-Credential`). It does not appear to be
necessary for us to use this flag, so we're going to test without it.

Fixes https://github.com/PowerShell/vscode-powershell/issues/3820.