### PR TITLE
Pass `EnableProfileLoading` and `InitialWorkingDirectory` as `initializationOptions`

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -540,6 +540,11 @@ export class SessionManager implements Middleware {
                     configurationSection: [ utils.PowerShellLanguageId, "files", "search" ],
                     // fileEvents: vscode.workspace.createFileSystemWatcher('**/.eslintrc')
                 },
+                // NOTE: Some settings are only applicable on startup, so we send them during initialization.
+                initializationOptions: {
+                    EnableProfileLoading: this.sessionSettings.enableProfileLoading,
+                    InitialWorkingDirectory: this.sessionSettings.cwd,
+                },
                 errorHandler: {
                     // Override the default error handler to prevent it from
                     // closing the LanguageClient incorrectly when the socket

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -268,7 +268,7 @@ export function load(): ISettings {
             //   is the reason terminals on macOS typically run login shells by default which set up
             //   the environment. See http://unix.stackexchange.com/a/119675/115410"
             configuration.get<IStartAsLoginShellSettings>("startAsLoginShell", defaultStartAsLoginShellSettings),
-        cwd:
+        cwd: // TODO: Should we resolve this path and/or default to a workspace folder?
             configuration.get<string>("cwd", null),
     };
 }


### PR DESCRIPTION
To fix stdio clients, we needed to fix our startup logic so that the PowerShell host was actually started on initialization, not in the`onDidChangeConfiguration` handler. The previous way it was done only worked because it relied on a quirk of the VS Code client to send that request immediately, which other clients don’t necessarily do. In order to startup sooner though, we need any configuration that’s applicable on startup to be passed across the wire with the `initialize` request.

Pairs with https://github.com/PowerShell/PowerShellEditorServices/pull/1801