### PR TITLE
Fix incorrect docstring for `powershell.cwd`

### DIFF
--- a/package.json
+++ b/package.json
@@ -644,7 +644,7 @@
         "powershell.cwd": {
           "type": "string",
           "default": null,
-          "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process and the shell's location will be set to this directory. Predefined variables can be used (i.e. ${fileDirname} to use the current opened file's directory)."
+          "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. A real path must be provided!"
         },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -644,7 +644,7 @@
         "powershell.cwd": {
           "type": "string",
           "default": null,
-          "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. A real path must be provided!"
+          "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. A fully resolved path must be provided!"
         },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",


### PR DESCRIPTION
This variable never could have accepted VS Code predefined variables because support for that is still an open feature request upstream. We have no API to resolve predefined variables in values given to contributed settings, and so cannot support this.

Resolves https://github.com/PowerShell/vscode-powershell/issues/4163