### PR TITLE
Fix capitalization of keys in `initializationOptions`

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -542,8 +542,8 @@ export class SessionManager implements Middleware {
                 },
                 // NOTE: Some settings are only applicable on startup, so we send them during initialization.
                 initializationOptions: {
-                    EnableProfileLoading: this.sessionSettings.enableProfileLoading,
-                    InitialWorkingDirectory: this.sessionSettings.cwd,
+                    enableProfileLoading: this.sessionSettings.enableProfileLoading,
+                    initialWorkingDirectory: this.sessionSettings.cwd,
                 },
                 errorHandler: {
                     // Override the default error handler to prevent it from


### PR DESCRIPTION
While the TypeScript LSP client library didn’t lowercase the first letter of these properties, unfortunately OmniSharp’s stdio client (used for end-to-end testing) did, and so this was the easiest solution.

Required by https://github.com/PowerShell/PowerShellEditorServices/pull/1802