### PR TITLE
Send `p` instead of `\0` for `sendKeyPress`

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -164,7 +164,11 @@ export class PowerShellProcess {
     }
 
     public sendKeyPress() {
-        this.consoleTerminal.sendText("\0", false);
+        // NOTE: This is a regular character instead of something like \0
+        // because non-printing characters can cause havoc with different
+        // languages and terminal settings. We discard the character server-side
+        // anyway, so it doesn't matter what we send.
+        this.consoleTerminal.sendText("p", false);
     }
 
     private logTerminalPid(pid: number, exeName: string) {


### PR DESCRIPTION
This sends a less-risky character in case PSReadLine does _not_ consume it (due to a race condition). The `p` can be deleted and does ring the console bell.