### PR TITLE
Handle busy notification for all PowerShell tasks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
 
     // Features and command registrations that require language client
     languageClientConsumers = [
-        new ConsoleFeature(logger, sessionManager),
+        new ConsoleFeature(logger),
         new ExpandAliasFeature(logger),
         new GetCommandsFeature(logger),
         new ShowHelpFeature(logger),


### PR DESCRIPTION
Since with https://github.com/PowerShell/PowerShellEditorServices/pull/1928 the server now sends a busy notification for any PowerShell task, not just registered editor commands, we can handle this in the session class.