### PR TITLE
Fix how we check extension mode

### DIFF
--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -35,7 +35,10 @@ NOTE: At some point, we should release a helper npm package that wraps the API a
 export class ExternalApiFeature extends LanguageClientConsumer implements IPowerShellExtensionClient {
     private static readonly registeredExternalExtension: Map<string, IExternalExtension> = new Map<string, IExternalExtension>();
 
-    constructor(private sessionManager: SessionManager, private log: Logger) {
+    constructor(
+        private extensionContext: vscode.ExtensionContext,
+        private sessionManager: SessionManager,
+        private log: Logger) {
         super();
     }
 
@@ -67,8 +70,9 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
             throw new Error(`No extension installed with id '${id}'. You must use a valid extension id.`);
         }
 
-        // If we're in development mode, we allow these to be used for testing purposes.
-        if (!this.sessionManager.InDevelopmentMode && (id === "ms-vscode.PowerShell" || id === "ms-vscode.PowerShell-Preview")) {
+        // These are only allowed to be used in our unit tests.
+        if ((id === "ms-vscode.powershell" || id === "ms-vscode.powershell-preview")
+            && !(this.extensionContext.extensionMode === vscode.ExtensionMode.Test)) {
             throw new Error("You can't use the PowerShell extension's id in this registration.");
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -127,6 +127,7 @@ export function activate(context: vscode.ExtensionContext): IPowerShellExtension
 
     sessionManager =
         new SessionManager(
+            context,
             logger,
             documentSelector,
             PackageJSON.displayName,
@@ -145,7 +146,7 @@ export function activate(context: vscode.ExtensionContext): IPowerShellExtension
         new SpecifyScriptArgsFeature(context),
     ]
 
-    const externalApi = new ExternalApiFeature(sessionManager, logger);
+    const externalApi = new ExternalApiFeature(context, sessionManager, logger);
 
     // Features and command registrations that require language client
     languageClientConsumers = [

--- a/src/session.ts
+++ b/src/session.ts
@@ -62,9 +62,8 @@ export class SessionManager implements Middleware {
     // Initialized by the start() method, since this requires settings
     private powershellExeFinder: PowerShellExeFinder;
 
-    public readonly InDevelopmentMode = vscode.ExtensionMode.Development;
-
     constructor(
+        private extensionContext: vscode.ExtensionContext,
         private log: Logger,
         private documentSelector: DocumentSelector,
         hostName: string,
@@ -167,7 +166,7 @@ export class SessionManager implements Middleware {
 
         this.bundledModulesPath = path.resolve(__dirname, this.sessionSettings.bundledModulesPath);
 
-        if (this.InDevelopmentMode) {
+        if (this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
             const devBundledModulesPath =
                 path.resolve(
                     __dirname,
@@ -571,7 +570,7 @@ export class SessionManager implements Middleware {
             // This enables handling Semantic Highlighting messages in PowerShell Editor Services
             this.languageServerClient.registerProposedFeatures();
 
-            if (!this.InDevelopmentMode) {
+            if (this.extensionContext.extensionMode === vscode.ExtensionMode.Production) {
                 this.languageServerClient.onTelemetry((event) => {
                     const eventName: string = event.eventName ? event.eventName : "PSESEvent";
                     const data: any = event.data ? event.data : event
@@ -588,7 +587,7 @@ export class SessionManager implements Middleware {
                                 this.versionDetails = versionDetails;
                                 this.started = true;
 
-                                if (!this.InDevelopmentMode) {
+                                if (this.extensionContext.extensionMode === vscode.ExtensionMode.Production) {
                                     this.telemetryReporter.sendTelemetryEvent("powershellVersionCheck",
                                         { powershellVersion: versionDetails.version });
                                 }


### PR DESCRIPTION
Well, this was dumb, and was the reason for red-herring logs in user reports that their extension was in development mode, and why our telemetry had stopped coming through.