### PR TITLE
Refactor the debug launch configuration resolvers

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,7 +442,7 @@
               "type": "PowerShell",
               "request": "launch",
               "script": "^\"\\${file}\"",
-              "cwd": "^\"\\${file}\""
+              "cwd": "^\"\\${cwd}\""
             }
           },
           {
@@ -453,7 +453,7 @@
               "type": "PowerShell",
               "request": "launch",
               "script": "^\"enter path or command to execute e.g.: \\${workspaceFolder}/src/foo.ps1 or Invoke-Pester\"",
-              "cwd": "^\"\\${workspaceFolder}\""
+              "cwd": "^\"\\${cwd}\""
             }
           },
           {
@@ -463,7 +463,7 @@
               "name": "PowerShell Interactive Session",
               "type": "PowerShell",
               "request": "launch",
-              "cwd": ""
+              "cwd": "^\"\\${cwd}\""
             }
           },
           {

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -222,7 +222,6 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
                         type: "PowerShell",
                         request: "launch",
                         script: "${file}",
-                        cwd: "${file}",
                     })
                 })
         ]

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -3,7 +3,6 @@
 
 import * as path from "path";
 import vscode = require("vscode");
-import { SessionManager } from "../session";
 import Settings = require("../settings");
 import utils = require("../utils");
 
@@ -17,7 +16,7 @@ export class PesterTestsFeature implements vscode.Disposable {
     private command: vscode.Disposable;
     private invokePesterStubScriptPath: string;
 
-    constructor(private sessionManager: SessionManager) {
+    constructor() {
         this.invokePesterStubScriptPath = path.resolve(__dirname, "../modules/PowerShellEditorServices/InvokePesterStub.ps1");
 
         // File context-menu command - Run Pester Tests
@@ -70,10 +69,9 @@ export class PesterTestsFeature implements vscode.Disposable {
         launchType: LaunchType,
         testName?: string,
         lineNum?: number,
-        outputPath?: string) {
+        outputPath?: string): vscode.DebugConfiguration {
 
         const uri = vscode.Uri.parse(uriString);
-        const currentDocument = vscode.window.activeTextEditor.document;
         const settings = Settings.load();
 
         // Since we pass the script path to PSES in single quotes to avoid issues with PowerShell
@@ -83,7 +81,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         const launchConfig = {
             request: "launch",
             type: "PowerShell",
-            name: "PowerShell Launch Pester Tests",
+            name: "PowerShell: Launch Pester Tests",
             script: this.invokePesterStubScriptPath,
             args: [
                 "-ScriptPath",
@@ -125,7 +123,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         return launchConfig;
     }
 
-    private async launch(launchConfig): Promise<boolean> {
+    private async launch(launchConfig: vscode.DebugConfiguration): Promise<boolean> {
         // Create or show the interactive console
         // TODO: #367 Check if "newSession" mode is configured
         await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -51,23 +51,15 @@ export class RunCodeFeature implements vscode.Disposable {
 function createLaunchConfig(launchType: LaunchType, commandToRun: string, args: string[]) {
     const settings = Settings.load();
 
-    let cwd: string = vscode.workspace.rootPath;
-    if (vscode.window.activeTextEditor
-        && vscode.window.activeTextEditor.document
-        && !vscode.window.activeTextEditor.document.isUntitled) {
-        cwd = path.dirname(vscode.window.activeTextEditor.document.fileName);
-    }
-
     const launchConfig = {
         request: "launch",
         type: "PowerShell",
-        name: "PowerShell Run Code",
+        name: "PowerShell: Run Code",
         internalConsoleOptions: "neverOpen",
         noDebug: (launchType === LaunchType.Run),
         createTemporaryIntegratedConsole: settings.debugging.createTemporaryIntegratedConsole,
         script: commandToRun,
         args,
-        cwd,
     };
 
     return launchConfig;

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,7 +140,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         new GenerateBugReportFeature(sessionManager),
         new ISECompatibilityFeature(),
         new OpenInISEFeature(),
-        new PesterTestsFeature(sessionManager),
+        new PesterTestsFeature(),
         new RunCodeFeature(sessionManager),
         new CodeActionsFeature(logger),
         new SpecifyScriptArgsFeature(context),

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -27,17 +27,15 @@ describe("RunCode feature", function () {
         const expected: object = {
             request: "launch",
             type: "PowerShell",
-            name: "PowerShell Run Code",
-            script: commandToRun,
-            args,
+            name: "PowerShell: Run Code",
             internalConsoleOptions: "neverOpen",
             noDebug: false,
             createTemporaryIntegratedConsole: false,
-            cwd: vscode.workspace.rootPath,
+            script: commandToRun,
+            args,
         };
 
         const actual: object = createLaunchConfig(LaunchType.Debug, commandToRun, args);
-
         assert.deepStrictEqual(actual, expected);
     });
 


### PR DESCRIPTION
Some much needed TLC, especially now that VS Code with resolve its predefined variables used in configurations.

Do not set `cwd` for debug launch configurations

Instead, respect it if it exists, and otherwise consistently do not change it. Debugging will run in the session's current `cwd`, or if and only if the user set `cwd` on the launch config will it change.

Resolves #4082. My own testing seems to indicate this works well and as expected (consistently). However, I suspect we'll get some complaints when it rolls out.