### PR TITLE
Use `vscode.workspace.fs` and suppress startup banner for `dotnet` installs of PowerShell

### DIFF
--- a/src/features/Examples.ts
+++ b/src/features/Examples.ts
@@ -15,7 +15,7 @@ export class ExamplesFeature implements vscode.Disposable {
             vscode.commands.executeCommand("vscode.openFolder", this.examplesPath, true);
             // Return existence of the path for testing. The `vscode.openFolder`
             // command should do this, but doesn't (yet).
-            return utils.fileExists(this.examplesPath);
+            return utils.checkIfFileExists(this.examplesPath);
         });
     }
 

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -134,7 +134,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         //
         // Ensure the necessary script exists (for testing). The debugger will
         // start regardless, but we also pass its success along.
-        return utils.fileExists(this.invokePesterStubScriptPath)
+        return utils.checkIfFileExists(this.invokePesterStubScriptPath)
             && vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);
     }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -38,6 +38,7 @@ export interface IPlatformDetails {
 export interface IPowerShellExeDetails {
     readonly displayName: string;
     readonly exePath: string;
+    readonly supportsProperArguments: boolean;
 }
 
 export function getPlatformDetails(): IPlatformDetails {
@@ -266,6 +267,7 @@ export class PowerShellExeFinder {
 
         const dotnetGlobalToolExePath: string = path.join(os.homedir(), ".dotnet", "tools", exeName);
 
+        // The dotnet installed version of PowerShell does not support proper argument parsing, and so it fails with our multi-line startup banner.
         return new PossiblePowerShellExe(dotnetGlobalToolExePath, ".NET Core PowerShell Global Tool", undefined, false);
     }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,7 +6,9 @@ import * as os from "os";
 import * as path from "path";
 import * as process from "process";
 import { IPowerShellAdditionalExePathSettings } from "./settings";
-import { checkIfFileExists, checkIfDirectoryExists } from "./utils";
+// This uses require so we can rewire it in unit tests!
+// tslint:disable-next-line:no-var-requires
+const utils = require("./utils")
 
 const WindowsPowerShell64BitLabel = "Windows PowerShell (x64)";
 const WindowsPowerShell32BitLabel = "Windows PowerShell (x86)";
@@ -276,7 +278,7 @@ export class PowerShellExeFinder {
         // Find the base directory for MSIX application exe shortcuts
         const msixAppDir = path.join(process.env.LOCALAPPDATA, "Microsoft", "WindowsApps");
 
-        if (!await checkIfDirectoryExists(msixAppDir)) {
+        if (!await utils.checkIfDirectoryExists(msixAppDir)) {
             return null;
         }
 
@@ -319,7 +321,7 @@ export class PowerShellExeFinder {
         const powerShellInstallBaseDir = path.join(programFilesPath, "PowerShell");
 
         // Ensure the base directory exists
-        if (!await checkIfDirectoryExists(powerShellInstallBaseDir)) {
+        if (!await utils.checkIfDirectoryExists(powerShellInstallBaseDir)) {
             return null;
         }
 
@@ -365,7 +367,7 @@ export class PowerShellExeFinder {
 
             // Now look for the file
             const exePath = path.join(powerShellInstallBaseDir, item, "pwsh.exe");
-            if (!await checkIfFileExists(exePath)) {
+            if (!await utils.checkIfFileExists(exePath)) {
                 continue;
             }
 
@@ -491,7 +493,7 @@ class PossiblePowerShellExe implements IPossiblePowerShellExe {
 
     public async exists(): Promise<boolean> {
         if (this.knownToExist === undefined) {
-            this.knownToExist = await checkIfFileExists(this.exePath);
+            this.knownToExist = await utils.checkIfFileExists(this.exePath);
         }
         return this.knownToExist;
     }

--- a/src/process.ts
+++ b/src/process.ts
@@ -9,7 +9,7 @@ import vscode = require("vscode");
 import { Logger } from "./logging";
 import Settings = require("./settings");
 import utils = require("./utils");
-import { IEditorServicesSessionDetails, SessionManager } from "./session";
+import { IEditorServicesSessionDetails } from "./session";
 
 export class PowerShellProcess {
     public static escapeSingleQuotes(psPath: string): string {
@@ -83,12 +83,14 @@ export class PowerShellProcess {
             PowerShellProcess.escapeSingleQuotes(psesModulePath) +
             "'; Start-EditorServices " + this.startPsesArgs;
 
+        // On Windows we unfortunately can't Base64 encode the startup command
+        // because it annoys some poorly implemented anti-virus scanners.
         if (utils.isWindows) {
             powerShellArgs.push(
                 "-Command",
                 startEditorServices);
         } else {
-            // Use -EncodedCommand for better quote support on non-Windows
+            // Otherwise use -EncodedCommand for better quote support.
             powerShellArgs.push(
                 "-EncodedCommand",
                 Buffer.from(startEditorServices, "utf16le").toString("base64"));

--- a/src/session.ts
+++ b/src/session.ts
@@ -215,6 +215,13 @@ export class SessionManager implements Middleware {
 
         if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
             this.editorServicesArgs += "-StartupBanner '' ";
+        } else if (utils.isWindows && !this.PowerShellExeDetails.supportsProperArguments) {
+            // NOTE: On Windows we don't Base64 encode the startup command
+            // because it annoys some poorly implemented anti-virus scanners.
+            // Unfortunately this means that for some installs of PowerShell
+            // (such as through the `dotnet` package manager), we can't include
+            // a multi-line startup banner as the quotes break the command.
+            this.editorServicesArgs += `-StartupBanner '${this.HostName} Extension v${this.HostVersion}' `;
         } else {
             const startupBanner = `${this.HostName} Extension v${this.HostVersion}
 Copyright (c) Microsoft Corporation.

--- a/src/session.ts
+++ b/src/session.ts
@@ -148,9 +148,9 @@ export class SessionManager implements Middleware {
         this.migrateWhitespaceAroundPipeSetting();
 
         try {
-            let powerShellExeDetails;
+            let powerShellExeDetails: IPowerShellExeDetails;
             if (this.sessionSettings.powerShellDefaultVersion) {
-                for (const details of this.powershellExeFinder.enumeratePowerShellInstallations()) {
+                for await (const details of this.powershellExeFinder.enumeratePowerShellInstallations()) {
                     // Need to compare names case-insensitively, from https://stackoverflow.com/a/2140723
                     const wantedName = this.sessionSettings.powerShellDefaultVersion;
                     if (wantedName.localeCompare(details.displayName, undefined, { sensitivity: "accent" }) === 0) {
@@ -161,7 +161,7 @@ export class SessionManager implements Middleware {
             }
 
             this.PowerShellExeDetails = powerShellExeDetails ||
-                this.powershellExeFinder.getFirstAvailablePowerShellInstallation();
+                await this.powershellExeFinder.getFirstAvailablePowerShellInstallation();
 
         } catch (e) {
             this.log.writeError(`Error occurred while searching for a PowerShell executable:\n${e}`);
@@ -463,7 +463,7 @@ Type 'help' to get help.
     private registerCommands(): void {
         this.registeredCommands = [
             vscode.commands.registerCommand("PowerShell.RestartSession", () => { this.restartSession(); }),
-            vscode.commands.registerCommand(this.ShowSessionMenuCommandName, () => { this.showSessionMenu(); }),
+            vscode.commands.registerCommand(this.ShowSessionMenuCommandName, async () => { await this.showSessionMenu(); }),
             vscode.workspace.onDidChangeConfiguration(async () => { await this.onConfigurationUpdated(); }),
             vscode.commands.registerCommand(
                 "PowerShell.ShowSessionConsole", (isExecute?: boolean) => { this.showSessionConsole(isExecute); }),
@@ -795,8 +795,8 @@ Type 'help' to get help.
         }
     }
 
-    private showSessionMenu() {
-        const availablePowerShellExes = this.powershellExeFinder.getAllAvailablePowerShellInstallations();
+    private async showSessionMenu() {
+        const availablePowerShellExes = await this.powershellExeFinder.getAllAvailablePowerShellInstallations();
 
         let sessionText: string;
 

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -3,7 +3,6 @@
 
 import * as assert from "assert";
 import * as fs from "fs";
-import * as path from "path";
 import * as vscode from "vscode";
 import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import utils = require("../utils");

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -77,34 +77,42 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\Program Files\\PowerShell\\6\\pwsh.exe",
                     displayName: "PowerShell (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\6\\pwsh.exe",
                     displayName: "PowerShell (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshMsixPath,
                     displayName: "PowerShell (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files\\PowerShell\\7-preview\\pwsh.exe",
                     displayName: "PowerShell Preview (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshPreviewMsixPath,
                     displayName: "PowerShell Preview (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\7-preview\\pwsh.exe",
                     displayName: "PowerShell Preview (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
@@ -156,10 +164,12 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
@@ -187,34 +197,42 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\6\\pwsh.exe",
                     displayName: "PowerShell (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files\\PowerShell\\6\\pwsh.exe",
                     displayName: "PowerShell (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshMsixPath,
                     displayName: "PowerShell (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\7-preview\\pwsh.exe",
                     displayName: "PowerShell Preview (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshPreviewMsixPath,
                     displayName: "PowerShell Preview (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files\\PowerShell\\7-preview\\pwsh.exe",
                     displayName: "PowerShell Preview (x64)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\Sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x64)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
@@ -266,10 +284,12 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\Sysnative\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x64)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
@@ -297,22 +317,27 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\6\\pwsh.exe",
                     displayName: "PowerShell (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshMsixPath,
                     displayName: "PowerShell (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Program Files (x86)\\PowerShell\\7-preview\\pwsh.exe",
                     displayName: "PowerShell Preview (x86)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: pwshPreviewMsixPath,
                     displayName: "PowerShell Preview (Store)",
+                    supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
@@ -353,11 +378,49 @@ if (process.platform === "win32") {
                 {
                     exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                     displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
                 },
             ],
             filesystem: {
                 "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0": {
                     "powershell.exe": "",
+                },
+            },
+        },
+        {
+            name: "Windows (dotnet)",
+            platformDetails: {
+                operatingSystem: platform.OperatingSystem.Windows,
+                isOS64Bit: true,
+                isProcess64Bit: true,
+            },
+            environmentVars: {
+                "USERNAME": "test",
+                "USERPROFILE": "C:\\Users\\test",
+                "ProgramFiles": "C:\\Program Files",
+                "ProgramFiles(x86)": "C:\\Program Files (x86)",
+                "windir": "C:\\WINDOWS",
+            },
+            expectedPowerShellSequence: [
+                {
+                    exePath: "C:\\Users\\test\\.dotnet\\tools\\pwsh.exe",
+                    displayName: ".NET Core PowerShell Global Tool",
+                    supportsProperArguments: false
+                },
+                {
+                    exePath: "C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+                    displayName: "Windows PowerShell (x64)",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "C:\\WINDOWS\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe",
+                    displayName: "Windows PowerShell (x86)",
+                    supportsProperArguments: true
+                },
+            ],
+            filesystem: {
+                "C:\\Users\\test\\.dotnet\\tools": {
+                    "pwsh.exe": "",
                 },
             },
         },
@@ -372,10 +435,26 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             expectedPowerShellSequence: [
-                { exePath: "/usr/bin/pwsh", displayName: "PowerShell" },
-                { exePath: "/snap/bin/pwsh", displayName: "PowerShell Snap" },
-                { exePath: "/usr/bin/pwsh-preview", displayName: "PowerShell Preview" },
-                { exePath: "/snap/bin/pwsh-preview", displayName: "PowerShell Preview Snap" },
+                {
+                    exePath: "/usr/bin/pwsh",
+                    displayName: "PowerShell",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/snap/bin/pwsh",
+                    displayName: "PowerShell Snap",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/usr/bin/pwsh-preview",
+                    displayName: "PowerShell Preview",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/snap/bin/pwsh-preview",
+                    displayName: "PowerShell Preview Snap",
+                    supportsProperArguments: true
+                },
             ],
             filesystem: {
                 "/usr/bin": {
@@ -396,8 +475,16 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             expectedPowerShellSequence: [
-                { exePath: "/usr/local/bin/pwsh", displayName: "PowerShell" },
-                { exePath: "/usr/local/bin/pwsh-preview", displayName: "PowerShell Preview" },
+                {
+                    exePath: "/usr/local/bin/pwsh",
+                    displayName: "PowerShell",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/usr/local/bin/pwsh-preview",
+                    displayName: "PowerShell Preview",
+                    supportsProperArguments: true
+                },
             ],
             filesystem: {
                 "/usr/local/bin": {
@@ -414,7 +501,11 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             expectedPowerShellSequence: [
-                { exePath: "/usr/bin/pwsh", displayName: "PowerShell" },
+                {
+                    exePath: "/usr/bin/pwsh",
+                    displayName: "PowerShell",
+                    supportsProperArguments: true
+                },
             ],
             filesystem: {
                 "/usr/bin": {
@@ -430,7 +521,11 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             expectedPowerShellSequence: [
-                { exePath: "/snap/bin/pwsh", displayName: "PowerShell Snap" },
+                {
+                    exePath: "/snap/bin/pwsh",
+                    displayName: "PowerShell Snap",
+                    supportsProperArguments: true
+                },
             ],
             filesystem: {
                 "/snap/bin": {
@@ -446,10 +541,62 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             expectedPowerShellSequence: [
-                { exePath: "/usr/local/bin/pwsh", displayName: "PowerShell" },
+                {
+                    exePath: "/usr/local/bin/pwsh",
+                    displayName: "PowerShell",
+                    supportsProperArguments: true
+                },
             ],
             filesystem: {
                 "/usr/local/bin": {
+                    pwsh: "",
+                },
+            },
+        },
+        {
+            name: "MacOS (dotnet)",
+            platformDetails: {
+                operatingSystem: platform.OperatingSystem.MacOS,
+                isOS64Bit: true,
+                isProcess64Bit: true,
+            },
+            environmentVars: {
+                "USER": "test",
+                "HOME": "/Users/test",
+            },
+            expectedPowerShellSequence: [
+                {
+                    exePath: "/Users/test/.dotnet/tools/pwsh",
+                    displayName: ".NET Core PowerShell Global Tool",
+                    supportsProperArguments: false
+                },
+            ],
+            filesystem: {
+                "/Users/test/.dotnet/tools": {
+                    pwsh: "",
+                },
+            },
+        },
+        {
+            name: "Linux (dotnet)",
+            platformDetails: {
+                operatingSystem: platform.OperatingSystem.Linux,
+                isOS64Bit: true,
+                isProcess64Bit: true,
+            },
+            environmentVars: {
+                "USER": "test",
+                "HOME": "/home/test",
+            },
+            expectedPowerShellSequence: [
+                {
+                    exePath: "/home/test/.dotnet/tools/pwsh",
+                    displayName: ".NET Core PowerShell Global Tool",
+                    supportsProperArguments: false
+                },
+            ],
+            filesystem: {
+                "/home/test/.dotnet/tools": {
                     pwsh: "",
                 },
             },
@@ -559,6 +706,7 @@ describe("Platform module", function () {
 
                 assert.strictEqual(defaultPowerShell.exePath, expectedPowerShell.exePath);
                 assert.strictEqual(defaultPowerShell.displayName, expectedPowerShell.displayName);
+                assert.strictEqual(defaultPowerShell.supportsProperArguments, expectedPowerShell.supportsProperArguments);
             });
         }
 
@@ -594,6 +742,7 @@ describe("Platform module", function () {
 
                     assert.strictEqual(foundPowerShell && foundPowerShell.exePath, expectedPowerShell.exePath);
                     assert.strictEqual(foundPowerShell && foundPowerShell.displayName, expectedPowerShell.displayName);
+                    assert.strictEqual(foundPowerShell && foundPowerShell.supportsProperArguments, expectedPowerShell.supportsProperArguments);
                 }
 
                 assert.strictEqual(

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -521,19 +521,19 @@ describe("Platform module", function () {
         }
     });
 
-    describe("Default PowerShell installation", function () {
+    describe("Default PowerShell installation", async function () {
         afterEach(function () {
             sinon.restore();
             mockFS.restore();
         });
 
         for (const testPlatform of successTestCases) {
-            it(`Finds it on ${testPlatform.name}`, function () {
+            it(`Finds it on ${testPlatform.name}`, async function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
 
-                const defaultPowerShell = powerShellExeFinder.getFirstAvailablePowerShellInstallation();
+                const defaultPowerShell = await powerShellExeFinder.getFirstAvailablePowerShellInstallation();
                 const expectedPowerShell = testPlatform.expectedPowerShellSequence[0];
 
                 assert.strictEqual(defaultPowerShell.exePath, expectedPowerShell.exePath);
@@ -542,12 +542,12 @@ describe("Platform module", function () {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Fails gracefully on ${testPlatform.name}`, function () {
+            it(`Fails gracefully on ${testPlatform.name}`, async function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
 
-                const defaultPowerShell = powerShellExeFinder.getFirstAvailablePowerShellInstallation();
+                const defaultPowerShell = await powerShellExeFinder.getFirstAvailablePowerShellInstallation();
                 assert.strictEqual(defaultPowerShell, undefined);
             });
         }
@@ -560,12 +560,12 @@ describe("Platform module", function () {
         });
 
         for (const testPlatform of successTestCases) {
-            it(`Finds them on ${testPlatform.name}`, function () {
+            it(`Finds them on ${testPlatform.name}`, async function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
 
-                const foundPowerShells = powerShellExeFinder.getAllAvailablePowerShellInstallations();
+                const foundPowerShells = await powerShellExeFinder.getAllAvailablePowerShellInstallations();
 
                 for (let i = 0; i < testPlatform.expectedPowerShellSequence.length; i++) {
                     const foundPowerShell = foundPowerShells[i];
@@ -583,12 +583,12 @@ describe("Platform module", function () {
         }
 
         for (const testPlatform of errorTestCases) {
-            it(`Fails gracefully on ${testPlatform.name}`, function () {
+            it(`Fails gracefully on ${testPlatform.name}`, async function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platform.PowerShellExeFinder(testPlatform.platformDetails);
 
-                const foundPowerShells = powerShellExeFinder.getAllAvailablePowerShellInstallations();
+                const foundPowerShells = await powerShellExeFinder.getAllAvailablePowerShellInstallations();
                 assert.strictEqual(foundPowerShells.length, 0);
             });
         }

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -7,7 +7,6 @@ import * as path from "path";
 import rewire = require("rewire");
 import vscode = require("vscode");
 import utils = require("../utils");
-import { sleep } from "../../src/utils";
 
 // Setup function that is not exported.
 const customViews = rewire("../../src/features/RunCode");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,11 @@
     // the sources which the tests need). The extension is built with `esbuild`.
     "module": "commonjs",
     "outDir": "out",
-    "target": "ES6",
-    "lib": [ "ES6", "DOM" ],
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
     "sourceMap": true,
     "rootDir": ".",
     // TODO: We need to enable stricter checking...


### PR DESCRIPTION
This was some yak-shaving. I added `supportsProperArguments` to `PossiblePowerShellExe` so we can special-case the `dotnet` installer and drop the startup banner (since it doesn't support proper argument parsing).

Fixes https://github.com/PowerShell/vscode-powershell/issues/4111.