### PR TITLE
Don't hide extension terminal entirely

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -109,7 +109,6 @@ export class PowerShellProcess {
             shellPath: this.exePath,
             shellArgs: powerShellArgs,
             cwd: this.sessionSettings.cwd,
-            hideFromUser: !this.sessionSettings.integratedConsole.showOnStartup,
             iconPath: new vscode.ThemeIcon("terminal-powershell"),
         };
 


### PR DESCRIPTION
When `showOnStartup` is false, we currently completely hide the terminal from the user via an API that essentially backgrounds the terminal. This was in response to a user request, but has caused more problems than it's worth. This PR reverts the behavior so that it simply won't show the terminal pane on startup, but opening it reveals the connected extension terminal.

This resolves https://github.com/PowerShell/vscode-powershell/issues/2523 and https://github.com/PowerShell/vscode-powershell/issues/3918, and reverts https://github.com/PowerShell/vscode-powershell/pull/2437 which was a response to https://github.com/PowerShell/vscode-powershell/issues/2434. However, we've decided that behavior is undesirable.

Future work: we're going to flight switching the default of `showOnStartup`, and add to the upcoming PowerShell Walkthrough a step which shows how to re-enable it.