### PR TITLE
Improve Settings Editor experience in a few places

### DIFF
--- a/package.json
+++ b/package.json
@@ -556,26 +556,10 @@
           "description": "Specify array of Modules to exclude from Command Explorer listing."
         },
         "powershell.powerShellAdditionalExePaths": {
-          "type": "array",
-          "description": "Specifies an array of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
-          "scope": "machine",
-          "uniqueItems": true,
-          "items": {
-            "type": "object",
-            "required": [
-              "versionName",
-              "exePath"
-            ],
-            "properties": {
-              "versionName": {
-                "type": "string",
-                "description": "Specifies the version name of this PowerShell executable. The version name can be referenced via the powershell.powerShellDefaultVersion setting."
-              },
-              "exePath": {
-                "type": "string",
-                "description": "Specifies the path to the PowerShell executable. Typically this is a path to a non-standard install location."
-              }
-            }
+          "type": "object",
+          "description": "Specifies a list of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
+          "additionalProperties": {
+            "type": "string"
           }
         },
         "powershell.powerShellDefaultVersion": {

--- a/package.json
+++ b/package.json
@@ -549,6 +549,9 @@
         },
         "powershell.sideBar.CommandExplorerExcludeFilter": {
           "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [],
           "description": "Specify array of Modules to exclude from Command Explorer listing."
         },
@@ -822,7 +825,10 @@
         },
         "powershell.developer.featureFlags": {
           "type": "array",
-          "default": null,
+          "items": {
+            "type": "string"
+          },
+          "default": [],
           "description": "An array of strings that enable experimental features in the PowerShell extension."
         },
         "powershell.developer.waitForSessionFileTimeoutSeconds": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -75,7 +75,7 @@ export class PowerShellExeFinder {
     private readonly platformDetails: IPlatformDetails;
 
     // Additional configured PowerShells
-    private readonly additionalPSExeSettings: Iterable<IPowerShellAdditionalExePathSettings>;
+    private readonly additionalPSExeSettings: IPowerShellAdditionalExePathSettings;
 
     private winPS: IPossiblePowerShellExe;
 
@@ -88,10 +88,10 @@ export class PowerShellExeFinder {
      */
     constructor(
         platformDetails?: IPlatformDetails,
-        additionalPowerShellExes?: Iterable<IPowerShellAdditionalExePathSettings>) {
+        additionalPowerShellExes?: IPowerShellAdditionalExePathSettings) {
 
         this.platformDetails = platformDetails || getPlatformDetails();
-        this.additionalPSExeSettings = additionalPowerShellExes || [];
+        this.additionalPSExeSettings = additionalPowerShellExes || {};
     }
 
     /**
@@ -217,8 +217,13 @@ export class PowerShellExeFinder {
      * without checking for their existence.
      */
     private *enumerateAdditionalPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
-        for (const additionalPwshSetting of this.additionalPSExeSettings) {
-            yield new PossiblePowerShellExe(additionalPwshSetting.exePath, additionalPwshSetting.versionName);
+        for (const versionName in this.additionalPSExeSettings) {
+            if (Object.prototype.hasOwnProperty.call(this.additionalPSExeSettings, versionName)) {
+                const exePath = this.additionalPSExeSettings[versionName];
+                if (exePath) {
+                    yield new PossiblePowerShellExe(exePath, versionName);
+                }
+            }
         }
     }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -808,7 +808,7 @@ export class SessionManager implements Middleware {
 
             new SessionMenuItem(
                 "Modify 'powerShell.powerShellAdditionalExePaths' in Settings",
-                () => { vscode.commands.executeCommand("workbench.action.openSettingsJson"); }),
+                () => { vscode.commands.executeCommand("workbench.action.openSettings", "powershell.powerShellAdditionalExePaths"); }),
         ];
 
         vscode

--- a/src/session.ts
+++ b/src/session.ts
@@ -807,7 +807,7 @@ export class SessionManager implements Middleware {
                 () => { vscode.commands.executeCommand("PowerShell.OpenLogFolder"); }),
 
             new SessionMenuItem(
-                "Modify 'powerShell.powerShellAdditionalExePaths' in Settings",
+                "Modify list of additional PowerShell locations",
                 () => { vscode.commands.executeCommand("workbench.action.openSettings", "powerShellAdditionalExePaths"); }),
         ];
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -808,7 +808,7 @@ export class SessionManager implements Middleware {
 
             new SessionMenuItem(
                 "Modify 'powerShell.powerShellAdditionalExePaths' in Settings",
-                () => { vscode.commands.executeCommand("workbench.action.openSettings", "powershell.powerShellAdditionalExePaths"); }),
+                () => { vscode.commands.executeCommand("workbench.action.openSettings", "powerShellAdditionalExePaths"); }),
         ];
 
         vscode

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,8 +27,7 @@ export enum CommentType {
 }
 
 export interface IPowerShellAdditionalExePathSettings {
-    versionName: string;
-    exePath: string;
+    [versionName: string]: string;
 }
 
 export interface IBugReportingSettings {
@@ -79,7 +78,7 @@ export interface IDeveloperSettings {
 }
 
 export interface ISettings {
-    powerShellAdditionalExePaths?: IPowerShellAdditionalExePathSettings[];
+    powerShellAdditionalExePaths?: IPowerShellAdditionalExePathSettings;
     powerShellDefaultVersion?: string;
     // This setting is no longer used but is here to assist in cleaning up the users settings.
     powerShellExePath?: string;
@@ -225,7 +224,7 @@ export function load(): ISettings {
         startAutomatically:
             configuration.get<boolean>("startAutomatically", true),
         powerShellAdditionalExePaths:
-            configuration.get<IPowerShellAdditionalExePathSettings[]>("powerShellAdditionalExePaths", undefined),
+            configuration.get<IPowerShellAdditionalExePathSettings>("powerShellAdditionalExePaths", undefined),
         powerShellDefaultVersion:
             configuration.get<string>("powerShellDefaultVersion", undefined),
         powerShellExePath:

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -21,10 +21,9 @@ describe("Settings module", function () {
     });
 
     describe("User-only settings", async function () {
-        const psExeDetails = [{
-            versionName: "My PowerShell",
-            exePath: "dummyPath",
-        }];
+        const psExeDetails = {
+            "My PowerShell": "dummyPath",
+        };
 
         it("Throws when updating at workspace-level", async function () {
             assert.rejects(async () => await Settings.change("powerShellAdditionalExePaths", psExeDetails, false /* workspace-level */));
@@ -32,7 +31,9 @@ describe("Settings module", function () {
 
         it("Doesn't throw when updating at user-level", async function () {
             await Settings.change("powerShellAdditionalExePaths", psExeDetails, true /* user-level */);
-            assert.strictEqual(Settings.load().powerShellAdditionalExePaths[0].versionName, psExeDetails[0].versionName);
+            const result = Settings.load().powerShellAdditionalExePaths["My PowerShell"];
+            assert.notStrictEqual(result, undefined);
+            assert.strictEqual(result, psExeDetails["My PowerShell"]);
         });
     });
 


### PR DESCRIPTION
## PR Summary

This PR is two commits:

* two low hanging fruits that allow the `CommandExplorerExcludeFilter` and `featureFlags` settings to show up in the settings editor:
![image](https://user-images.githubusercontent.com/2644648/163107693-82a32334-8bad-41b7-95f1-67c9e62a90ba.png)

* a reworking of the `powerShellAdditionalExePaths` to be an object of `{ [versionName: string]: "exePath" }` so that the user has a nicer experience in the settings editor. It's not perfect (I wish the `Item` and `Value` headers could be renamed), but it's the best we can do with the settings API today and think it's worth it.
![image](https://user-images.githubusercontent.com/2644648/163107805-b4fff22b-50e3-428f-a11f-0f3639d0bc58.png)

This also lights up nice things like this:
![image](https://user-images.githubusercontent.com/2644648/163107842-bc202b7c-e870-4652-8da7-b23e06943f29.png)

jumping to this:
![image](https://user-images.githubusercontent.com/2644648/163107895-f9b36d19-718a-4799-b59b-c01c89126b32.png)

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
