### PR TITLE
Add setting to control the references code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -609,6 +609,11 @@
           "default": true,
           "description": "Loads user and system-wide PowerShell profiles (profile.ps1 and Microsoft.VSCode_profile.ps1) into the PowerShell session. This affects IntelliSense and interactive script execution, but it does not affect the debugger."
         },
+        "powershell.enableReferencesCodeLens": {
+          "type": "boolean",
+          "default": false,
+          "description": "Displays a code lens above function definitions showing the number of times the function is referenced in the workspace. Enabling this setting can have a high impact on performance in large workspaces."
+        },
         "powershell.bugReporting.project": {
           "type": "string",
           "default": "https://github.com/PowerShell/vscode-powershell",

--- a/package.json
+++ b/package.json
@@ -611,8 +611,8 @@
         },
         "powershell.enableReferencesCodeLens": {
           "type": "boolean",
-          "default": false,
-          "description": "Displays a code lens above function definitions showing the number of times the function is referenced in the workspace. Enabling this setting can have a high impact on performance in large workspaces."
+          "default": true,
+          "description": "Displays a code lens above function definitions showing the number of times the function is referenced in the workspace. Large workspaces should disable this setting due to high performance impact."
         },
         "powershell.bugReporting.project": {
           "type": "string",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -101,6 +101,7 @@ export interface ISettings {
     buttons?: IButtonSettings;
     cwd?: string;
     notebooks?: INotebooksSettings;
+    enableReferencesCodeLens?: boolean;
 }
 
 export interface IStartAsLoginShellSettings {
@@ -268,6 +269,8 @@ export function load(): ISettings {
             configuration.get<IStartAsLoginShellSettings>("startAsLoginShell", defaultStartAsLoginShellSettings),
         cwd: // NOTE: This must be validated at startup via `validateCwdSetting()`. There's probably a better way to do this.
             configuration.get<string>("cwd", undefined),
+        enableReferencesCodeLens:
+            configuration.get<boolean>("enableReferencesCodeLens", false),
     };
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -270,7 +270,7 @@ export function load(): ISettings {
         cwd: // NOTE: This must be validated at startup via `validateCwdSetting()`. There's probably a better way to do this.
             configuration.get<string>("cwd", undefined),
         enableReferencesCodeLens:
-            configuration.get<boolean>("enableReferencesCodeLens", false),
+            configuration.get<boolean>("enableReferencesCodeLens", true),
     };
 }
 


### PR DESCRIPTION
## PR Summary

This PR relies on PowerShell/PowerShellEditorServices#1900

I have the default as `false` here, specifically until I can go in and fix it to not scan every file in the workspace multiple times every time a document change event fires.

I'm also open to waiting for those changes and considering this to be WIP.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
