### PR TITLE
Update and extend CI matrix

### DIFF
--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -8,11 +8,6 @@ variables:
   - name: DOTNET_CLI_TELEMETRY_OPTOUT
     value: 'true'
 
-trigger:
-  branches:
-    include:
-      - main
-
 resources:
   repositories:
   - repository: PowerShellEditorServices
@@ -22,8 +17,24 @@ resources:
     ref: main
 
 jobs:
-- job: PS51_Win2019
-  displayName: PowerShell 5.1 - Windows Server 2019
+- job: windows2022
+  displayName: Windows 2022 PowerShell 5.1
+  pool:
+    vmImage: windows-2022
+  steps:
+  - template: templates/ci-general.yml
+    parameters:
+      pwsh: false
+
+- job: windows2022pwsh
+  displayName: Windows 2022 PowerShell 7
+  pool:
+    vmImage: windows-2022
+  steps:
+  - template: templates/ci-general.yml
+
+- job: windows2019
+  displayName: Windows 2019 PowerShell 5.1
   pool:
     vmImage: windows-2019
   steps:
@@ -31,22 +42,22 @@ jobs:
     parameters:
       pwsh: false
 
-- job: PS7_Win2019
-  displayName: PowerShell 7 - Windows Server 2019
+- job: windows2019pwsh
+  displayName: Windows 2019 PowerShell 7
   pool:
     vmImage: windows-2019
   steps:
   - template: templates/ci-general.yml
 
-- job: PS7_macOS
-  displayName: PowerShell 7 - macOS 10.15
+- job: macOS11
+  displayName: macOS 11
   pool:
-    vmImage: macOS-10.15
+    vmImage: macOS-11
   steps:
   - template: templates/ci-general.yml
 
-- job: PS7_Ubuntu
-  displayName: PowerShell 7 - Ubuntu 20.04
+- job: ubuntu2004
+  displayName: Ubuntu 20.04
   pool:
     vmImage: ubuntu-20.04
   steps:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,10 @@ The extension _should_ work anywhere VS Code itself and PowerShell Core 7 or hig
 PowerShell Core 6 is end-of-life and so not supported. Our test matrix includes the
 following:
 
-- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.2.4
-- **macOS 10.15** with PowerShell Core 7.2.5
-- **Ubuntu 20.04** with PowerShell Core 7.2.4
+- **Windows Server 2022** with Windows PowerShell 5.1 and PowerShell Core 7.2.5
+- **Windows Server 2019** with Windows PowerShell 5.1 and PowerShell Core 7.2.5
+- **macOS 11** with PowerShell Core 7.2.5
+- **Ubuntu 20.04** with PowerShell Core 7.2.5
 
 [supported]: https://docs.microsoft.com/en-us/powershell/scripting/powershell-support-lifecycle
 


### PR DESCRIPTION
Now includes Windows Server 2022 and macOS 11 Big Sur.

Necessary per https://github.com/actions/virtual-environments/issues/5583.