### PR TITLE
Fix automatic focus to temporary debug terminal (if it exists)

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -225,8 +225,9 @@ export class DebugSessionFeature extends LanguageClientConsumer
         if (this.sessionManager.getSessionStatus() !== SessionStatus.Running) {
             await this.sessionManager.start();
         }
-        // Create or show the Extension Terminal.
-        vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+
+        // Create or show the debug terminal (either temporary or session).
+        this.sessionManager.showDebugTerminal(true);
 
         return config;
     }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -3,6 +3,7 @@
 
 import * as path from "path";
 import vscode = require("vscode");
+import { SessionManager } from "../session";
 import Settings = require("../settings");
 import utils = require("../utils");
 
@@ -16,7 +17,7 @@ export class PesterTestsFeature implements vscode.Disposable {
     private command: vscode.Disposable;
     private invokePesterStubScriptPath: string;
 
-    constructor() {
+    constructor(private sessionManager: SessionManager) {
         this.invokePesterStubScriptPath = path.resolve(__dirname, "../modules/PowerShellEditorServices/InvokePesterStub.ps1");
 
         // File context-menu command - Run Pester Tests
@@ -126,7 +127,7 @@ export class PesterTestsFeature implements vscode.Disposable {
     private async launch(launchConfig: vscode.DebugConfiguration): Promise<boolean> {
         // Create or show the interactive console
         // TODO: #367 Check if "newSession" mode is configured
-        await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+        this.sessionManager.showDebugTerminal(true);
 
         // TODO: Update to handle multiple root workspaces.
         //

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import * as path from "path";
 import vscode = require("vscode");
 import { SessionManager } from "../session";
 import Settings = require("../settings");
-import utils = require("../utils");
 
 enum LaunchType {
     Debug,
@@ -41,7 +39,7 @@ export class RunCodeFeature implements vscode.Disposable {
     private async launch(launchConfig: string | vscode.DebugConfiguration) {
         // Create or show the interactive console
         // TODO: #367: Check if "newSession" mode is configured
-        await vscode.commands.executeCommand("PowerShell.ShowSessionConsole", true);
+        this.sessionManager.showDebugTerminal(true);
 
         // TODO: Update to handle multiple root workspaces.
         await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], launchConfig);

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,7 +139,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         new GenerateBugReportFeature(sessionManager),
         new ISECompatibilityFeature(),
         new OpenInISEFeature(),
-        new PesterTestsFeature(),
+        new PesterTestsFeature(sessionManager),
         new RunCodeFeature(sessionManager),
         new CodeActionsFeature(logger),
         new SpecifyScriptArgsFeature(context),

--- a/src/process.ts
+++ b/src/process.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 import cp = require("child_process");
-import * as semver from "semver";
 import path = require("path");
 import vscode = require("vscode");
 import { Logger } from "./logging";
@@ -138,10 +137,8 @@ export class PowerShellProcess {
         return sessionDetails;
     }
 
-    public showConsole(preserveFocus: boolean) {
-        if (this.consoleTerminal) {
-            this.consoleTerminal.show(preserveFocus);
-        }
+    public showTerminal(preserveFocus?: boolean) {
+        this.consoleTerminal?.show(preserveFocus);
     }
 
     public dispose() {


### PR DESCRIPTION
This fixes the client so that if a temporary debug terminal is in use that it will be focused instead of the session terminal when debugging.

Fixes #4201.