### PR TITLE
Add `sendKeyPress` notification used to "cancel" `Console.ReadKey`

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -163,6 +163,10 @@ export class PowerShellProcess {
         }
     }
 
+    public sendKeyPress() {
+        this.consoleTerminal.sendText("\0", false);
+    }
+
     private logTerminalPid(pid: number, exeName: string) {
         this.log.write(`${exeName} PID: ${pid}`);
     }


### PR DESCRIPTION
Required for https://github.com/PowerShell/PowerShellEditorServices/pull/1751