### PR TITLE
Change `storageUri` to `globalStorageUri` for log and session files

### DIFF
--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -168,7 +168,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
     }
 
     public getStorageUri(): vscode.Uri {
-        return this.extensionContext.storageUri;
+        return this.extensionContext.globalStorageUri;
     }
 
     public dispose() {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -39,13 +39,7 @@ export class Logger implements ILogger {
 
     constructor(logBasePath: vscode.Uri) {
         this.logChannel = vscode.window.createOutputChannel("PowerShell Extension Logs");
-
-        if (logBasePath === undefined) {
-            // No workspace, we have to use another folder.
-            this.logBasePath = vscode.Uri.file(path.resolve(__dirname, "../logs"));
-        } else {
-            this.logBasePath = vscode.Uri.joinPath(logBasePath, "logs");
-        }
+        this.logBasePath = vscode.Uri.joinPath(logBasePath, "logs");
 
         this.commands = [
             vscode.commands.registerCommand(

--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         });
 
     // Setup the logger.
-    logger = new Logger(context.storageUri);
+    logger = new Logger(context.globalStorageUri);
     logger.MinimumLogLevel = LogLevel[extensionSettings.developer.editorServicesLogLevel];
 
     sessionManager =

--- a/src/session.ts
+++ b/src/session.ts
@@ -88,11 +88,7 @@ export class SessionManager implements Middleware {
         private telemetryReporter: TelemetryReporter) {
 
         // Create a folder for the session files.
-        if (extensionContext.storageUri !== undefined) {
-            this.sessionsFolder = vscode.Uri.joinPath(extensionContext.storageUri, "sessions");
-        } else {
-            this.sessionsFolder = vscode.Uri.file(path.resolve(__dirname, "../sessions"));
-        }
+        this.sessionsFolder = vscode.Uri.joinPath(extensionContext.globalStorageUri, "sessions");
         vscode.workspace.fs.createDirectory(this.sessionsFolder);
 
         this.platformDetails = getPlatformDetails();

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -9,10 +9,10 @@ import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import utils = require("../utils");
 
 describe("Path assumptions", function () {
-    let storageUri: vscode.Uri;
+    let globalStorageUri: vscode.Uri;
     before(async () => {
         const extension: IPowerShellExtensionClient = await utils.ensureEditorServicesIsConnected();
-        storageUri = extension.getStorageUri();
+        globalStorageUri = extension.getStorageUri();
     });
 
     // TODO: This is skipped because it interferes with other tests. Either
@@ -23,10 +23,10 @@ describe("Path assumptions", function () {
     });
 
     it("Creates the session folder at the correct path", function () {
-        assert(fs.existsSync(vscode.Uri.joinPath(storageUri, "sessions").fsPath));
+        assert(fs.existsSync(vscode.Uri.joinPath(globalStorageUri, "sessions").fsPath));
     });
 
     it("Creates the log folder at the correct path", function () {
-        assert(fs.existsSync(vscode.Uri.joinPath(storageUri, "logs").fsPath));
+        assert(fs.existsSync(vscode.Uri.joinPath(globalStorageUri, "logs").fsPath));
     });
 });


### PR DESCRIPTION
Instead of being workspace specific, as the extension itself is not. Also no chance of it being undefined.