### PR TITLE
Revert modifications caused by Code's test run

### DIFF
--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -118,6 +118,8 @@ task Build Restore, {
 task Test -If (!($env:TF_BUILD -and $global:IsLinux)) Build, {
     Write-Host "`n### Running extension tests" -ForegroundColor Green
     exec { & npm run test }
+    # Reset the state of files modified by tests
+    exec { git checkout package.json test/.vscode/settings.json}
 }
 
 task TestEditorServices -If (Get-EditorServicesPath) {


### PR DESCRIPTION
VS Code 1.67.0 and up now modify the local `package.json` file during test run. Because we first run our tests in CI and then package our extension, this modification gets saved into the extension package. We need to check the file back out from Git after the test run.

This was identified in https://github.com/microsoft/vscode/issues/148975, and I confirmed that our latest preview unfortunately had this `__metadata` added to it. As I don't know what side effects that will have, let's prevent it from happening.