### PR TITLE
Add multi-root choice experience to `powershell.cwd`

### DIFF
--- a/package.json
+++ b/package.json
@@ -798,10 +798,11 @@
             "Verbose",
             "Normal",
             "Warning",
-            "Error"
+            "Error",
+            "None"
           ],
           "default": "Normal",
-          "description": "Sets the logging verbosity level for the PowerShell Editor Services host executable.  Valid values are 'Diagnostic', 'Verbose', 'Normal', 'Warning', and 'Error'"
+          "description": "Sets the logging verbosity level for the PowerShell Editor Services host executable.  Valid values are 'Diagnostic', 'Verbose', 'Normal', 'Warning', 'Error', and 'None'"
         },
         "powershell.developer.editorServicesWaitForDebugger": {
           "type": "boolean",

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -19,6 +19,7 @@ export interface IPowerShellExtensionClient {
     unregisterExternalExtension(uuid: string): boolean;
     getPowerShellVersionDetails(uuid: string): Promise<IExternalPowerShellDetails>;
     waitUntilStarted(uuid: string): Promise<void>;
+    getStorageUri(): vscode.Uri;
 }
 
 /*
@@ -164,6 +165,10 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
         const extension = this.getRegisteredExtension(uuid);
         this.log.writeDiagnostic(`Extension '${extension.id}' called 'waitUntilStarted'`);
         return this.sessionManager.waitUntilStarted();
+    }
+
+    public getStorageUri(): vscode.Uri {
+        return this.extensionContext.storageUri;
     }
 
     public dispose() {

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -164,9 +164,9 @@ export async function InvokePowerShellUpdateCheck(
                 // Invoke the MSI via cmd.
                 const msi = spawn("msiexec", ["/i", msiDownloadPath]);
 
-                msi.on("close", (code) => {
+                msi.on("close", async () => {
                     // Now that the MSI is finished, start the Integrated Console session.
-                    sessionManager.start();
+                    await sessionManager.start();
                     fs.unlinkSync(msiDownloadPath);
                 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         });
 
     // Setup the logger.
-    logger = new Logger();
+    logger = new Logger(context.storageUri);
     logger.MinimumLogLevel = LogLevel[extensionSettings.developer.editorServicesLogLevel];
 
     sessionManager =
@@ -180,6 +180,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         unregisterExternalExtension: uuid => externalApi.unregisterExternalExtension(uuid),
         getPowerShellVersionDetails: uuid => externalApi.getPowerShellVersionDetails(uuid),
         waitUntilStarted: uuid => externalApi.waitUntilStarted(uuid),
+        getStorageUri: () => externalApi.getStorageUri(),
     };
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,7 +172,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
     sessionManager.setLanguageClientConsumers(languageClientConsumers);
 
     if (extensionSettings.startAutomatically) {
-        sessionManager.start();
+        await sessionManager.start();
     }
 
     return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,18 +52,24 @@ const documentSelector: DocumentSelector = [
     { language: "powershell", scheme: "untitled" },
 ];
 
-export function activate(context: vscode.ExtensionContext): IPowerShellExtensionClient {
-    // create telemetry reporter on extension activation
+// NOTE: Now that this is async, we can probably improve a lot!
+export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
     telemetryReporter = new TelemetryReporter(PackageJSON.name, PackageJSON.version, AI_KEY);
 
-    // If both extensions are enabled, this will cause unexpected behavior since both register the same commands
+    // If both extensions are enabled, this will cause unexpected behavior since both register the same commands.
+    // TODO: Merge extensions and use preview channel in marketplace instead.
     if (PackageJSON.name.toLowerCase() === "powershell-preview"
         && vscode.extensions.getExtension("ms-vscode.powershell")) {
         vscode.window.showWarningMessage(
             "'PowerShell' and 'PowerShell Preview' are both enabled. Please disable one for best performance.");
     }
 
+    // This displays a popup and a changelog after an update.
     checkForUpdatedVersion(context, PackageJSON.version);
+
+    // Load and validate settings (will prompt for 'cwd' if necessary).
+    await Settings.validateCwdSetting();
+    const extensionSettings = Settings.load();
 
     vscode.languages.setLanguageConfiguration(
         PowerShellLanguageId,
@@ -118,11 +124,8 @@ export function activate(context: vscode.ExtensionContext): IPowerShellExtension
             ],
         });
 
-    // Create the logger
+    // Setup the logger.
     logger = new Logger();
-
-    // Set the log level
-    const extensionSettings = Settings.load();
     logger.MinimumLogLevel = LogLevel[extensionSettings.developer.editorServicesLogLevel];
 
     sessionManager =

--- a/src/process.ts
+++ b/src/process.ts
@@ -51,7 +51,7 @@ export class PowerShellProcess {
                 : "";
 
         this.startPsesArgs +=
-            `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath)}' ` +
+            `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath.fsPath)}' ` +
             `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath)}' ` +
             `-FeatureFlags @(${featureFlags}) `;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -111,7 +111,7 @@ export class SessionManager implements Middleware {
             this.sessionSettings.powerShellDefaultVersion = exeNameOverride;
         }
 
-        this.log.startNewLog(this.sessionSettings.developer.editorServicesLogLevel);
+        await this.log.startNewLog(this.sessionSettings.developer.editorServicesLogLevel);
 
         // Create the PowerShell executable finder now
         this.powershellExeFinder = new PowerShellExeFinder(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@
 
 import vscode = require("vscode");
 import utils = require("./utils");
+import os = require("os");
 
 enum CodeFormattingPreset {
     Custom,
@@ -333,7 +334,7 @@ export async function validateCwdSetting(): Promise<string> {
         // If there were no workspace folders, or somehow they don't exist, use
         // the home directory.
         if (cwd === undefined || !utils.checkIfDirectoryExists(cwd)) {
-            return process.cwd();
+            return os.homedir();
         }
         return cwd;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -134,10 +134,10 @@ export interface INotebooksSettings {
     saveMarkdownCellsAs?: CommentType;
 }
 
+// TODO: This could probably be async, and call `validateCwdSetting()` directly.
 export function load(): ISettings {
     const configuration: vscode.WorkspaceConfiguration =
-        vscode.workspace.getConfiguration(
-            utils.PowerShellLanguageId);
+        vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
 
     const defaultBugReportingSettings: IBugReportingSettings = {
         project: "https://github.com/PowerShell/vscode-powershell",
@@ -265,17 +265,17 @@ export function load(): ISettings {
             //   is the reason terminals on macOS typically run login shells by default which set up
             //   the environment. See http://unix.stackexchange.com/a/119675/115410"
             configuration.get<IStartAsLoginShellSettings>("startAsLoginShell", defaultStartAsLoginShellSettings),
-        cwd: // TODO: Should we resolve this path and/or default to a workspace folder?
-            configuration.get<string>("cwd", null),
+        cwd: // NOTE: This must be validated at startup via `validateCwdSetting()`. There's probably a better way to do this.
+            configuration.get<string>("cwd", undefined),
     };
 }
 
 // Get the ConfigurationTarget (read: scope) of where the *effective* setting value comes from
 export async function getEffectiveConfigurationTarget(settingName: string): Promise<vscode.ConfigurationTarget> {
     const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
-
     const detail = configuration.inspect(settingName);
     let configurationTarget = null;
+
     if (typeof detail.workspaceFolderValue !== "undefined") {
         configurationTarget = vscode.ConfigurationTarget.WorkspaceFolder;
     }
@@ -294,7 +294,6 @@ export async function change(
     configurationTarget?: vscode.ConfigurationTarget | boolean): Promise<void> {
 
     const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
-
     await configuration.update(settingName, newValue, configurationTarget);
 }
 
@@ -311,4 +310,31 @@ function getWorkspaceSettingsWithDefaults<TSettings>(
         }
     }
     return defaultSettings;
+}
+
+export async function validateCwdSetting(): Promise<string> {
+    let cwd: string = vscode.workspace.getConfiguration(utils.PowerShellLanguageId).get<string>("cwd", null);
+
+    // Only use the cwd setting if it exists.
+    if (utils.checkIfDirectoryExists(cwd)) {
+        return cwd;
+    } else {
+        // Otherwise use a workspace folder, prompting if necessary.
+        if (vscode.workspace.workspaceFolders?.length > 1) {
+            const options: vscode.WorkspaceFolderPickOptions = {
+                placeHolder: "Select a folder to use as the PowerShell extension's working directory.",
+            }
+            cwd = (await vscode.window.showWorkspaceFolderPick(options))?.uri.fsPath;
+            // Save the picked 'cwd' to the workspace settings.
+            await change("cwd", cwd);
+        } else {
+            cwd = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+        }
+        // If there were no workspace folders, or somehow they don't exist, use
+        // the home directory.
+        if (cwd === undefined || !utils.checkIfDirectoryExists(cwd)) {
+            return process.cwd();
+        }
+        return cwd;
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,6 +109,16 @@ export function checkIfFileExists(filePath: string): boolean {
     }
 }
 
+export function checkIfDirectoryExists(directoryPath: string): boolean {
+    try {
+        // tslint:disable-next-line:no-bitwise
+        fs.accessSync(directoryPath, fs.constants.R_OK | fs.constants.O_DIRECTORY);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
 export function getTimestampString() {
     const time = new Date();
     return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`;

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -5,10 +5,15 @@ import * as assert from "assert";
 import * as fs from "fs";
 import * as path from "path";
 import * as vscode from "vscode";
+import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import utils = require("../utils");
 
 describe("Path assumptions", function () {
-    before(utils.ensureEditorServicesIsConnected);
+    let storageUri: vscode.Uri;
+    before(async () => {
+        const extension: IPowerShellExtensionClient = await utils.ensureEditorServicesIsConnected();
+        storageUri = extension.getStorageUri();
+    });
 
     // TODO: This is skipped because it interferes with other tests. Either
     // need to find a way to close the opened folder via a Code API, or find
@@ -22,6 +27,6 @@ describe("Path assumptions", function () {
     });
 
     it("Creates the log folder at the correct path", function () {
-        assert(fs.existsSync(path.resolve(utils.rootPath, "logs")));
+        assert(fs.existsSync(vscode.Uri.joinPath(storageUri, "logs").fsPath));
     });
 });

--- a/test/features/ExternalApi.test.ts
+++ b/test/features/ExternalApi.test.ts
@@ -7,51 +7,50 @@ import { IExternalPowerShellDetails, IPowerShellExtensionClient } from "../../sr
 
 describe("ExternalApi feature", function () {
     describe("External extension registration", function () {
-        let powerShellExtensionClient: IPowerShellExtensionClient;
+        let extension: IPowerShellExtensionClient;
         before(async function () {
-            const powershellExtension = await utils.ensureExtensionIsActivated();
-            powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
+            extension = await utils.ensureExtensionIsActivated();
         });
 
         it("Registers and unregisters an extension", function () {
-            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+            const sessionId: string = extension.registerExternalExtension(utils.extensionId);
             assert.notStrictEqual(sessionId, "");
             assert.notStrictEqual(sessionId, null);
             assert.strictEqual(
-                powerShellExtensionClient.unregisterExternalExtension(sessionId),
+                extension.unregisterExternalExtension(sessionId),
                 true);
         });
 
         it("Registers and unregisters an extension with a version", function () {
-            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId, "v2");
+            const sessionId: string = extension.registerExternalExtension(utils.extensionId, "v2");
             assert.notStrictEqual(sessionId, "");
             assert.notStrictEqual(sessionId, null);
             assert.strictEqual(
-                powerShellExtensionClient.unregisterExternalExtension(sessionId),
+                extension.unregisterExternalExtension(sessionId),
                 true);
         });
 
         it("Rejects if not registered", async function () {
             assert.rejects(
-                async () => await powerShellExtensionClient.getPowerShellVersionDetails(""))
+                async () => await extension.getPowerShellVersionDetails(""))
         });
 
         it("Throws if attempting to register an extension more than once", async function () {
-            const sessionId: string = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+            const sessionId: string = extension.registerExternalExtension(utils.extensionId);
             try {
                 assert.throws(
-                    () => powerShellExtensionClient.registerExternalExtension(utils.extensionId),
+                    () => extension.registerExternalExtension(utils.extensionId),
                     {
                         message: `The extension '${utils.extensionId}' is already registered.`
                     });
             } finally {
-                powerShellExtensionClient.unregisterExternalExtension(sessionId);
+                extension.unregisterExternalExtension(sessionId);
             }
         });
 
         it("Throws when unregistering an extension that isn't registered", async function () {
             assert.throws(
-                () => powerShellExtensionClient.unregisterExternalExtension("not-real"),
+                () => extension.unregisterExternalExtension("not-real"),
                 {
                     message: `No extension registered with session UUID: not-real`
                 });
@@ -60,18 +59,17 @@ describe("ExternalApi feature", function () {
 
     describe("PowerShell version details", () => {
         let sessionId: string;
-        let powerShellExtensionClient: IPowerShellExtensionClient;
+        let extension: IPowerShellExtensionClient;
 
         before(async function () {
-            const powershellExtension = await utils.ensureExtensionIsActivated();
-            powerShellExtensionClient = powershellExtension!.exports as IPowerShellExtensionClient;
-            sessionId = powerShellExtensionClient.registerExternalExtension(utils.extensionId);
+            extension = await utils.ensureExtensionIsActivated();
+            sessionId = extension.registerExternalExtension(utils.extensionId);
         });
 
-        after(function () { powerShellExtensionClient.unregisterExternalExtension(sessionId); });
+        after(function () { extension.unregisterExternalExtension(sessionId); });
 
         it("Gets non-empty version details from the PowerShell Editor Services", async function () {
-            const versionDetails: IExternalPowerShellDetails = await powerShellExtensionClient.getPowerShellVersionDetails(sessionId);
+            const versionDetails: IExternalPowerShellDetails = await extension.getPowerShellVersionDetails(sessionId);
 
             assert.notStrictEqual(versionDetails.architecture, "");
             assert.notStrictEqual(versionDetails.architecture, null);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -14,16 +14,16 @@ export const rootPath = path.resolve(__dirname, "../../")
 const packageJSON: any = require(path.resolve(rootPath, "package.json"));
 export const extensionId = `${packageJSON.publisher}.${packageJSON.name}`;
 
-export async function ensureExtensionIsActivated(): Promise<vscode.Extension<any>> {
+export async function ensureExtensionIsActivated(): Promise<IPowerShellExtensionClient> {
     const extension = vscode.extensions.getExtension(extensionId);
     if (!extension.isActive) { await extension.activate(); }
-    return extension;
+    return extension!.exports as IPowerShellExtensionClient;
 }
 
-export async function ensureEditorServicesIsConnected(): Promise<void> {
-    const powershellExtension = await ensureExtensionIsActivated();
-    const client = powershellExtension!.exports as IPowerShellExtensionClient;
-    const sessionId = client.registerExternalExtension(extensionId);
-    await client.waitUntilStarted(sessionId);
-    client.unregisterExternalExtension(sessionId);
+export async function ensureEditorServicesIsConnected(): Promise<IPowerShellExtensionClient> {
+    const extension = await ensureExtensionIsActivated();
+    const sessionId = extension.registerExternalExtension(extensionId);
+    await extension.waitUntilStarted(sessionId);
+    extension.unregisterExternalExtension(sessionId);
+    return extension;
 }


### PR DESCRIPTION
Client-side changes related to https://github.com/PowerShell/PowerShellEditorServices/issues/1849, we should be validating `powershell.cwd`. Part of https://github.com/PowerShell/vscode-powershell/issues/2153, we need to handle if the opened workspace has multiple folders.