### PR TITLE
Add `integratedConsole.startInBackground` to completely hide the terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -772,7 +772,12 @@
         "powershell.integratedConsole.showOnStartup": {
           "type": "boolean",
           "default": true,
-          "description": "Shows the Extension Terminal when the PowerShell extension is initialized."
+          "description": "Shows the Extension Terminal when the PowerShell extension is initialized. When disabled, the pane is not opened on startup, but the Extension Terminal is still created in order to power the extension's features."
+        },
+        "powershell.integratedConsole.startInBackground": {
+          "type": "boolean",
+          "default": false,
+          "description": "Starts the Extension Terminal in the background. WARNING: If this is enabled, to access the terminal you must run the 'Show Extension Terminal' command, and once shown it cannot be put back into the background. This option completely hides the Extension Terminal from the terminals pane. You are probably looking for the 'showOnStartup' option instead."
         },
         "powershell.integratedConsole.focusConsoleOnExecute": {
           "type": "boolean",

--- a/src/process.ts
+++ b/src/process.ts
@@ -112,6 +112,7 @@ export class PowerShellProcess {
             cwd: this.sessionSettings.cwd,
             iconPath: new vscode.ThemeIcon("terminal-powershell"),
             isTransient: true,
+            hideFromUser: this.sessionSettings.integratedConsole.startInBackground,
         };
 
         this.consoleTerminal = vscode.window.createTerminal(terminalOptions);
@@ -119,7 +120,8 @@ export class PowerShellProcess {
         const pwshName = path.basename(this.exePath);
         this.log.write(`${pwshName} started.`);
 
-        if (this.sessionSettings.integratedConsole.showOnStartup) {
+        if (this.sessionSettings.integratedConsole.showOnStartup
+            && !this.sessionSettings.integratedConsole.startInBackground) {
             // We still need to run this to set the active terminal to the extension terminal.
             this.consoleTerminal.show(true);
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -462,17 +462,12 @@ Type 'help' to get help.
 
         // Detect any setting changes that would affect the session
         if (!this.suppressRestartPrompt &&
-            (settings.cwd?.toLowerCase() !==
-                this.sessionSettings.cwd?.toLowerCase() ||
-                settings.powerShellDefaultVersion.toLowerCase() !==
-                this.sessionSettings.powerShellDefaultVersion.toLowerCase() ||
-            settings.developer.editorServicesLogLevel.toLowerCase() !==
-                this.sessionSettings.developer.editorServicesLogLevel.toLowerCase() ||
-            settings.developer.bundledModulesPath.toLowerCase() !==
-                this.sessionSettings.developer.bundledModulesPath.toLowerCase() ||
-            settings.integratedConsole.useLegacyReadLine !==
-                this.sessionSettings.integratedConsole.useLegacyReadLine)) {
-
+            (settings.cwd?.toLowerCase() !== this.sessionSettings.cwd?.toLowerCase()
+                || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
+                || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()
+                || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
+                || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
+                || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground)) {
             const response: string = await vscode.window.showInformationMessage(
                 "The PowerShell runtime configuration has changed, would you like to start a new session?",
                 "Yes", "No");

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -110,6 +110,7 @@ export interface IStartAsLoginShellSettings {
 
 export interface IIntegratedConsoleSettings {
     showOnStartup?: boolean;
+    startInBackground?: boolean;
     focusConsoleOnExecute?: boolean;
     useLegacyReadLine?: boolean;
     forceClearScrollbackBuffer?: boolean;
@@ -196,6 +197,7 @@ export function load(): ISettings {
 
     const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {
         showOnStartup: true,
+        startInBackground: false,
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
         forceClearScrollbackBuffer: false,


### PR DESCRIPTION
This makes hiding the Extension Terminal from the set of terminals in VS Code an option, with a big warning that most users are probably just looking for `showOnStartup`, and that if enabled, to access the terminal you must manually open it some other way (such as with `Show Extension Terminal`). Some users require this as part of their workflow.

Follows up on #4096 and resolves #4151.