### PR TITLE
Use `context.storageUri` for logs and support `None` level

### DIFF
--- a/package.json
+++ b/package.json
@@ -798,10 +798,11 @@
             "Verbose",
             "Normal",
             "Warning",
-            "Error"
+            "Error",
+            "None"
           ],
           "default": "Normal",
-          "description": "Sets the logging verbosity level for the PowerShell Editor Services host executable.  Valid values are 'Diagnostic', 'Verbose', 'Normal', 'Warning', and 'Error'"
+          "description": "Sets the logging verbosity level for the PowerShell Editor Services host executable.  Valid values are 'Diagnostic', 'Verbose', 'Normal', 'Warning', 'Error', and 'None'"
         },
         "powershell.developer.editorServicesWaitForDebugger": {
           "type": "boolean",

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         });
 
     // Setup the logger.
-    logger = new Logger();
+    logger = new Logger(context.storageUri);
     logger.MinimumLogLevel = LogLevel[extensionSettings.developer.editorServicesLogLevel];
 
     sessionManager =

--- a/src/process.ts
+++ b/src/process.ts
@@ -51,7 +51,7 @@ export class PowerShellProcess {
                 : "";
 
         this.startPsesArgs +=
-            `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath)}' ` +
+            `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath.fsPath)}' ` +
             `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath)}' ` +
             `-FeatureFlags @(${featureFlags}) `;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -111,7 +111,7 @@ export class SessionManager implements Middleware {
             this.sessionSettings.powerShellDefaultVersion = exeNameOverride;
         }
 
-        this.log.startNewLog(this.sessionSettings.developer.editorServicesLogLevel);
+        await this.log.startNewLog(this.sessionSettings.developer.editorServicesLogLevel);
 
         // Create the PowerShell executable finder now
         this.powershellExeFinder = new PowerShellExeFinder(


### PR DESCRIPTION
Resolves #4067 (and uses the _correct_ location for logs, as reported via Discord, our extension was defaulting to the extension folder which is not where they be stuck).