### PR TITLE
Fix Pester `Test/Debug` code lenses to now change directory

### DIFF
--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -91,11 +91,7 @@ export class PesterTestsFeature implements vscode.Disposable {
             ],
             internalConsoleOptions: "neverOpen",
             noDebug: (launchType === LaunchType.Run),
-            createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole,
-            cwd:
-                currentDocument.isUntitled
-                    ? vscode.workspace.rootPath
-                    : path.dirname(currentDocument.fileName),
+            createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole
         };
 
         if (lineNum) {


### PR DESCRIPTION
We're passing the full path of the test file to the invocation script,
so we do not need to (nor should we, as it could be difficult to
workaround) change the location before running the tests. This just
means not passing a value for `cwd` in the launch configuration.

Fixes #3259.