### PR TITLE
Update tooling and READMEs for branch rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,10 +9,10 @@ body:
     - label: I have written a descriptive issue title.
       required: true
     - label: I have searched all [issues](https://github.com/PowerShell/vscode-powershell/issues?q=is%3Aissue) to ensure it has not already been reported.
-    - label: I have read the [troubleshooting](https://github.com/PowerShell/vscode-powershell/blob/master/docs/troubleshooting.md) guide.
+    - label: I have read the [troubleshooting](https://github.com/PowerShell/vscode-powershell/blob/main/docs/troubleshooting.md) guide.
     - label: I am sure this issue is with the _extension itself_ and does not reproduce in a standalone [PowerShell](https://github.com/PowerShell/PowerShell/issues/new/choose) instance.
     - label: I have verified that I am using the latest version of Visual Studio Code and the PowerShell extension.
-    - label: If this is a security issue, I have read the [security issue reporting guidance](https://github.com/PowerShell/vscode-powershell/blob/master/SECURITY.md).
+    - label: If this is a security issue, I have read the [security issue reporting guidance](https://github.com/PowerShell/vscode-powershell/blob/main/SECURITY.md).
 - type: textarea
   attributes:
     label: Summary
@@ -78,4 +78,4 @@ body:
 - type: textarea
   attributes:
     label: Logs
-    description: Please upload logs collected by following these [instructions](https://github.com/PowerShell/vscode-powershell/blob/master/docs/troubleshooting.md#logs) in the area below. Be careful to scrub sensitive information!
+    description: Please upload logs collected by following these [instructions](https://github.com/PowerShell/vscode-powershell/blob/main/docs/troubleshooting.md#logs) in the area below. Be careful to scrub sensitive information!

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,11 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     tags: [ v* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: [ '**/*.md' ]
   schedule:
     - cron: '00 14 * * *' # Every morning at 7:00am PDT

--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -11,7 +11,7 @@ variables:
 trigger:
   branches:
     include:
-      - master
+      - main
 
 resources:
   repositories:
@@ -19,7 +19,7 @@ resources:
     type: github
     endpoint: GitHub
     name: PowerShell/PowerShellEditorServices
-    ref: master
+    ref: main
 
 jobs:
 - job: PS51_Win2019

--- a/.vsts-ci/misc-analysis.yml
+++ b/.vsts-ci/misc-analysis.yml
@@ -3,10 +3,10 @@ name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
 trigger:
   branches:
     include:
-    - master
+    - main
 
 pr:
-- master
+- main
 
 resources:
   repositories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1294,7 +1294,7 @@ for features to come out in the following stable release.
 
 You may also notice that the history of the changelog has changed.
 For a full list of changes between this release and the previous stable release,
-see [here](https://github.com/PowerShell/vscode-powershell/blob/master/docs/preview_to_stable_changelog.md).
+see [here](https://github.com/PowerShell/vscode-powershell/blob/main/docs/preview_to_stable_changelog.md).
 You can find the changelog from the old stable fork
 [here](https://github.com/PowerShell/vscode-powershell/blob/legacy/1.x/CHANGELOG.md).
 
@@ -1887,8 +1887,8 @@ As stated above, this version of the PowerShell extension only works with Window
 #### [vscode-PowerShell](https://github.com/PowerShell/vscode-PowerShell)
 
 - [vscode-PowerShell #1632](https://github.com/PowerShell/vscode-powershell/pull/1632) -
-  Started [a document for ISE-like configuration of VSCode](https://github.com/PowerShell/vscode-powershell/blob/master/docs/ise_compatibility.md).
-  Please help us build it out by [contirbuting an edit](https://github.com/PowerShell/vscode-powershell/edit/master/docs/ise_compatibility.md).
+  Started [a document for ISE-like configuration of VSCode](https://github.com/PowerShell/vscode-powershell/blob/main/docs/ise_compatibility.md).
+  Please help us build it out by [contirbuting an edit](https://github.com/PowerShell/vscode-powershell/edit/main/docs/ise_compatibility.md).
 
 #### [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices)
 
@@ -1929,7 +1929,7 @@ As stated above, this version of the PowerShell extension only works with Window
   Add <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> (<kbd>Cmd</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> on macOS)
   keybinding to open up list of available snippets
 - [vscode-PowerShell #1597](https://github.com/PowerShell/vscode-powershell/pull/1597) -
-  Make `Install-VSCode.ps1` work on macOS and Linux. Get the script [here](https://github.com/PowerShell/vscode-powershell/blob/master/scripts/Install-VSCode.ps1)
+  Make `Install-VSCode.ps1` work on macOS and Linux. Get the script [here](https://github.com/PowerShell/vscode-powershell/blob/main/scripts/Install-VSCode.ps1)
 - [vscode-PowerShell #1580](https://github.com/PowerShell/vscode-powershell/pull/1580) -
   `New-EditorFile` works on non-PowerShell untitled files
 - [vscode-PowerShell #1557](https://github.com/PowerShell/vscode-powershell/pull/1557) -
@@ -2619,14 +2619,14 @@ Thanks to new PowerShell Editor Services co-maintainer [Patrick Meinecke](https:
 we've gained a new set of useful commands for interacting with the $psEditor APIs
 within the Integrated Console:
 
-- [Find-Ast](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Find-Ast.md)
-- [Get-Token](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Get-Token.md)
-- [ConvertFrom-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/ConvertFrom-ScriptExtent.md)
-- [ConvertTo-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/ConvertTo-ScriptExtent.md)
-- [Set-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Set-ScriptExtent.md)
-- [Join-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Join-ScriptExtent.md)
-- [Test-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Test-ScriptExtent.md)
-- [Import-EditorCommand](https://github.com/PowerShell/PowerShellEditorServices/blob/master/module/docs/Import-EditorCommand.md)
+- [Find-Ast](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Find-Ast.md)
+- [Get-Token](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Get-Token.md)
+- [ConvertFrom-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/ConvertFrom-ScriptExtent.md)
+- [ConvertTo-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/ConvertTo-ScriptExtent.md)
+- [Set-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Set-ScriptExtent.md)
+- [Join-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Join-ScriptExtent.md)
+- [Test-ScriptExtent](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Test-ScriptExtent.md)
+- [Import-EditorCommand](https://github.com/PowerShell/PowerShellEditorServices/blob/main/module/docs/Import-EditorCommand.md)
 
 This should also resolve the issues some people were seeing when we tried
 to load the unsigned temporary script containing `Register-EditorCommand`

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The extension _should_ work anywhere VS Code itself and PowerShell Core 7 or hig
 PowerShell Core 6 is end-of-life and so not supported. Our test matrix includes the
 following:
 
-- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.2.1
-- **macOS 10.15** with PowerShell Core 7.2.1
-- **Ubuntu 20.04** with PowerShell Core 7.2.1
+- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.2.4
+- **macOS 10.15** with PowerShell Core 7.2.5
+- **Ubuntu 20.04** with PowerShell Core 7.2.4
 
 [supported]: https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle
 
@@ -61,7 +61,7 @@ in the [Visual Studio Code documentation](https://code.visualstudio.com/docs/edi
 In the Extensions pane, search for "PowerShell" extension and install it there. You will
 get notified automatically about any future extension updates!
 
-You can also install a VSIX package from our [Releases page](https://github.com/PowerShell/vscode-powershell/releases) by following the
+You can also install a VSIX package from our [releases page](https://github.com/PowerShell/vscode-powershell/releases) by following the
 [Install from a VSIX](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix)
 instructions. The easiest way is through the command line:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PowerShell Language Support for Visual Studio Code
 
-[![Build Status](https://dev.azure.com/powershell/vscode-powershell/_apis/build/status/PowerShell.vscode-powershell?branchName=master)](https://dev.azure.com/powershell/vscode-powershell/_build/latest?definitionId=51&branchName=master)
+[![Build Status](https://dev.azure.com/powershell/vscode-powershell/_apis/build/status/PowerShell.vscode-powershell?branchName=main)](https://dev.azure.com/powershell/vscode-powershell/_build/latest?definitionId=51&branchName=main)
 [![Version](https://vsmarketplacebadge.apphb.com/version/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 [![Discord](https://img.shields.io/discord/180528040881815552.svg?label=%23vscode&logo=discord&logoColor=white)](https://aka.ms/powershell-vscode-discord)
@@ -86,11 +86,11 @@ the `Install-Script` command.
 
 **Alternatively** you can download and execute the script directly from the web
 without the use of `Install-Script`.  However we **highly recommend** that you
-[read the script](https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/scripts/Install-VSCode.ps1)
+[read the script](https://raw.githubusercontent.com/PowerShell/vscode-powershell/main/scripts/Install-VSCode.ps1)
 first before running it in this way!
 
 ```powershell
-iex (iwr https://raw.githubusercontent.com/PowerShell/vscode-powershell/master/scripts/Install-VSCode.ps1)
+iex (iwr https://raw.githubusercontent.com/PowerShell/vscode-powershell/main/scripts/Install-VSCode.ps1)
 ```
 
 ## Reporting Problems
@@ -155,4 +155,4 @@ For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [open
 [conduct-code]: http://opensource.microsoft.com/codeofconduct/
 [conduct-FAQ]: http://opensource.microsoft.com/codeofconduct/faq/
 [conduct-email]: mailto:opencode@microsoft.com
-[conduct-md]: https://github.com/PowerShell/vscode-powershell/blob/master/CODE_OF_CONDUCT.md
+[conduct-md]: https://github.com/PowerShell/vscode-powershell/blob/main/CODE_OF_CONDUCT.md

--- a/build.ps1
+++ b/build.ps1
@@ -103,7 +103,7 @@ if ($Bootstrap) {
     } else {
         $missingTools | ForEach-Object {$string += "* $_`n"}
         $string += "`nAll instructions for installing these tools can be found on VSCode PowerShell's Github:`n" `
-            + "https://github.com/PowerShell/vscode-powershell/blob/master/docs/development.md"
+            + "https://github.com/PowerShell/vscode-powershell/blob/main/docs/development.md"
     }
     Write-Host "`n$string`n"
 } elseif(hasMissingTools) {

--- a/docs/azure_data_studio/README_FOR_MARKETPLACE.md
+++ b/docs/azure_data_studio/README_FOR_MARKETPLACE.md
@@ -1,6 +1,6 @@
 # PowerShell Language Support for Azure Data Studio
 
-[![Build Status](https://dev.azure.com/powershell/vscode-powershell/_apis/build/status/PowerShell.vscode-powershell?branchName=master)](https://dev.azure.com/powershell/vscode-powershell/_build/latest?definitionId=51&branchName=master)
+[![Build Status](https://dev.azure.com/powershell/vscode-powershell/_apis/build/status/PowerShell.vscode-powershell?branchName=main)](https://dev.azure.com/powershell/vscode-powershell/_build/latest?definitionId=51&branchName=main)
 [![Version](https://vsmarketplacebadge.apphb.com/version/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 [![Installs](https://vsmarketplacebadge.apphb.com/installs-short/ms-vscode.PowerShell.svg)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
 [![Discord](https://img.shields.io/discord/180528040881815552.svg?label=%23vscode&logo=discord&logoColor=white)](https://aka.ms/powershell-vscode-discord)
@@ -138,7 +138,7 @@ Name                 Status           Size     Space  Recovery Compat. Owner
                                             Available  Model     Level
 ----                 ------           ---- ---------- -------- ------- -----
 AdventureWorks2017   Normal      336.00 MB   57.01 MB Simple       140 sa
-master               Normal        6.00 MB  368.00 KB Simple       140 sa
+main               Normal        6.00 MB  368.00 KB Simple       140 sa
 model                Normal       16.00 MB    5.53 MB Full         140 sa
 msdb                 Normal       48.44 MB    1.70 MB Simple       140 sa
 PBIRS                Normal      144.00 MB   55.95 MB Full         140 sa
@@ -198,4 +198,4 @@ For more information see the [Code of Conduct FAQ][conduct-FAQ] or contact [open
 [conduct-code]: http://opensource.microsoft.com/codeofconduct/
 [conduct-FAQ]: http://opensource.microsoft.com/codeofconduct/faq/
 [conduct-email]: mailto:opencode@microsoft.com
-[conduct-md]: https://github.com/PowerShell/vscode-powershell/blob/master/CODE_OF_CONDUCT.md
+[conduct-md]: https://github.com/PowerShell/vscode-powershell/blob/main/CODE_OF_CONDUCT.md

--- a/docs/azure_data_studio/README_FOR_MARKETPLACE.md
+++ b/docs/azure_data_studio/README_FOR_MARKETPLACE.md
@@ -28,9 +28,9 @@ The extension _should_ work anywhere ADS itself and PowerShell Core 7 or higher 
 PowerShell Core 6 is end-of-life and so not supported. Our test matrix includes the
 following:
 
-- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.1.5
-- **macOS 10.15** with PowerShell Core 7.1.5
-- **Ubuntu 20.04** with PowerShell Core 7.1.5
+- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.2.4
+- **macOS 10.15** with PowerShell Core 7.2.5
+- **Ubuntu 20.04** with PowerShell Core 7.2.4
 
 [supported]: https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle?view=powershell-7.1#supported-platforms
 
@@ -61,7 +61,7 @@ in the [Azure Data Studio documentation](https://docs.microsoft.com/en-us/sql/az
 In the Extensions pane, search for "PowerShell" extension and install it there.  You will
 get notified automatically about any future extension updates!
 
-You can also install a VSIX package from our [Releases page](https://github.com/PowerShell/vscode-powershell/releases) by following the
+You can also install a VSIX package from our [releases page](https://github.com/PowerShell/vscode-powershell/releases) by following the
 [Install from a VSIX](https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix)
 instructions. The easiest way is through the command line:
 
@@ -69,9 +69,15 @@ instructions. The easiest way is through the command line:
 azuredatastudio --install-extension powershell-<version>.vsix
 ```
 
+## Reporting Problems
+
+If you experience any problems with the PowerShell Extension, see
+[the troubleshooting docs](./docs/troubleshooting.md) for information
+on diagnosing and reporting issues.
+
 ## Security Note
 
-For any security issues, please see [here](./docs/troubleshooting.md#note-on-security).
+For any security issues, please see [here](./SECURITY.md).
 
 ## Example Scripts
 
@@ -173,7 +179,6 @@ on how to contribute to this extension!
 
 ## Maintainers
 
-- Rob Holt - [@rjmholt](https://github.com/rjmholt)
 - Patrick Meinecke - [@SeeminglyScience](https://github.com/SeeminglyScience)
 - Andy Schwartzmeyer - [@andschwa](https://github.com/andschwa)
 - Sydney Smith - [@SydneyhSmith](https://github.com/SydneyhSmith)
@@ -181,6 +186,7 @@ on how to contribute to this extension!
 ### Emeriti
 
 - Keith Hill - [@rkeithhill](https://github.com/rkeithhill)
+- Rob Holt - [@rjmholt](https://github.com/rjmholt)
 - Tyler Leonhardt - [@TylerLeonhardt](https://github.com/TylerLeonhardt)
 - David Wilson - [@daviwil](https://github.com/daviwil)
 

--- a/docs/community_snippets.md
+++ b/docs/community_snippets.md
@@ -811,7 +811,7 @@ To optimize snippet usability and discoverability for end users we will only shi
 - Must be substantially different from existing snippets or intellisense
 - Must not violate any intellectual property rights
 
-If your snippet does not meet these requirements but would still be useful to customers we will include it in our list of [Awesome Community Snippets](https://github.com/PowerShell/vscode-powershell/blob/master/docs/community_snippets.md). Additionally, snippet creators can publish snippet libraries as standalone extensions in the [VSCode Marketplace](https://code.visualstudio.com/api/working-with-extensions/publishing-extension).
+If your snippet does not meet these requirements but would still be useful to customers we will include it in our list of [Awesome Community Snippets](https://github.com/PowerShell/vscode-powershell/blob/main/docs/community_snippets.md). Additionally, snippet creators can publish snippet libraries as standalone extensions in the [VSCode Marketplace](https://code.visualstudio.com/api/working-with-extensions/publishing-extension).
 
 If you'd like a snippet to be considered for addition to the list, [open a pull request](https://opensource.guide/how-to-contribute/#opening-a-pull-request) with the following changes:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,7 +59,7 @@ code --extensionDevelopmentPath="c:\path\to\vscode-powershell" .
 ## Contributing Snippets
 
 For more information on contributing snippets please read our
-[snippet requirements](https://github.com/PowerShell/vscode-powershell/blob/master/docs/community_snippets.md#contributing).
+[snippet requirements](https://github.com/PowerShell/vscode-powershell/blob/main/docs/community_snippets.md#contributing).
 
 ## Creating a Release
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "vscode": "^1.59.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
-  "homepage": "https://github.com/PowerShell/vscode-powershell/blob/master/README.md",
+  "homepage": "https://github.com/PowerShell/vscode-powershell/blob/main/README.md",
   "categories": [
     "Debuggers",
     "Programming Languages",

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.4.2
+.VERSION 1.4.3
 
 .GUID 539e5585-7a02-4dd6-b9a6-5dd288d0a5d0
 

--- a/scripts/Install-VSCode.ps1
+++ b/scripts/Install-VSCode.ps1
@@ -12,9 +12,9 @@
 
 .TAGS install vscode installer
 
-.LICENSEURI https://github.com/PowerShell/vscode-powershell/blob/master/LICENSE.txt
+.LICENSEURI https://github.com/PowerShell/vscode-powershell/blob/main/LICENSE.txt
 
-.PROJECTURI https://github.com/PowerShell/vscode-powershell/blob/master/scripts/Install-VSCode.ps1
+.PROJECTURI https://github.com/PowerShell/vscode-powershell/blob/main/scripts/Install-VSCode.ps1
 
 .ICONURI
 
@@ -62,7 +62,7 @@
 
     Please contribute improvements to this script on GitHub!
 
-    https://github.com/PowerShell/vscode-powershell/blob/master/scripts/Install-VSCode.ps1
+    https://github.com/PowerShell/vscode-powershell/blob/main/scripts/Install-VSCode.ps1
 
 .PARAMETER Architecture
     A validated string defining the bit version to download. Values can be either 64-bit or 32-bit.

--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -39,7 +39,7 @@ I am experiencing a problem with...
 Attached Logs
 =====
 
-Follow the instructions in the [README](https://github.com/PowerShell/vscode-powershell/blob/master/docs/troubleshooting.md) about
+Follow the instructions in the [README](https://github.com/PowerShell/vscode-powershell/blob/main/docs/troubleshooting.md) about
 capturing and sending logs.
 
 Environment Information

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -399,7 +399,7 @@ function New-ReleasePR {
 
     $Params = @{
         Head  = "release"
-        Base  = "master"
+        Base  = "main"
         Draft = $true
         Title = "Release ``v$Version``"
         Body  = "Automated PR for new release!"


### PR DESCRIPTION
Since `master` is now `main`.