### PR TITLE
Improve language client library close action message

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -621,7 +621,10 @@ Type 'help' to get help.
                 },
                 closed: (): CloseHandlerResult => {
                     // We have our own restart experience
-                    return { action: CloseAction.DoNotRestart };
+                    return {
+                        action: CloseAction.DoNotRestart,
+                        message: "Connection to PowerShell Editor Services (the Extension Terminal) was closed. See below prompt to restart!"
+                    };
                 },
             },
             revealOutputChannelOn: RevealOutputChannelOn.Never,


### PR DESCRIPTION
The updated language client library now displays an error when the connection to the server terminates. Thing is, we already have our own restart experience where we inform the user that the terminal should be restarted, and give them a Yes/No option to do so. Unfortunately, we can't suppress this error message, and I don't think that we want to auto-restart the terminal, so I've at least made the message a little more clear.