### PR TITLE
Re-implement indicator when running registered editor commands

### DIFF
--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -14,7 +14,7 @@ import { LanguageClientConsumer } from "../languageClientConsumer";
 export const EvaluateRequestType = new RequestType<IEvaluateRequestArguments, void, void>("evaluate");
 export const OutputNotificationType = new NotificationType<IOutputNotificationBody>("output");
 export const ExecutionStatusChangedNotificationType =
-    new NotificationType<IExecutionStatusDetails>("powerShell/executionStatusChanged");
+    new NotificationType<ExecutionStatus>("powerShell/executionStatusChanged");
 
 export const ShowChoicePromptRequestType =
     new RequestType<IShowChoicePromptRequestArgs,
@@ -31,12 +31,6 @@ export interface IEvaluateRequestArguments {
 export interface IOutputNotificationBody {
     category: string;
     output: string;
-}
-
-interface IExecutionStatusDetails {
-    executionOptions: IExecutionOptions;
-    executionStatus: ExecutionStatus;
-    hadErrors: boolean;
 }
 
 interface IChoiceDetails {
@@ -73,13 +67,6 @@ enum ExecutionStatus {
     Failed,
     Aborted,
     Completed,
-}
-
-interface IExecutionOptions {
-    writeOutputToHost: boolean;
-    writeErrorsToHost: boolean;
-    addToHistory: boolean;
-    interruptCommandPrompt: boolean;
 }
 
 function showChoicePrompt(
@@ -257,12 +244,12 @@ export class ConsoleFeature extends LanguageClientConsumer {
                 ShowInputPromptRequestType,
                 (promptDetails) => showInputPrompt(promptDetails)),
 
-            // TODO: We're not receiving these events from the server any more.
             // Set up status bar alerts for when PowerShell is executing a script.
             this.languageClient.onNotification(
                 ExecutionStatusChangedNotificationType,
                 (executionStatusDetails) => {
-                    switch (executionStatusDetails.executionStatus) {
+                    switch (executionStatusDetails) {
+                        // TODO: Use the new language status bar item.
                         // If execution has changed to running, make a notification
                         case ExecutionStatus.Running:
                             this.showExecutionStatus("PowerShell");

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,6 @@
 
 "use strict";
 
-import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter from "@vscode/extension-telemetry";
 import { DocumentSelector } from "vscode-languageclient";
@@ -150,7 +149,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
 
     // Features and command registrations that require language client
     languageClientConsumers = [
-        new ConsoleFeature(logger),
+        new ConsoleFeature(logger, sessionManager),
         new ExpandAliasFeature(logger),
         new GetCommandsFeature(logger),
         new ShowHelpFeature(logger),


### PR DESCRIPTION
Resolves #3954 and uses the new language status bar item. Essentially just adds a spinner when the editor command is running.