### PR TITLE
Change configuration title to just `PowerShell`

### DIFF
--- a/package.json
+++ b/package.json
@@ -540,7 +540,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "PowerShell Configuration",
+      "title": "PowerShell",
       "properties": {
         "powershell.sideBar.CommandExplorerVisibility": {
           "type": "boolean",


### PR DESCRIPTION
The vast majority of other extensions don't add "configuration" to the prefix, as the text is already displayed under Settings -> Extensions, and the amount of horizontal space available is small. Since this is just the title, it is a non-breaking change.

This just always bothered me:

<img width="332" alt="Screen Shot 2022-07-05 at 3 24 00 PM" src="https://user-images.githubusercontent.com/2226434/177427111-14aa010f-1270-43b2-a51b-5b6432524e68.png">