### PR TITLE
Fix title of PowerShell Command Explorer pane

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,17 +92,17 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "PowerShellCommandExplorer",
-          "title": "(Preview) PowerShell Command Explorer",
+          "id": "PowerShell",
+          "title": "PowerShell",
           "icon": "$(terminal-powershell)"
         }
       ]
     },
     "views": {
-      "PowerShellCommandExplorer": [
+      "PowerShell": [
         {
           "id": "PowerShellCommands",
-          "name": "PowerShell Commands",
+          "name": "Command Explorer",
           "when": "config.powershell.sideBar.CommandExplorerVisibility"
         }
       ]

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -53,8 +53,8 @@ export class ISECompatibilityFeature implements vscode.Disposable {
             }
         }
 
-        // Show the PowerShell Command Explorer
-        await vscode.commands.executeCommand("workbench.view.extension.PowerShellCommandExplorer");
+        // Show the PowerShell view container which has the Command Explorer view
+        await vscode.commands.executeCommand("workbench.view.extension.PowerShell");
 
         if (!Settings.load().sideBar.CommandExplorerVisibility) {
             // Hide the explorer if the setting says so.


### PR DESCRIPTION
It's no longer in preview, and the title was repetitive.

This _probably_ won't break anyone (unless they bound a keyboard shortcut to this particular view, which both seems unlikely and I didn't see anything on a search of GitHub indicating anyone was doing this).