### PR TITLE
Mark unused `useX86Host` setting as deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -564,14 +564,14 @@
         },
         "powershell.powerShellDefaultVersion": {
           "type": "string",
-          "description": "Specifies the PowerShell version name, as displayed by the 'PowerShell: Show Session Menu' command, used when the extension loads e.g \"Windows PowerShell (x86)\" or \"PowerShell Core 6 (x64)\". You can specify additional PowerShell executables by using the \"powershell.powerShellAdditionalExePaths\" setting."
+          "description": "Specifies the PowerShell version name, as displayed by the 'PowerShell: Show Session Menu' command, used when the extension loads e.g \"Windows PowerShell (x86)\" or \"PowerShell Core 7 (x64)\". You can specify additional PowerShell executables by using the \"powershell.powerShellAdditionalExePaths\" setting."
         },
         "powershell.powerShellExePath": {
           "type": "string",
           "default": "",
           "scope": "machine",
-          "description": "REMOVED. Please use the \"powershell.powerShellDefaultVersion\" setting instead.",
-          "deprecationMessage": "Please use the \"powershell.powerShellDefaultVersion\" setting instead."
+          "description": "REMOVED: Please use the \"powershell.powerShellAdditionalExePaths\" setting instead.",
+          "deprecationMessage": "Please use the \"powershell.powerShellAdditionalExePaths\" setting instead."
         },
         "powershell.promptToUpdatePowerShell": {
           "type": "boolean",
@@ -580,8 +580,8 @@
         },
         "powershell.promptToUpdatePackageManagement": {
           "type": "boolean",
-          "description": "Specifies whether you should be prompted to update your version of PackageManagement if it's under 1.4.6.",
-          "default": true,
+          "description": "REMOVED: Specifies whether you should be prompted to update your version of PackageManagement if it's under 1.4.6.",
+          "default": false,
           "deprecationMessage": "This prompt has been removed as it's no longer strictly necessary to upgrade the PackageManagement module."
         },
         "powershell.startAsLoginShell.osx": {
@@ -602,7 +602,8 @@
         "powershell.useX86Host": {
           "type": "boolean",
           "default": false,
-          "description": "Uses the 32-bit language service on 64-bit Windows. This setting has no effect on 32-bit Windows or on the PowerShell extension debugger, which has its own architecture configuration."
+          "description": "REMOVED: Uses the 32-bit language service on 64-bit Windows. This setting has no effect on 32-bit Windows or on the PowerShell extension debugger, which has its own architecture configuration.",
+          "deprecationMessage": "This setting was removed when the PowerShell installation searcher was added. Please use the \"powershell.powerShellAdditionalExePaths\" setting instead."
         },
         "powershell.enableProfileLoading": {
           "type": "boolean",

--- a/src/session.ts
+++ b/src/session.ts
@@ -394,9 +394,7 @@ export class SessionManager implements Middleware {
 
         // Detect any setting changes that would affect the session
         if (!this.suppressRestartPrompt &&
-            (settings.useX86Host !==
-                this.sessionSettings.useX86Host ||
-             settings.powerShellDefaultVersion.toLowerCase() !==
+            (settings.powerShellDefaultVersion.toLowerCase() !==
                 this.sessionSettings.powerShellDefaultVersion.toLowerCase() ||
              settings.developer.editorServicesLogLevel.toLowerCase() !==
                 this.sessionSettings.developer.editorServicesLogLevel.toLowerCase() ||

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -86,7 +86,6 @@ export interface ISettings {
     bundledModulesPath?: string;
     startAsLoginShell?: IStartAsLoginShellSettings;
     startAutomatically?: boolean;
-    useX86Host?: boolean;
     enableProfileLoading?: boolean;
     helpCompletion: string;
     scriptAnalysis?: IScriptAnalysisSettings;
@@ -233,8 +232,6 @@ export function load(): ISettings {
             configuration.get<boolean>("promptToUpdatePowerShell", true),
         bundledModulesPath:
             "../modules", // Because the extension is always at `<root>/out/main.js`
-        useX86Host:
-            configuration.get<boolean>("useX86Host", false),
         enableProfileLoading:
             configuration.get<boolean>("enableProfileLoading", false),
         helpCompletion:

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -10,7 +10,7 @@ import utils = require("../utils");
 describe("Path assumptions", function () {
     before(utils.ensureEditorServicesIsConnected);
 
-    // TODO: This is skipped because it intereferes with other tests. Either
+    // TODO: This is skipped because it interferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find
     // another way to test this.
     it.skip("Opens the examples folder at the expected path", async function () {


### PR DESCRIPTION
Resolves #4033. This setting hasn't been in use since #2238.