### PR TITLE
Fix `checkIfDirectoryExists()` so `validateCwdSetting()` works

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -212,7 +212,7 @@ export class PowerShellProcess {
 
         // Check every 2 seconds
         for (let i = numOfTries; i > 0; i--) {
-            if (utils.checkIfFileExists(this.sessionFilePath.fsPath)) {
+            if (await utils.checkIfFileExists(this.sessionFilePath)) {
                 this.log.write("Session file found");
                 const sessionDetails = PowerShellProcess.readSessionFile(this.sessionFilePath);
                 PowerShellProcess.deleteSessionFile(this.sessionFilePath);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -317,7 +317,7 @@ export async function validateCwdSetting(): Promise<string> {
     let cwd: string = vscode.workspace.getConfiguration(utils.PowerShellLanguageId).get<string>("cwd", null);
 
     // Only use the cwd setting if it exists.
-    if (utils.checkIfDirectoryExists(cwd)) {
+    if (await utils.checkIfDirectoryExists(cwd)) {
         return cwd;
     } else {
         // Otherwise use a workspace folder, prompting if necessary.
@@ -333,7 +333,7 @@ export async function validateCwdSetting(): Promise<string> {
         }
         // If there were no workspace folders, or somehow they don't exist, use
         // the home directory.
-        if (cwd === undefined || !utils.checkIfDirectoryExists(cwd)) {
+        if (cwd === undefined || !await utils.checkIfDirectoryExists(cwd)) {
             return os.homedir();
         }
         return cwd;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,20 +37,19 @@ export function getPipePath(pipeName: string) {
     }
 }
 
-export function checkIfFileExists(filePath: string): boolean {
+export async function checkIfFileExists(filePath: vscode.Uri): Promise<boolean> {
     try {
-        fs.accessSync(filePath, fs.constants.R_OK);
-        return true;
+        const stat: vscode.FileStat = await vscode.workspace.fs.stat(filePath);
+        return stat.type === vscode.FileType.File;
     } catch (e) {
         return false;
     }
 }
 
-export function checkIfDirectoryExists(directoryPath: string): boolean {
+export async function checkIfDirectoryExists(directoryPath: string): Promise<boolean> {
     try {
-        // tslint:disable-next-line:no-bitwise
-        fs.accessSync(directoryPath, fs.constants.R_OK | fs.constants.O_DIRECTORY);
-        return true;
+        const stat: vscode.FileStat = await vscode.workspace.fs.stat(vscode.Uri.file(directoryPath));
+        return stat.type === vscode.FileType.Directory;
     } catch (e) {
         return false;
     }


### PR DESCRIPTION
Oops, Node APIs are weird. Moved to VS Code APIs.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4098.