### PR TITLE
Deprecate `promptToUpdatePackageManagement`

### DIFF
--- a/package.json
+++ b/package.json
@@ -594,7 +594,8 @@
           "type": "string",
           "default": "",
           "scope": "machine",
-          "description": "REMOVED. Please use the \"powershell.powerShellDefaultVersion\" setting instead."
+          "description": "REMOVED. Please use the \"powershell.powerShellDefaultVersion\" setting instead.",
+          "deprecationMessage": "Please use the \"powershell.powerShellDefaultVersion\" setting instead."
         },
         "powershell.promptToUpdatePowerShell": {
           "type": "boolean",
@@ -604,7 +605,8 @@
         "powershell.promptToUpdatePackageManagement": {
           "type": "boolean",
           "description": "Specifies whether you should be prompted to update your version of PackageManagement if it's under 1.4.6.",
-          "default": true
+          "default": true,
+          "deprecationMessage": "This prompt has been removed as it's no longer strictly necessary to upgrade the PackageManagement module."
         },
         "powershell.startAsLoginShell.osx": {
           "type": "boolean",
@@ -746,7 +748,8 @@
         "powershell.codeFormatting.whitespaceAroundPipe": {
           "type": "boolean",
           "default": true,
-          "description": "REMOVED. Please use the \"powershell.codeFormatting.addWhitespaceAroundPipe\" setting instead. If you've used this setting before, we have moved it for you automatically."
+          "description": "REMOVED. Please use the \"powershell.codeFormatting.addWhitespaceAroundPipe\" setting instead. If you've used this setting before, we have moved it for you automatically.",
+          "deprecationMessage": "Please use the \"powershell.codeFormatting.addWhitespaceAroundPipe\" setting instead. If you've used this setting before, we have moved it for you automatically."
         },
         "powershell.codeFormatting.addWhitespaceAroundPipe": {
           "type": "boolean",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,7 +84,6 @@ export interface ISettings {
     // This setting is no longer used but is here to assist in cleaning up the users settings.
     powerShellExePath?: string;
     promptToUpdatePowerShell?: boolean;
-    promptToUpdatePackageManagement?: boolean;
     bundledModulesPath?: string;
     startAsLoginShell?: IStartAsLoginShellSettings;
     startAutomatically?: boolean;
@@ -233,8 +232,6 @@ export function load(): ISettings {
             configuration.get<string>("powerShellExePath", undefined),
         promptToUpdatePowerShell:
             configuration.get<boolean>("promptToUpdatePowerShell", true),
-        promptToUpdatePackageManagement:
-            configuration.get<boolean>("promptToUpdatePackageManagement", true),
         bundledModulesPath:
             "../modules", // Because the extension is always at `<root>/out/main.js`
         useX86Host:


### PR DESCRIPTION
Fixes #3858

## PR Summary

Deprecate the `promptToUpdatePackageManagement` setting as it's no longer required with the new PSES architecture.

Also add deprecation messages to other clearly intended to be deprecated settings.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
