### PR TITLE
fixes #4119

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -94,7 +94,7 @@
       "do {",
       "\t${0:$TM_SELECTED_TEXT}",
       "} while (",
-      "\t${1:<# Condition that stops the loop if it returns false #>})",
+      "\t${1:<# Condition that stops the loop if it returns false #>}",
       ")"
     ]
   },


### PR DESCRIPTION
Removes extraneous `)` from the do-while powershell snippet

## PR Summary

Removes extraneous `)` from the do-while powershell snippet

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x ] PR has a meaningful title
- [x ] Summarized changes
- [ ] PR has tests N/A
- [x ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
