### PR TITLE
Always Base64 encode the startup command to avoid quoting issues

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -83,16 +83,10 @@ export class PowerShellProcess {
             PowerShellProcess.escapeSingleQuotes(psesModulePath) +
             "'; Start-EditorServices " + this.startPsesArgs;
 
-        if (utils.isWindows) {
-            powerShellArgs.push(
-                "-Command",
-                startEditorServices);
-        } else {
-            // Use -EncodedCommand for better quote support on non-Windows
-            powerShellArgs.push(
-                "-EncodedCommand",
-                Buffer.from(startEditorServices, "utf16le").toString("base64"));
-        }
+        // Use -EncodedCommand to avoid quoting issues
+        powerShellArgs.push(
+            "-EncodedCommand",
+            Buffer.from(startEditorServices, "utf16le").toString("base64"));
 
         this.log.write(
             "Language server starting --",


### PR DESCRIPTION
We already did this for non-Windows and it works great to avoid issues with quoting the server startup command. Let's do it on Windows too because some installations of PowerShell (specifically through the `dotnet` global tool) also have quote issues that became apparent with a multi-line startup banner.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4111.