### PR TITLE
Add assertion to build that PSES bits are built in release configuration

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -70,6 +70,18 @@ steps:
     workingDirectory: $(Build.SourcesDirectory)/vscode-powershell
     pwsh: ${{ parameters.pwsh }}
 
+- task: PowerShell@2
+  displayName: Assert PowerShellEditorServices release configuration
+  inputs:
+    targetType: inline
+    script: |
+      $assembly = [Reflection.Assembly]::LoadFile("$(Build.SourcesDirectory)/vscode-powershell/modules/PowerShellEditorServices.VSCode/bin/Microsoft.PowerShell.EditorServices.VSCode.dll")
+      if ($assembly.GetCustomAttributes([System.Diagnostics.DebuggableAttribute], $true).IsJITOptimizerDisabled) {
+        Write-Host "##vso[task.LogIssue type=error;] PowerShell Editor Services bits were not built in release configuration!"
+        exit 1
+      }
+    pwsh: ${{ parameters.pwsh }}
+
 - publish: $(vsixPath)
   artifact: vscode-powershell-vsix-$(System.JobId)
   displayName: Publish extension artifact

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -50,7 +50,7 @@ task RestoreEditorServices -If (Get-EditorServicesPath) {
             }
 
             Write-Host "`n### Building PSES`n" -ForegroundColor Green
-            Invoke-Build Build (Get-EditorServicesPath)
+            Invoke-Build Build (Get-EditorServicesPath) -Configuration $Configuration
         }
         "Release" {
             # When releasing, we ensure the bits are not symlinked but copied,
@@ -64,7 +64,7 @@ task RestoreEditorServices -If (Get-EditorServicesPath) {
                 # We only build if it hasn't been built at all.
                 if (!(Test-Path "$(Split-Path (Get-EditorServicesPath))/module/PowerShellEditorServices/bin")) {
                     Write-Host "`n### Building PSES`n" -ForegroundColor Green
-                    Invoke-Build Build (Get-EditorServicesPath)
+                    Invoke-Build Build (Get-EditorServicesPath) -Configuration $Configuration
                 }
 
                 Write-Host "`n### Copying PSES`n" -ForegroundColor Green


### PR DESCRIPTION
Because it's way too easy to break that! We were building in release configuration, then running the tests...and the tests were then building (and overwriting the bits) in debug configuration.