### PR TITLE
Use `context.storageUri` for session file (and refactor)

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -309,7 +309,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         // Create or show the interactive console
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
-        const sessionFilePath = this.sessionManager.getDebugSessionFilePath();
+        const sessionFilePath = this.sessionManager.getNewSessionFilePath();
 
         if (config.createTemporaryIntegratedConsole) {
             this.tempDebugProcess = this.sessionManager.createDebugSessionProcess(sessionFilePath, settings);

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -8,9 +8,8 @@ import { NotificationType, RequestType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { getPlatformDetails, OperatingSystem } from "../platform";
 import { PowerShellProcess} from "../process";
-import { SessionManager, SessionStatus } from "../session";
+import { IEditorServicesSessionDetails, SessionManager, SessionStatus } from "../session";
 import Settings = require("../settings");
-import utils = require("../utils");
 import { Logger } from "../logging";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
@@ -25,8 +24,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
 
     private sessionCount: number = 1;
     private tempDebugProcess: PowerShellProcess;
-    private tempDebugEventHandler: vscode.Disposable;
-    private tempSessionDetails: utils.IEditorServicesSessionDetails;
+    private tempSessionDetails: IEditorServicesSessionDetails;
 
     constructor(context: ExtensionContext, private sessionManager: SessionManager, private logger: Logger) {
         super();
@@ -314,12 +312,11 @@ export class DebugSessionFeature extends LanguageClientConsumer
         const sessionFilePath = this.sessionManager.getDebugSessionFilePath();
 
         if (config.createTemporaryIntegratedConsole) {
-            // TODO: This should be cleaned up to support multiple temporary consoles.
             this.tempDebugProcess = this.sessionManager.createDebugSessionProcess(sessionFilePath, settings);
             this.tempSessionDetails = await this.tempDebugProcess.start(`DebugSession-${this.sessionCount++}`);
-            await utils.writeSessionFile(sessionFilePath, this.tempSessionDetails);
+            await this.sessionManager.writeSessionFile(sessionFilePath, this.tempSessionDetails);
         } else {
-            await utils.writeSessionFile(sessionFilePath, this.sessionManager.getSessionDetails());
+            await this.sessionManager.writeSessionFile(sessionFilePath, this.sessionManager.getSessionDetails());
         }
 
         return config;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -311,7 +311,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         // Create or show the interactive console
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
-        const sessionFilePath = utils.getDebugSessionFilePath();
+        const sessionFilePath = this.sessionManager.getDebugSessionFilePath();
 
         if (config.createTemporaryIntegratedConsole) {
             // TODO: This should be cleaned up to support multiple temporary consoles.

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -309,14 +309,9 @@ export class DebugSessionFeature extends LanguageClientConsumer
         // Create or show the interactive console
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
-        const sessionFilePath = this.sessionManager.getNewSessionFilePath();
-
         if (config.createTemporaryIntegratedConsole) {
-            this.tempDebugProcess = this.sessionManager.createDebugSessionProcess(sessionFilePath, settings);
+            this.tempDebugProcess = this.sessionManager.createDebugSessionProcess(settings);
             this.tempSessionDetails = await this.tempDebugProcess.start(`DebugSession-${this.sessionCount++}`);
-            await this.sessionManager.writeSessionFile(sessionFilePath, this.tempSessionDetails);
-        } else {
-            await this.sessionManager.writeSessionFile(sessionFilePath, this.sessionManager.getSessionDetails());
         }
 
         return config;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -317,9 +317,9 @@ export class DebugSessionFeature extends LanguageClientConsumer
             // TODO: This should be cleaned up to support multiple temporary consoles.
             this.tempDebugProcess = this.sessionManager.createDebugSessionProcess(sessionFilePath, settings);
             this.tempSessionDetails = await this.tempDebugProcess.start(`DebugSession-${this.sessionCount++}`);
-            utils.writeSessionFile(sessionFilePath, this.tempSessionDetails);
+            await utils.writeSessionFile(sessionFilePath, this.tempSessionDetails);
         } else {
-            utils.writeSessionFile(sessionFilePath, this.sessionManager.getSessionDetails());
+            await utils.writeSessionFile(sessionFilePath, this.sessionManager.getSessionDetails());
         }
 
         return config;

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -128,7 +128,7 @@ export class PesterTestsFeature implements vscode.Disposable {
     private async launch(launchConfig): Promise<boolean> {
         // Create or show the interactive console
         // TODO: #367 Check if "newSession" mode is configured
-        vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+        await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
         await this.sessionManager.writeSessionFile(

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -131,7 +131,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
-        await utils.writeSessionFile(
+        await this.sessionManager.writeSessionFile(
             this.sessionManager.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -131,7 +131,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
-        utils.writeSessionFile(
+        await utils.writeSessionFile(
             utils.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -132,7 +132,7 @@ export class PesterTestsFeature implements vscode.Disposable {
 
         // Write out temporary debug session file
         await utils.writeSessionFile(
-            utils.getDebugSessionFilePath(),
+            this.sessionManager.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 
         // TODO: Update to handle multiple root workspaces.

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -130,11 +130,6 @@ export class PesterTestsFeature implements vscode.Disposable {
         // TODO: #367 Check if "newSession" mode is configured
         await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
-        // Write out temporary debug session file
-        await this.sessionManager.writeSessionFile(
-            this.sessionManager.getDebugSessionFilePath(),
-            this.sessionManager.getSessionDetails());
-
         // TODO: Update to handle multiple root workspaces.
         //
         // Ensure the necessary script exists (for testing). The debugger will

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -44,7 +44,7 @@ export class RunCodeFeature implements vscode.Disposable {
         await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
-        await utils.writeSessionFile(
+        await this.sessionManager.writeSessionFile(
             this.sessionManager.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -45,7 +45,7 @@ export class RunCodeFeature implements vscode.Disposable {
 
         // Write out temporary debug session file
         await utils.writeSessionFile(
-            utils.getDebugSessionFilePath(),
+            this.sessionManager.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 
         // TODO: Update to handle multiple root workspaces.

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -40,7 +40,7 @@ export class RunCodeFeature implements vscode.Disposable {
 
     private async launch(launchConfig: string | vscode.DebugConfiguration) {
         // Create or show the interactive console
-        // TODO #367: Check if "newSession" mode is configured
+        // TODO: #367: Check if "newSession" mode is configured
         await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -43,11 +43,6 @@ export class RunCodeFeature implements vscode.Disposable {
         // TODO: #367: Check if "newSession" mode is configured
         await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
-        // Write out temporary debug session file
-        await this.sessionManager.writeSessionFile(
-            this.sessionManager.getDebugSessionFilePath(),
-            this.sessionManager.getSessionDetails());
-
         // TODO: Update to handle multiple root workspaces.
         await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
     }

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -35,21 +35,21 @@ export class RunCodeFeature implements vscode.Disposable {
 
         const launchType = runInDebugger ? LaunchType.Debug : LaunchType.Run;
         const launchConfig = createLaunchConfig(launchType, scriptToRun, args);
-        this.launch(launchConfig);
+        await this.launch(launchConfig);
     }
 
-    private launch(launchConfig) {
+    private async launch(launchConfig: string | vscode.DebugConfiguration) {
         // Create or show the interactive console
         // TODO #367: Check if "newSession" mode is configured
-        vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+        await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
 
         // Write out temporary debug session file
-        utils.writeSessionFile(
+        await utils.writeSessionFile(
             utils.getDebugSessionFilePath(),
             this.sessionManager.getSessionDetails());
 
         // TODO: Update to handle multiple root workspaces.
-        vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
+        await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
     }
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -5,7 +5,6 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 import vscode = require("vscode");
-import utils = require("./utils");
 
 export enum LogLevel {
     Diagnostic,
@@ -44,7 +43,6 @@ export class Logger implements ILogger {
         if (logBasePath === undefined) {
             // No workspace, we have to use another folder.
             this.logBasePath = vscode.Uri.file(path.resolve(__dirname, "../logs"));
-            utils.ensurePathExists(this.logBasePath.fsPath);
         } else {
             this.logBasePath = vscode.Uri.joinPath(logBasePath, "logs");
         }

--- a/src/process.ts
+++ b/src/process.ts
@@ -31,7 +31,7 @@ export class PowerShellProcess {
         private title: string,
         private log: Logger,
         private startPsesArgs: string,
-        private sessionFilePath: string,
+        private sessionFilePath: vscode.Uri,
         private sessionSettings: Settings.ISettings) {
 
         this.onExited = this.onExitedEmitter.event;
@@ -53,7 +53,7 @@ export class PowerShellProcess {
 
         this.startPsesArgs +=
             `-LogPath '${PowerShellProcess.escapeSingleQuotes(editorServicesLogPath.fsPath)}' ` +
-            `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath)}' ` +
+        `-SessionDetailsPath '${PowerShellProcess.escapeSingleQuotes(this.sessionFilePath.fsPath)}' ` +
             `-FeatureFlags @(${featureFlags}) `;
 
         if (this.sessionSettings.integratedConsole.useLegacyReadLine) {
@@ -197,7 +197,7 @@ export class PowerShellProcess {
 
         // Check every 2 seconds
         for (let i = numOfTries; i > 0; i--) {
-            if (utils.checkIfFileExists(this.sessionFilePath)) {
+            if (utils.checkIfFileExists(this.sessionFilePath.fsPath)) {
                 this.log.write("Session file found");
                 const sessionDetails = SessionManager.readSessionFile(this.sessionFilePath);
                 SessionManager.deleteSessionFile(this.sessionFilePath);

--- a/src/session.ts
+++ b/src/session.ts
@@ -16,13 +16,15 @@ import utils = require("./utils");
 import {
     CloseAction, DocumentSelector, ErrorAction, LanguageClientOptions,
     Middleware, NotificationType, RequestType0,
-    ResolveCodeLensSignature, RevealOutputChannelOn } from "vscode-languageclient";
+    ResolveCodeLensSignature, RevealOutputChannelOn
+} from "vscode-languageclient";
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 
 import { GitHubReleaseInformation, InvokePowerShellUpdateCheck } from "./features/UpdatePowerShell";
 import {
     getPlatformDetails, IPlatformDetails, IPowerShellExeDetails,
-    OperatingSystem, PowerShellExeFinder } from "./platform";
+    OperatingSystem, PowerShellExeFinder
+} from "./platform";
 import { LanguageClientConsumer } from "./languageClientConsumer";
 
 export enum SessionStatus {
@@ -287,20 +289,6 @@ export class SessionManager implements Middleware {
         return vscode.Uri.joinPath(this.sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID + "-" + uniqueId + ".json");
     }
 
-    public static readSessionFile(sessionFilePath: vscode.Uri): IEditorServicesSessionDetails {
-        // TODO: Use vscode.workspace.fs.readFile instead of fs.readFileSync.
-        const fileContents = fs.readFileSync(sessionFilePath.fsPath, "utf-8");
-        return JSON.parse(fileContents);
-    }
-
-    public static async deleteSessionFile(sessionFilePath: vscode.Uri) {
-        try {
-            await vscode.workspace.fs.delete(sessionFilePath);
-        } catch (e) {
-            // TODO: Be more specific about what we're catching
-        }
-    }
-
     public createDebugSessionProcess(sessionSettings: Settings.ISettings): PowerShellProcess {
 
         // NOTE: We only support one temporary integrated console at a time. To
@@ -337,7 +325,7 @@ export class SessionManager implements Middleware {
     }
 
     public async waitUntilStarted(): Promise<void> {
-        while(!this.started) {
+        while (!this.started) {
             await utils.sleep(300);
         }
     }
@@ -348,43 +336,43 @@ export class SessionManager implements Middleware {
         codeLens: vscode.CodeLens,
         token: vscode.CancellationToken,
         next: ResolveCodeLensSignature): vscode.ProviderResult<vscode.CodeLens> {
-            const resolvedCodeLens = next(codeLens, token);
-            const resolveFunc =
-                (codeLensToFix: vscode.CodeLens): vscode.CodeLens => {
-                    if (codeLensToFix.command?.command === "editor.action.showReferences") {
-                        const oldArgs = codeLensToFix.command.arguments;
+        const resolvedCodeLens = next(codeLens, token);
+        const resolveFunc =
+            (codeLensToFix: vscode.CodeLens): vscode.CodeLens => {
+                if (codeLensToFix.command?.command === "editor.action.showReferences") {
+                    const oldArgs = codeLensToFix.command.arguments;
 
-                        // Our JSON objects don't get handled correctly by
-                        // VS Code's built in editor.action.showReferences
-                        // command so we need to convert them into the
-                        // appropriate types to send them as command
-                        // arguments.
+                    // Our JSON objects don't get handled correctly by
+                    // VS Code's built in editor.action.showReferences
+                    // command so we need to convert them into the
+                    // appropriate types to send them as command
+                    // arguments.
 
-                        codeLensToFix.command.arguments = [
-                            vscode.Uri.parse(oldArgs[0]),
-                            new vscode.Position(oldArgs[1].line, oldArgs[1].character),
-                            oldArgs[2].map((position) => {
-                                return new vscode.Location(
-                                    vscode.Uri.parse(position.uri),
-                                    new vscode.Range(
-                                        position.range.start.line,
-                                        position.range.start.character,
-                                        position.range.end.line,
-                                        position.range.end.character));
-                            }),
-                        ];
-                    }
+                    codeLensToFix.command.arguments = [
+                        vscode.Uri.parse(oldArgs[0]),
+                        new vscode.Position(oldArgs[1].line, oldArgs[1].character),
+                        oldArgs[2].map((position) => {
+                            return new vscode.Location(
+                                vscode.Uri.parse(position.uri),
+                                new vscode.Range(
+                                    position.range.start.line,
+                                    position.range.start.character,
+                                    position.range.end.line,
+                                    position.range.end.character));
+                        }),
+                    ];
+                }
 
-                    return codeLensToFix;
-                };
+                return codeLensToFix;
+            };
 
-            if ((resolvedCodeLens as Thenable<vscode.CodeLens>).then) {
-                return (resolvedCodeLens as Thenable<vscode.CodeLens>).then(resolveFunc);
-            } else if (resolvedCodeLens as vscode.CodeLens) {
-                return resolveFunc(resolvedCodeLens as vscode.CodeLens);
-            }
+        if ((resolvedCodeLens as Thenable<vscode.CodeLens>).then) {
+            return (resolvedCodeLens as Thenable<vscode.CodeLens>).then(resolveFunc);
+        } else if (resolvedCodeLens as vscode.CodeLens) {
+            return resolveFunc(resolvedCodeLens as vscode.CodeLens);
+        }
 
-            return resolvedCodeLens;
+        return resolvedCodeLens;
     }
 
     // Move old setting codeFormatting.whitespaceAroundPipe to new setting codeFormatting.addWhitespaceAroundPipe
@@ -440,9 +428,9 @@ export class SessionManager implements Middleware {
                 this.sessionSettings.cwd.toLowerCase() ||
                 settings.powerShellDefaultVersion.toLowerCase() !==
                 this.sessionSettings.powerShellDefaultVersion.toLowerCase() ||
-             settings.developer.editorServicesLogLevel.toLowerCase() !==
+            settings.developer.editorServicesLogLevel.toLowerCase() !==
                 this.sessionSettings.developer.editorServicesLogLevel.toLowerCase() ||
-             settings.developer.bundledModulesPath.toLowerCase() !==
+            settings.developer.bundledModulesPath.toLowerCase() !==
                 this.sessionSettings.developer.bundledModulesPath.toLowerCase() ||
             settings.integratedConsole.useLegacyReadLine !==
                 this.sessionSettings.integratedConsole.useLegacyReadLine)) {
@@ -451,9 +439,9 @@ export class SessionManager implements Middleware {
                 "The PowerShell runtime configuration has changed, would you like to start a new session?",
                 "Yes", "No");
 
-                    if (response === "Yes") {
-                        await this.restartSession();
-                    }
+            if (response === "Yes") {
+                await this.restartSession();
+            }
         }
     }
 
@@ -567,7 +555,7 @@ export class SessionManager implements Middleware {
                             "connect",
                             () => {
                                 this.log.write("Language service connected.");
-                                resolve({writer: socket, reader: socket});
+                                resolve({ writer: socket, reader: socket });
                             });
                     });
             };
@@ -576,7 +564,7 @@ export class SessionManager implements Middleware {
                 documentSelector: this.documentSelector,
                 synchronize: {
                     // backend uses "files" and "search" to ignore references.
-                    configurationSection: [ utils.PowerShellLanguageId, "files", "search" ],
+                    configurationSection: [utils.PowerShellLanguageId, "files", "search"],
                     // fileEvents: vscode.workspace.createFileSystemWatcher('**/.eslintrc')
                 },
                 // NOTE: Some settings are only applicable on startup, so we send them during initialization.
@@ -819,8 +807,8 @@ export class SessionManager implements Middleware {
             case SessionStatus.NeverStarted:
             case SessionStatus.Stopping:
                 const currentPowerShellExe =
-                availablePowerShellExes
-                    .find((item) => item.displayName.toLowerCase() === this.PowerShellExeDetails.displayName.toLowerCase());
+                    availablePowerShellExes
+                        .find((item) => item.displayName.toLowerCase() === this.PowerShellExeDetails.displayName.toLowerCase());
 
                 const powerShellSessionName =
                     currentPowerShellExe ?
@@ -887,7 +875,7 @@ class SessionMenuItem implements vscode.QuickPickItem {
     constructor(
         public readonly label: string,
         // tslint:disable-next-line:no-empty
-        public readonly callback: () => void = () => {}) {
+        public readonly callback: () => void = () => { }) {
     }
 }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -424,8 +424,8 @@ export class SessionManager implements Middleware {
 
         // Detect any setting changes that would affect the session
         if (!this.suppressRestartPrompt &&
-            (settings.cwd.toLowerCase() !==
-                this.sessionSettings.cwd.toLowerCase() ||
+            (settings.cwd?.toLowerCase() !==
+                this.sessionSettings.cwd?.toLowerCase() ||
                 settings.powerShellDefaultVersion.toLowerCase() !==
                 this.sessionSettings.powerShellDefaultVersion.toLowerCase() ||
             settings.developer.editorServicesLogLevel.toLowerCase() !==

--- a/src/session.ts
+++ b/src/session.ts
@@ -56,6 +56,8 @@ export class SessionManager implements Middleware {
     private languageServerClient: LanguageClient = undefined;
     private sessionSettings: Settings.ISettings = undefined;
     private sessionDetails: utils.IEditorServicesSessionDetails;
+    private sessionsFolder = path.resolve(__dirname, "../sessions");
+    private sessionFilePathPrefix = path.resolve(this.sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID);
     private bundledModulesPath: string;
     private started: boolean = false;
 
@@ -259,6 +261,14 @@ export class SessionManager implements Middleware {
         return this.versionDetails;
     }
 
+    private getSessionFilePath(uniqueId: number): string {
+        return `${this.sessionFilePathPrefix}-${uniqueId}`;
+    }
+
+    public getDebugSessionFilePath(): string {
+        return `${this.sessionFilePathPrefix}-Debug`;
+    }
+
     public createDebugSessionProcess(
         sessionPath: string,
         sessionSettings: Settings.ISettings): PowerShellProcess {
@@ -446,7 +456,7 @@ export class SessionManager implements Middleware {
         this.setSessionStatus("Starting...", SessionStatus.Initializing);
 
         const sessionFilePath =
-            utils.getSessionFilePath(
+            this.getSessionFilePath(
                 Math.floor(100000 + Math.random() * 900000));
 
         this.languageServerProcess =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,19 +10,6 @@ import vscode = require("vscode");
 
 export const PowerShellLanguageId = "powershell";
 
-export function ensurePathExists(targetPath: string): void {
-    // Ensure that the path exists
-    try {
-        // TODO: Use vscode.workspace.fs
-        fs.mkdirSync(targetPath);
-    } catch (e) {
-        // If the exception isn't to indicate that the folder exists already, rethrow it.
-        if (e.code !== "EEXIST") {
-            throw e;
-        }
-    }
-}
-
 // Check that the file exists in an asynchronous manner that relies solely on the VS Code API, not Node's fs library.
 export async function fileExists(targetPath: string | vscode.Uri): Promise<boolean> {
     try {
@@ -67,9 +54,6 @@ export type IReadSessionFileCallback = (details: IEditorServicesSessionDetails) 
 const sessionsFolder = path.resolve(__dirname, "../sessions");
 const sessionFilePathPrefix = path.resolve(sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID);
 
-// Create the sessions path if it doesn't exist already
-ensurePathExists(sessionsFolder);
-
 export function getSessionFilePath(uniqueId: number) {
     return `${sessionFilePathPrefix}-${uniqueId}`;
 }
@@ -78,8 +62,8 @@ export function getDebugSessionFilePath() {
     return `${sessionFilePathPrefix}-Debug`;
 }
 
-export function writeSessionFile(sessionFilePath: string, sessionDetails: IEditorServicesSessionDetails) {
-    ensurePathExists(sessionsFolder);
+export async function writeSessionFile(sessionFilePath: string, sessionDetails: IEditorServicesSessionDetails) {
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(sessionsFolder));
 
     const writeStream = fs.createWriteStream(sessionFilePath);
     writeStream.write(JSON.stringify(sessionDetails));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,15 +52,6 @@ export interface IEditorServicesSessionDetails {
 export type IReadSessionFileCallback = (details: IEditorServicesSessionDetails) => void;
 
 const sessionsFolder = path.resolve(__dirname, "../sessions");
-const sessionFilePathPrefix = path.resolve(sessionsFolder, "PSES-VSCode-" + process.env.VSCODE_PID);
-
-export function getSessionFilePath(uniqueId: number) {
-    return `${sessionFilePathPrefix}-${uniqueId}`;
-}
-
-export function getDebugSessionFilePath() {
-    return `${sessionFilePathPrefix}-Debug`;
-}
 
 export async function writeSessionFile(sessionFilePath: string, sessionDetails: IEditorServicesSessionDetails) {
     await vscode.workspace.fs.createDirectory(vscode.Uri.file(sessionsFolder));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,44 +37,6 @@ export function getPipePath(pipeName: string) {
     }
 }
 
-export interface IEditorServicesSessionDetails {
-    status: string;
-    reason: string;
-    detail: string;
-    powerShellVersion: string;
-    channel: string;
-    languageServicePort: number;
-    debugServicePort: number;
-    languageServicePipeName: string;
-    debugServicePipeName: string;
-}
-
-export type IReadSessionFileCallback = (details: IEditorServicesSessionDetails) => void;
-
-const sessionsFolder = path.resolve(__dirname, "../sessions");
-
-export async function writeSessionFile(sessionFilePath: string, sessionDetails: IEditorServicesSessionDetails) {
-    await vscode.workspace.fs.createDirectory(vscode.Uri.file(sessionsFolder));
-
-    const writeStream = fs.createWriteStream(sessionFilePath);
-    writeStream.write(JSON.stringify(sessionDetails));
-    writeStream.close();
-}
-
-
-export function readSessionFile(sessionFilePath: string): IEditorServicesSessionDetails {
-    const fileContents = fs.readFileSync(sessionFilePath, "utf-8");
-    return JSON.parse(fileContents);
-}
-
-export function deleteSessionFile(sessionFilePath: string) {
-    try {
-        fs.unlinkSync(sessionFilePath);
-    } catch (e) {
-        // TODO: Be more specific about what we're catching
-    }
-}
-
 export function checkIfFileExists(filePath: string): boolean {
     try {
         fs.accessSync(filePath, fs.constants.R_OK);

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -23,7 +23,7 @@ describe("Path assumptions", function () {
     });
 
     it("Creates the session folder at the correct path", function () {
-        assert(fs.existsSync(path.resolve(utils.rootPath, "sessions")));
+        assert(fs.existsSync(vscode.Uri.joinPath(storageUri, "sessions").fsPath));
     });
 
     it("Creates the log folder at the correct path", function () {


### PR DESCRIPTION
This is a decent cleanup of our session file logic in the client, so it needs a close review. Most important note is that I completely removed `writeSessionFile`...and everything works as expected in my testing. Which I think makes sense, as we pass the session file path to the server and expect it to write the session file. I don't know why we had the client ever writing a session file. Furthermore, the only reference I can find to it in the server is with a writer, no reader. 🤷

Related to https://github.com/PowerShell/vscode-powershell/pull/4071.