### PR TITLE
Workaround test failures caused by upstream changes

### DIFF
--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "terminal.integrated.shellIntegration.enabled": false,
+  "powershell.enableProfileLoading": false,
+}


### PR DESCRIPTION
Ok, um, I think what happened is that CI builds PSES from the tip of its master branch. So as soon as https://github.com/PowerShell/PowerShellEditorServices/pull/1802 was merged, any CI triggered here afterwards started failing because the ADO machines have, I don't know, some weird/broken profile? This was tough to track down because at the _same time_, I noticed like in https://github.com/microsoft/vscode/issues/148975 that our `package.json` was being reformatted and updated with this `__metadata` field, and additionally, Code's shell integration is now on by default. I've turned that off for the tests as well (though strangely it looks like it's still trying to run in CI, but no longer failing at least).