### PR TITLE
Add walkthrough telemetry command

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,6 +261,11 @@
         "category": "PowerShell"
       },
       {
+        "command": "PowerShell.WalkthroughTelemetry",
+        "title": "Walkthrough Telemetry",
+        "category": "PowerShell"
+      },
+      {
         "command": "PowerShell.ClosePanel",
         "title": "Close panel",
         "category": "PowerShell",


### PR DESCRIPTION
This exposes a command that could be used in a walkthrough to send a level (presumably 1, 2, or 3) indicating satisfaction. It also refactors slightly to de-duplicate checking the extension mode before sending telemetry.