### PR TITLE
Rename "Integrated Console" to "Extension Terminal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ to get more details on how to use the extension on these platforms.
 - Run selected selection of PowerShell code using <kbd>F8</kbd>
 - Launch online help for the symbol under the cursor using <kbd>Ctrl</kbd>+<kbd>F1</kbd>
 - Local script debugging
-- Integrated console support
+- Extension Terminal support
 - PowerShell ISE color theme
 
 ## Installing the Extension

--- a/docs/azure_data_studio/README_FOR_MARKETPLACE.md
+++ b/docs/azure_data_studio/README_FOR_MARKETPLACE.md
@@ -51,7 +51,7 @@ to get more details on how to use the extension on these platforms.
 - Run selected selection of PowerShell code using <kbd>F8</kbd>
 - Launch online help for the symbol under the cursor using <kbd>Ctrl</kbd>+<kbd>F1</kbd>
 - Local script debugging
-- Integrated console support
+- Extension Terminal support
 - PowerShell ISE color theme
 
 ## Installing the Extension

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,12 +39,12 @@ message starts with `[PSScriptAnalyzer]` or if you are getting faulty script dia
 ## Completions aren't appearing
 
 First, please ensure that the extension itself has properly started. Do this by opening
-the PowerShell Integrated Console and checking the value of the variable `$psEditor`,
+the PowerShell Extension Terminal and checking the value of the variable `$psEditor`,
 it should return a version and other fields. If it does not, you're probably in a
-different "PowerShell" terminal in VS Code, and not the extension's integrated console.
+different "PowerShell" terminal in VS Code, and not the PowerShell Extension Terminal.
 So please open a bug about your extension failing to start instead.
 
-If the extension _is_ started and the PSIC functional, completions should appear! Please
+If the extension _is_ started and the Extension Terminal functional, completions should appear! Please
 double-check that your `editor.suggest.showFunctions` VS Code setting is `true`, as
 setting it to `false` _will_ disable completions (from all extensions). You may also want
 to check other related settings under "Text Editor -> Suggestions" in VS Code.
@@ -308,7 +308,7 @@ these messages. To do this:
 
 ### Visual Studio Code version
 
-[Your VS Code version][] can be obtained from the Integrated Console or any terminal:
+[Your VS Code version][] can be obtained from the Extension Terminal or any terminal:
 
 ```powershell
 code --version
@@ -353,7 +353,7 @@ Extensions` and list your extensions.
 
 ### Editor Services version
 
-To get the [PowerShell Editor Services][] version, in the Integrated Console, enter:
+To get the [PowerShell Editor Services][] version, in the Extension Terminal, enter:
 
 ```powershell
 > $psEditor.EditorServicesVersion
@@ -364,7 +364,7 @@ Major  Minor  Build  Revision
 
 ### PowerShell version table
 
-You can get [your PowerShell version table][] from the Integrated Console through the
+You can get [your PowerShell version table][] from the Extension Terminal through the
 variable `$PSVersionTable`:
 
 ```powershell

--- a/package.json
+++ b/package.json
@@ -233,7 +233,7 @@
       },
       {
         "command": "PowerShell.ShowSessionConsole",
-        "title": "Show Integrated Console",
+        "title": "Show Extension Terminal",
         "category": "PowerShell"
       },
       {
@@ -447,7 +447,7 @@
           },
           {
             "label": "PowerShell: Interactive Session",
-            "description": "Debug commands executed from the Integrated Console",
+            "description": "Debug commands executed from the Extension Terminal",
             "body": {
               "name": "PowerShell Interactive Session",
               "type": "PowerShell",
@@ -498,7 +498,7 @@
               },
               "createTemporaryIntegratedConsole": {
                 "type": "boolean",
-                "description": "Determines whether a temporary PowerShell Integrated Console is created for each debugging session, useful for debugging PowerShell classes and binary modules.  Overrides the user setting 'powershell.debugging.createTemporaryIntegratedConsole'.",
+                "description": "Determines whether a temporary PowerShell Extension Terminal is created for each debugging session, useful for debugging PowerShell classes and binary modules.  Overrides the user setting 'powershell.debugging.createTemporaryIntegratedConsole'.",
                 "default": false
               }
             }
@@ -597,7 +597,7 @@
         "powershell.startAutomatically": {
           "type": "boolean",
           "default": true,
-          "description": "Starts PowerShell extension features automatically when a PowerShell file opens. If false, to start the extension, use the 'PowerShell: Restart Current Session' command. IntelliSense, code navigation, integrated console, code formatting, and other features are not enabled until the extension starts."
+          "description": "Starts PowerShell extension features automatically when a PowerShell file opens. If false, to start the extension, use the 'PowerShell: Restart Current Session' command. IntelliSense, code navigation, Extension Terminal, code formatting, and other features are not enabled until the extension starts."
         },
         "powershell.useX86Host": {
           "type": "boolean",
@@ -628,7 +628,7 @@
         "powershell.cwd": {
           "type": "string",
           "default": null,
-          "description": "An explicit start path where the Powershell Integrated Console will be launched. Both the PowerShell process and the shell's location will be set to this directory. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
+          "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process and the shell's location will be set to this directory. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
         },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",
@@ -761,7 +761,7 @@
         "powershell.integratedConsole.showOnStartup": {
           "type": "boolean",
           "default": true,
-          "description": "Shows the integrated console when the PowerShell extension is initialized."
+          "description": "Shows the Extension Terminal when the PowerShell extension is initialized."
         },
         "powershell.integratedConsole.focusConsoleOnExecute": {
           "type": "boolean",
@@ -771,7 +771,7 @@
         "powershell.integratedConsole.useLegacyReadLine": {
           "type": "boolean",
           "default": false,
-          "description": "Falls back to the legacy (lightweight) ReadLine experience. This will disable the use of PSReadLine in the PowerShell Integrated Console."
+          "description": "Falls back to the legacy ReadLine experience. This will disable the use of PSReadLine in the PowerShell Extension Terminal."
         },
         "powershell.integratedConsole.forceClearScrollbackBuffer": {
           "type": "boolean",
@@ -780,12 +780,12 @@
         "powershell.integratedConsole.suppressStartupBanner": {
           "type": "boolean",
           "default": false,
-          "description": "Do not show the Powershell Integrated Console banner on launch"
+          "description": "Do not show the Powershell Extension Terminal banner on launch"
         },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",
           "default": false,
-          "description": "Determines whether a temporary PowerShell Integrated Console is created for each debugging session, useful for debugging PowerShell classes and binary modules."
+          "description": "Determines whether a temporary PowerShell Extension Terminal is created for each debugging session. Useful for debugging PowerShell classes and binary modules."
         },
         "powershell.developer.bundledModulesPath": {
           "type": "string",

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -207,8 +207,8 @@ export class ConsoleFeature extends LanguageClientConsumer {
             vscode.commands.registerCommand("PowerShell.RunSelection", async () => {
 
                 if (vscode.window.activeTerminal &&
-                    vscode.window.activeTerminal.name !== "PowerShell Integrated Console") {
-                    this.log.write("PSIC is not active terminal. Running in active terminal using 'runSelectedText'");
+                    vscode.window.activeTerminal.name !== "PowerShell Extension") {
+                    this.log.write("PowerShell Extension Terminal is not active! Running in current terminal using 'runSelectedText'");
                     await vscode.commands.executeCommand("workbench.action.terminal.runSelectedText");
 
                     // We need to honor the focusConsoleOnExecute setting here too. However, the boolean that `show`
@@ -236,7 +236,7 @@ export class ConsoleFeature extends LanguageClientConsumer {
                     expression: editor.document.getText(selectionRange),
                 });
 
-                // Show the integrated console if it isn't already visible and
+                // Show the Extension Terminal if it isn't already visible and
                 // scroll terminal to bottom so new output is visible
                 await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
                 await vscode.commands.executeCommand("workbench.action.terminal.scrollToBottom");

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -91,7 +91,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
             {
                 id: DebugConfig.InteractiveSession,
                 label: "Interactive Session",
-                description: "Debug commands executed from the Integrated Console",
+                description: "Debug commands executed from the PowerShell Extension Terminal",
             },
             {
                 id: DebugConfig.AttachHostProcess,
@@ -230,7 +230,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
                         : currentDocument.fileName;
 
             } else {
-                // If the non-temp integrated console is being used, default to the current working dir.
+                // If the non-temp Extension Terminal is being used, default to the current working dir.
                 config.cwd = "";
             }
         }
@@ -450,7 +450,7 @@ export class PickPSHostProcessFeature extends LanguageClientConsumer {
         // Start with the current PowerShell process in the list.
         const items: IProcessItem[] = [{
             label: "Current",
-            description: "The current PowerShell Integrated Console process.",
+            description: "The current PowerShell Extension process.",
             pid: "current",
         }];
         for (const p in hostProcesses) {

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -149,7 +149,7 @@ export async function InvokePowerShellUpdateCheck(
                     await streamPipeline(res.body, fs.createWriteStream(msiDownloadPath));
                 });
 
-                // Stop the Integrated Console session because Windows likes to hold on to files.
+                // Stop the session because Windows likes to hold on to files.
                 sessionManager.stop();
 
                 // Close all terminals with the name "pwsh" in the current VS Code session.
@@ -165,7 +165,7 @@ export async function InvokePowerShellUpdateCheck(
                 const msi = spawn("msiexec", ["/i", msiDownloadPath]);
 
                 msi.on("close", async () => {
-                    // Now that the MSI is finished, start the Integrated Console session.
+                    // Now that the MSI is finished, restart the session.
                     await sessionManager.start();
                     fs.unlinkSync(msiDownloadPath);
                 });

--- a/src/process.ts
+++ b/src/process.ts
@@ -124,7 +124,7 @@ export class PowerShellProcess {
         this.log.write(`${pwshName} started.`);
 
         if (this.sessionSettings.integratedConsole.showOnStartup) {
-            // We still need to run this to set the active terminal to the Integrated Console.
+            // We still need to run this to set the active terminal to the extension terminal.
             this.consoleTerminal.show(true);
         }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -220,7 +220,7 @@ export class SessionManager implements Middleware {
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
         } else {
-            const startupBanner = `=====> ${this.HostName} Integrated Console v${this.HostVersion} <=====
+            const startupBanner = `=====> ${this.HostName} Extension v${this.HostVersion} <=====
 `;
             this.editorServicesArgs += `-StartupBanner '${startupBanner}' `;
         }
@@ -291,7 +291,7 @@ export class SessionManager implements Middleware {
 
     public createDebugSessionProcess(sessionSettings: Settings.ISettings): PowerShellProcess {
 
-        // NOTE: We only support one temporary integrated console at a time. To
+        // NOTE: We only support one temporary Extension Terminal at a time. To
         // support more, we need to track each separately, and tie the session
         // for the event handler to the right process (and dispose of the event
         // handler when the process is disposed).
@@ -304,14 +304,14 @@ export class SessionManager implements Middleware {
             new PowerShellProcess(
                 this.PowerShellExeDetails.exePath,
                 this.bundledModulesPath,
-                "[TEMP] PowerShell Integrated Console",
+                "[TEMP] PowerShell Extension",
                 this.log,
                 this.editorServicesArgs + "-DebugServiceOnly ",
                 this.getNewSessionFilePath(),
                 sessionSettings);
 
-        // Similar to the regular integrated console, we need to send a key
-        // press to the process spawned for temporary integrated consoles when
+        // Similar to the regular Extension Terminal, we need to send a key
+        // press to the process spawned for temporary Extension Terminals when
         // the server requests a cancellation os Console.ReadKey.
         this.debugEventHandler = vscode.debug.onDidReceiveDebugSessionCustomEvent(
             e => {
@@ -477,7 +477,7 @@ export class SessionManager implements Middleware {
             new PowerShellProcess(
                 this.PowerShellExeDetails.exePath,
                 this.bundledModulesPath,
-                "PowerShell Integrated Console",
+                "PowerShell Extension",
                 this.log,
                 this.editorServicesArgs,
                 this.getNewSessionFilePath(),
@@ -532,7 +532,7 @@ export class SessionManager implements Middleware {
 
     private async promptForRestart() {
         const response: string = await vscode.window.showErrorMessage(
-            "The PowerShell Integrated Console (PSIC) has stopped, would you like to restart it? (IntelliSense will not work unless the PSIC is active and unblocked.)",
+            "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
             "Yes", "No");
 
         if (response === "Yes") {

--- a/src/session.ts
+++ b/src/session.ts
@@ -220,9 +220,13 @@ export class SessionManager implements Middleware {
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
         } else {
-            const startupBanner = `=====> ${this.HostName} Extension v${this.HostVersion} <=====
+            const startupBanner = `${this.HostName} Extension v${this.HostVersion}
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
 `;
-            this.editorServicesArgs += `-StartupBanner '${startupBanner}' `;
+            this.editorServicesArgs += `-StartupBanner "${startupBanner}" `;
         }
 
         if (this.sessionSettings.developer.editorServicesWaitForDebugger) {

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -82,7 +82,7 @@ function Get-Bullets {
             'Area-Documentation'        = '📖'
             'Area-Engine'               = '🚂'
             'Area-Folding'              = '📚'
-            'Area-Integrated Console'   = '📟'
+            'Area-Extension Terminal'   = '📟'
             'Area-IntelliSense'         = '🧠'
             'Area-Logging'              = '💭'
             'Area-Pester'               = '🐢'


### PR DESCRIPTION
Resolves https://github.com/PowerShell/vscode-powershell/issues/4053.