### PR TITLE
Enable new PSScriptAnalyzer option `avoidSemicolonsAsLineTerminators`

### DIFF
--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -36,6 +36,7 @@
       "MD024": false // no-duplicate-header
     },
     "powershell.codeFormatting.autoCorrectAliases": true,
+    "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
     "powershell.codeFormatting.newLineAfterCloseBrace": false,
     "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
     "powershell.codeFormatting.useCorrectCasing": true,

--- a/package.json
+++ b/package.json
@@ -676,6 +676,11 @@
           "default": false,
           "description": "Replaces aliases with their aliased name."
         },
+        "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": {
+          "type": "boolean",
+          "default": false,
+          "description": "Removes redundant semicolon(s) at the end of a line where a line terminator is sufficient."
+        },
         "powershell.codeFormatting.preset": {
           "type": "string",
           "enum": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,7 @@ export interface ICodeFoldingSettings {
 
 export interface ICodeFormattingSettings {
     autoCorrectAliases: boolean;
+    avoidSemicolonsAsLineTerminators: boolean;
     preset: CodeFormattingPreset;
     openBraceOnSameLine: boolean;
     newLineAfterOpenBrace: boolean;
@@ -173,6 +174,7 @@ export function load(): ISettings {
 
     const defaultCodeFormattingSettings: ICodeFormattingSettings = {
         autoCorrectAliases: false,
+        avoidSemicolonsAsLineTerminators: false,
         preset: CodeFormattingPreset.Custom,
         openBraceOnSameLine: true,
         newLineAfterOpenBrace: true,


### PR DESCRIPTION
## PR Summary

Expose new setting `avoidSemicolonsAsLineTerminators` related to new `AvoidSemicolonsAsLineTerminators` rule in PSSA 1.21.0. Requires this PSES PR first: https://github.com/PowerShell/PowerShellEditorServices/pull/1916

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [X] PR has a meaningful title
- [X] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
