### PR TITLE
Refactor `settings.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -584,7 +584,6 @@
         },
         "powershell.powerShellExePath": {
           "type": "string",
-          "default": "",
           "scope": "machine",
           "description": "REMOVED: Please use the \"powershell.powerShellAdditionalExePaths\" setting instead.",
           "deprecationMessage": "Please use the \"powershell.powerShellAdditionalExePaths\" setting instead."
@@ -653,7 +652,6 @@
         },
         "powershell.cwd": {
           "type": "string",
-          "default": null,
           "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. A fully resolved path must be provided!"
         },
         "powershell.scriptAnalysis.enable": {
@@ -811,6 +809,7 @@
         },
         "powershell.integratedConsole.forceClearScrollbackBuffer": {
           "type": "boolean",
+          "default": false,
           "description": "Use the vscode API to clear the terminal since that's the only reliable way to clear the scrollback buffer. Turn this on if you're used to 'Clear-Host' clearing scroll history as well as clear-terminal-via-lsp."
         },
         "powershell.integratedConsole.suppressStartupBanner": {
@@ -825,6 +824,7 @@
         },
         "powershell.developer.bundledModulesPath": {
           "type": "string",
+          "default": "../../PowerShellEditorServices/module",
           "description": "Specifies an alternate path to the folder containing modules that are bundled with the PowerShell extension (i.e. PowerShell Editor Services, PSScriptAnalyzer, Plaster)"
         },
         "powershell.developer.editorServicesLogLevel": {

--- a/package.json
+++ b/package.json
@@ -573,6 +573,7 @@
         },
         "powershell.powerShellAdditionalExePaths": {
           "type": "object",
+          "default": {},
           "description": "Specifies a list of versionName / exePath pairs where exePath points to a non-standard install location for PowerShell and versionName can be used to reference this path with the powershell.powerShellDefaultVersion setting.",
           "additionalProperties": {
             "type": "string"
@@ -580,10 +581,12 @@
         },
         "powershell.powerShellDefaultVersion": {
           "type": "string",
+          "default": "",
           "description": "Specifies the PowerShell version name, as displayed by the 'PowerShell: Show Session Menu' command, used when the extension loads e.g \"Windows PowerShell (x86)\" or \"PowerShell Core 7 (x64)\". You can specify additional PowerShell executables by using the \"powershell.powerShellAdditionalExePaths\" setting."
         },
         "powershell.powerShellExePath": {
           "type": "string",
+          "default": "",
           "scope": "machine",
           "description": "REMOVED: Please use the \"powershell.powerShellAdditionalExePaths\" setting instead.",
           "deprecationMessage": "Please use the \"powershell.powerShellAdditionalExePaths\" setting instead."
@@ -652,6 +655,7 @@
         },
         "powershell.cwd": {
           "type": "string",
+          "default": "",
           "description": "An explicit start path where the PowerShell Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. A fully resolved path must be provided!"
         },
         "powershell.scriptAnalysis.enable": {

--- a/package.json
+++ b/package.json
@@ -641,7 +641,8 @@
         "powershell.bugReporting.project": {
           "type": "string",
           "default": "https://github.com/PowerShell/vscode-powershell",
-          "description": "Specifies the URL of the GitHub project in which to generate bug reports."
+          "description": "Specifies the URL of the GitHub project in which to generate bug reports.",
+          "deprecationMessage": "This setting was never meant to be changed!"
         },
         "powershell.helpCompletion": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -816,7 +816,7 @@
         "powershell.integratedConsole.suppressStartupBanner": {
           "type": "boolean",
           "default": false,
-          "description": "Do not show the Powershell Extension Terminal banner on launch"
+          "description": "Do not show the PowerShell Extension Terminal banner on launch."
         },
         "powershell.debugging.createTemporaryIntegratedConsole": {
           "type": "boolean",

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -6,7 +6,7 @@ import { NotificationType, RequestType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { ICheckboxQuickPickItem, showCheckboxQuickPick } from "../controls/checkboxQuickPick";
 import { Logger } from "../logging";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 export const EvaluateRequestType = new RequestType<IEvaluateRequestArguments, void, void>("evaluate");
@@ -182,7 +182,7 @@ export class ConsoleFeature extends LanguageClientConsumer {
                     // We need to honor the focusConsoleOnExecute setting here too. However, the boolean that `show`
                     // takes is called `preserveFocus` which when `true` the terminal will not take focus.
                     // This is the inverse of focusConsoleOnExecute so we have to inverse the boolean.
-                    vscode.window.activeTerminal.show(!Settings.load().integratedConsole.focusConsoleOnExecute);
+                    vscode.window.activeTerminal.show(!getSettings().integratedConsole.focusConsoleOnExecute);
                     await vscode.commands.executeCommand("workbench.action.terminal.scrollToBottom");
 
                     return;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -11,7 +11,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { getPlatformDetails, OperatingSystem } from "../platform";
 import { PowerShellProcess } from "../process";
 import { IEditorServicesSessionDetails, SessionManager, SessionStatus } from "../session";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 import { Logger } from "../logging";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 import path = require("path");
@@ -169,7 +169,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         // setting. Otherwise, the launch config value overrides the setting.
         //
         // Also start the temporary process and console for this configuration.
-        const settings = Settings.load();
+        const settings = getSettings();
         config.createTemporaryIntegratedConsole =
             config.createTemporaryIntegratedConsole ??
             settings.debugging.createTemporaryIntegratedConsole;

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -10,7 +10,7 @@ import {
 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 export interface IExtensionCommand {
@@ -260,7 +260,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
                 () => {
                     // We check to see if they have TrueClear on. If not, no-op because the
                     // overriden Clear-Host already calls [System.Console]::Clear()
-                    if (Settings.load().integratedConsole.forceClearScrollbackBuffer) {
+                    if (getSettings().integratedConsole.forceClearScrollbackBuffer) {
                         void vscode.commands.executeCommand("workbench.action.terminal.clear");
                     }
                 })

--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -5,12 +5,11 @@ import os = require("os");
 import vscode = require("vscode");
 import child_process = require("child_process");
 import { SessionManager } from "../session";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 
 const queryStringPrefix = "?";
 
-const settings = Settings.load();
-const project = settings.bugReporting.project;
+const project = getSettings().bugReporting.project;
 const issuesUrl = `${project}/issues/new`;
 
 const extensions =

--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -5,11 +5,10 @@ import os = require("os");
 import vscode = require("vscode");
 import child_process = require("child_process");
 import { SessionManager } from "../session";
-import { getSettings } from "../settings";
 
 const queryStringPrefix = "?";
 
-const project = getSettings().bugReporting.project;
+const project = "https://github.com/PowerShell/vscode-powershell";
 const issuesUrl = `${project}/issues/new`;
 
 const extensions =

--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -6,6 +6,7 @@ import { RequestType0 } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
 import { LanguageClientConsumer } from "../languageClientConsumer";
+import { getSettings } from "../settings";
 
 interface ICommand {
     name: string;
@@ -68,8 +69,8 @@ export class GetCommandsFeature extends LanguageClientConsumer {
             return;
         }
         await this.languageClient.sendRequest(GetCommandRequestType).then((result) => {
-            const SidebarConfig = vscode.workspace.getConfiguration("powershell.sideBar");
-            const excludeFilter = (SidebarConfig.CommandExplorerExcludeFilter).map((filter: string) => filter.toLowerCase());
+            const exclusions = getSettings().sideBar.CommandExplorerExcludeFilter;
+            const excludeFilter = exclusions.map((filter: string) => filter.toLowerCase());
             result = result.filter((command) => (excludeFilter.indexOf(command.moduleName.toLowerCase()) === -1));
             this.commandsExplorerProvider.powerShellCommands = result.map(toCommand);
             this.commandsExplorerProvider.refresh();

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -7,7 +7,7 @@ import {
 } from "vscode";
 import { RequestType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
-import Settings = require("../settings");
+import { ISettings, CommentType, getSettings } from "../settings";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -27,13 +27,13 @@ enum SearchState { Searching, Locked, Found }
 export class HelpCompletionFeature extends LanguageClientConsumer {
     private helpCompletionProvider: HelpCompletionProvider | undefined;
     private disposable: Disposable | undefined;
-    private settings: Settings.ISettings;
+    private settings: ISettings;
 
     constructor() {
         super();
-        this.settings = Settings.load();
+        this.settings = getSettings();
 
-        if (this.settings.helpCompletion !== Settings.CommentType.Disabled) {
+        if (this.settings.helpCompletion !== CommentType.Disabled) {
             this.helpCompletionProvider = new HelpCompletionProvider();
             this.disposable = workspace.onDidChangeTextDocument(async (e) => { await this.onEvent(e); });
         }
@@ -125,11 +125,11 @@ class HelpCompletionProvider {
     private lastChangeRange: Range | undefined;
     private lastDocument: TextDocument | undefined;
     private langClient: LanguageClient | undefined;
-    private settings: Settings.ISettings;
+    private settings: ISettings;
 
     constructor() {
         this.triggerFinderHelpComment = new TriggerFinder("##");
-        this.settings = Settings.load();
+        this.settings = getSettings();
     }
 
     public get triggerFound(): boolean {
@@ -161,7 +161,7 @@ class HelpCompletionProvider {
         const result = await this.langClient.sendRequest(CommentHelpRequestType, {
             documentUri: doc.uri.toString(),
             triggerPosition: triggerStartPos,
-            blockComment: this.settings.helpCompletion === Settings.CommentType.BlockComment,
+            blockComment: this.settings.helpCompletion === CommentType.BlockComment,
         });
 
         if (result.content.length === 0) {

--- a/src/features/HelpCompletion.ts
+++ b/src/features/HelpCompletion.ts
@@ -7,7 +7,7 @@ import {
 } from "vscode";
 import { RequestType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
-import { ISettings, CommentType, getSettings } from "../settings";
+import { Settings, CommentType, getSettings } from "../settings";
 import { LanguageClientConsumer } from "../languageClientConsumer";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -27,7 +27,7 @@ enum SearchState { Searching, Locked, Found }
 export class HelpCompletionFeature extends LanguageClientConsumer {
     private helpCompletionProvider: HelpCompletionProvider | undefined;
     private disposable: Disposable | undefined;
-    private settings: ISettings;
+    private settings: Settings;
 
     constructor() {
         super();
@@ -125,7 +125,7 @@ class HelpCompletionProvider {
     private lastChangeRange: Range | undefined;
     private lastDocument: TextDocument | undefined;
     private langClient: LanguageClient | undefined;
-    private settings: ISettings;
+    private settings: Settings;
 
     constructor() {
         this.triggerFinderHelpComment = new TriggerFinder("##");

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import * as vscode from "vscode";
-import * as Settings from "../settings";
+import { getSettings } from "../settings";
 
 interface ISetting {
     path: string;
@@ -63,7 +63,7 @@ export class ISECompatibilityFeature implements vscode.Disposable {
         // Show the PowerShell view container which has the Command Explorer view
         await vscode.commands.executeCommand("workbench.view.extension.PowerShell");
 
-        if (!Settings.load().sideBar.CommandExplorerVisibility) {
+        if (!getSettings().sideBar.CommandExplorerVisibility) {
             // Hide the explorer if the setting says so.
             await vscode.commands.executeCommand("workbench.action.toggleSidebarVisibility");
         }

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -4,7 +4,7 @@
 import * as path from "path";
 import vscode = require("vscode");
 import { SessionManager } from "../session";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 import utils = require("../utils");
 
 enum LaunchType {
@@ -83,7 +83,7 @@ export class PesterTestsFeature implements vscode.Disposable {
         lineNum?: number,
         outputPath?: string): vscode.DebugConfiguration {
 
-        const settings = Settings.load();
+        const settings = getSettings();
 
         // Since we pass the script path to PSES in single quotes to avoid issues with PowerShell
         // special chars like & $ @ () [], we do have to double up the interior single quotes.

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -3,7 +3,7 @@
 
 import vscode = require("vscode");
 import { SessionManager } from "../session";
-import Settings = require("../settings");
+import { getSettings } from "../settings";
 
 enum LaunchType {
     Debug,
@@ -46,7 +46,7 @@ export class RunCodeFeature implements vscode.Disposable {
 }
 
 function createLaunchConfig(launchType: LaunchType, commandToRun: string, args: string[]) {
-    const settings = Settings.load();
+    const settings = getSettings();
 
     const launchConfig = {
         request: "launch",

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -14,7 +14,7 @@ import { MessageItem, ProgressLocation, window } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { Logger } from "../logging";
 import { SessionManager } from "../session";
-import * as Settings from "../settings";
+import { changeSetting } from "../settings";
 import { isMacOS, isWindows } from "../utils";
 import { EvaluateRequestType } from "./Console";
 
@@ -195,7 +195,7 @@ export async function InvokePowerShellUpdateCheck(
 
         // Never choice.
     case 2:
-        await Settings.change("promptToUpdatePowerShell", false, true, logger);
+        await changeSetting("promptToUpdatePowerShell", false, true, logger);
         break;
     default:
         break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { ShowHelpFeature } from "./features/ShowHelp";
 import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { Logger } from "./logging";
 import { SessionManager } from "./session";
-import Settings = require("./settings");
+import { LogLevel, getSettings, validateCwdSetting } from "./settings";
 import { PowerShellLanguageId } from "./utils";
 import { LanguageClientConsumer } from "./languageClientConsumer";
 
@@ -51,7 +51,7 @@ const documentSelector: DocumentSelector = [
 
 export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
     const logLevel = vscode.workspace.getConfiguration(`${PowerShellLanguageId}.developer`)
-        .get<string>("editorServicesLogLevel", "Normal");
+        .get<string>("editorServicesLogLevel", LogLevel.Normal);
     logger = new Logger(logLevel, context.globalStorageUri);
 
     telemetryReporter = new TelemetryReporter(PackageJSON.name, PackageJSON.version, AI_KEY);
@@ -65,8 +65,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
     }
 
     // Load and validate settings (will prompt for 'cwd' if necessary).
-    await Settings.validateCwdSetting(logger);
-    const settings = Settings.load();
+    await validateCwdSetting(logger);
+    const settings = getSettings();
     logger.writeDiagnostic(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
 
     languageConfigurationDisposable = vscode.languages.setLanguageConfiguration(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -5,7 +5,7 @@ import * as os from "os";
 import * as path from "path";
 import * as process from "process";
 import { integer } from "vscode-languageserver-protocol";
-import { IPowerShellAdditionalExePathSettings } from "./settings";
+import { PowerShellAdditionalExePathSettings } from "./settings";
 
 // This uses require so we can rewire it in unit tests!
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires
@@ -79,7 +79,7 @@ export class PowerShellExeFinder {
     private readonly platformDetails: IPlatformDetails;
 
     // Additional configured PowerShells
-    private readonly additionalPSExeSettings: IPowerShellAdditionalExePathSettings;
+    private readonly additionalPSExeSettings: PowerShellAdditionalExePathSettings;
 
     private winPS: IPossiblePowerShellExe | undefined;
 
@@ -92,7 +92,7 @@ export class PowerShellExeFinder {
      */
     constructor(
         platformDetails?: IPlatformDetails,
-        additionalPowerShellExes?: IPowerShellAdditionalExePathSettings) {
+        additionalPowerShellExes?: PowerShellAdditionalExePathSettings) {
 
         this.platformDetails = platformDetails ?? getPlatformDetails();
         this.additionalPSExeSettings = additionalPowerShellExes ?? {};

--- a/src/process.ts
+++ b/src/process.ts
@@ -46,7 +46,7 @@ export class PowerShellProcess {
                 "PowerShellEditorServices/PowerShellEditorServices.psd1");
 
         const featureFlags =
-            this.sessionSettings.developer.featureFlags !== undefined
+            this.sessionSettings.developer.featureFlags.length > 0
                 ? this.sessionSettings.developer.featureFlags.map((f) => `'${f}'`).join(", ")
                 : "";
 

--- a/src/process.ts
+++ b/src/process.ts
@@ -31,7 +31,7 @@ export class PowerShellProcess {
         private logger: Logger,
         private startPsesArgs: string,
         private sessionFilePath: vscode.Uri,
-        private sessionSettings: Settings.ISettings) {
+        private sessionSettings: Settings.Settings) {
 
         this.onExited = this.onExitedEmitter.event;
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -525,13 +525,14 @@ export class SessionManager implements Middleware {
     }
 
     private async getBundledModulesPath(): Promise<string> {
-        let bundledModulesPath = path.resolve(__dirname, this.sessionSettings.bundledModulesPath);
+        // Because the extension is always at `<root>/out/main.js`
+        let bundledModulesPath = path.resolve(__dirname, "../modules");
 
         if (this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
             const devBundledModulesPath = path.resolve(__dirname, this.sessionSettings.developer.bundledModulesPath);
 
             // Make sure the module's bin path exists
-            if (await utils.checkIfDirectoryExists(path.join(devBundledModulesPath, "PowerShellEditorServices/bin"))) {
+            if (await utils.checkIfDirectoryExists(devBundledModulesPath)) {
                 bundledModulesPath = devBundledModulesPath;
             } else {
                 void this.logger.writeAndShowWarning(

--- a/src/session.ts
+++ b/src/session.ts
@@ -9,7 +9,7 @@ import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements
 import { Message } from "vscode-jsonrpc";
 import { Logger } from "./logging";
 import { PowerShellProcess } from "./process";
-import { ISettings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
+import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
 import utils = require("./utils");
 
 import {
@@ -102,7 +102,7 @@ export class SessionManager implements Middleware {
 
     constructor(
         private extensionContext: vscode.ExtensionContext,
-        private sessionSettings: ISettings,
+        private sessionSettings: Settings,
         private logger: Logger,
         private documentSelector: DocumentSelector,
         hostName: string,
@@ -234,7 +234,7 @@ export class SessionManager implements Middleware {
         return vscode.Uri.joinPath(this.sessionsFolder, `PSES-VSCode-${process.env.VSCODE_PID}-${uniqueId}.json`);
     }
 
-    public async createDebugSessionProcess(settings: ISettings): Promise<PowerShellProcess> {
+    public async createDebugSessionProcess(settings: Settings): Promise<PowerShellProcess> {
         // NOTE: We only support one temporary Extension Terminal at a time. To
         // support more, we need to track each separately, and tie the session
         // for the event handler to the right process (and dispose of the event

--- a/src/session.ts
+++ b/src/session.ts
@@ -354,7 +354,7 @@ export class SessionManager implements Middleware {
 
     // TODO: Remove this migration code.
     private async promptPowerShellExeSettingsCleanup() {
-        if (!this.sessionSettings.powerShellExePath) { // undefined or null
+        if (this.sessionSettings.powerShellExePath === "") {
             return;
         }
 
@@ -378,7 +378,7 @@ export class SessionManager implements Middleware {
         }
 
         // Show the session menu at the end if they don't have a PowerShellDefaultVersion.
-        if (this.sessionSettings.powerShellDefaultVersion === undefined) {
+        if (this.sessionSettings.powerShellDefaultVersion === "") {
             await vscode.commands.executeCommand(this.ShowSessionMenuCommandName);
         }
     }
@@ -389,8 +389,8 @@ export class SessionManager implements Middleware {
 
         // Detect any setting changes that would affect the session
         if (!this.suppressRestartPrompt &&
-            (settings.cwd?.toLowerCase() !== this.sessionSettings.cwd?.toLowerCase()
-                || settings.powerShellDefaultVersion?.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion?.toLowerCase()
+            (settings.cwd.toLowerCase() !== this.sessionSettings.cwd.toLowerCase()
+                || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
                 || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()
                 || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
@@ -489,7 +489,7 @@ export class SessionManager implements Middleware {
         let foundPowerShell: IPowerShellExeDetails | undefined;
         try {
             let defaultPowerShell: IPowerShellExeDetails | undefined;
-            if (this.sessionSettings.powerShellDefaultVersion !== undefined) {
+            if (this.sessionSettings.powerShellDefaultVersion !== "") {
                 for await (const details of powershellExeFinder.enumeratePowerShellInstallations()) {
                     // Need to compare names case-insensitively, from https://stackoverflow.com/a/2140723
                     const wantedName = this.sessionSettings.powerShellDefaultVersion;

--- a/src/session.ts
+++ b/src/session.ts
@@ -625,6 +625,7 @@ Type 'help' to get help.
         const clientOptions: LanguageClientOptions = {
             documentSelector: this.documentSelector,
             synchronize: {
+                // TODO: This is deprecated and they should be pulled by the server.
                 // backend uses "files" and "search" to ignore references.
                 configurationSection: [utils.PowerShellLanguageId, "files", "search"],
                 // TODO: fileEvents: vscode.workspace.createFileSystemWatcher('**/.eslintrc')
@@ -657,6 +658,7 @@ Type 'help' to get help.
         this.languageClient = new LanguageClient("PowerShell Editor Services", connectFunc, clientOptions);
 
         // This enables handling Semantic Highlighting messages in PowerShell Editor Services
+        // TODO: We should only turn this on in preview.
         this.languageClient.registerProposedFeatures();
 
         this.languageClient.onTelemetry((event) => {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,14 @@ import utils = require("./utils");
 import os = require("os");
 import { Logger } from "./logging";
 
+// TODO: Quite a few of these settings are unused in the client and instead
+// exist just for the server. Those settings do not need to be represented in
+// this class, as the LSP layers take care of communicating them. Frankly, this
+// class is over-engineered and seems to have originally been created to avoid
+// using vscode.workspace.getConfiguration() directly. It wasn't a bad idea to
+// keep things organized so consistent...but it ended up failing in execution.
+// Perhaps we just get rid of this entirely?
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class PartialSettings { }
 
@@ -22,7 +30,6 @@ export class Settings extends PartialSettings {
     scriptAnalysis = new ScriptAnalysisSettings();
     debugging = new DebuggingSettings();
     developer = new DeveloperSettings();
-    codeFolding = new CodeFoldingSettings();
     codeFormatting = new CodeFormattingSettings();
     integratedConsole = new IntegratedConsoleSettings();
     sideBar = new SideBarSettings();
@@ -64,11 +71,6 @@ export enum CommentType {
 }
 
 export type PowerShellAdditionalExePathSettings = Record<string, string>;
-
-class CodeFoldingSettings extends PartialSettings {
-    enable = true;
-    showLastLine = true;
-}
 
 class CodeFormattingSettings extends PartialSettings {
     autoCorrectAliases = false;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,7 +102,7 @@ class DebuggingSettings extends PartialSettings {
 }
 
 class DeveloperSettings extends PartialSettings {
-    featureFlags = [];
+    featureFlags: string[] = [];
     // From `<root>/out/main.js` we go to the directory before <root> and
     // then into the other repo.
     bundledModulesPath = "../../PowerShellEditorServices/module";
@@ -130,8 +130,8 @@ class IntegratedConsoleSettings extends PartialSettings {
 }
 
 class SideBarSettings extends PartialSettings {
-    // TODO: add CommandExplorerExcludeFilter
     CommandExplorerVisibility = true;
+    CommandExplorerExcludeFilter: string[] = [];
 }
 
 class PesterSettings extends PartialSettings {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,8 +33,8 @@ export interface IBugReportingSettings {
 }
 
 export interface ICodeFoldingSettings {
-    enable?: boolean;
-    showLastLine?: boolean;
+    enable: boolean;
+    showLastLine: boolean;
 }
 
 export interface ICodeFormattingSettings {
@@ -60,46 +60,46 @@ export interface ICodeFormattingSettings {
 }
 
 export interface IScriptAnalysisSettings {
-    enable?: boolean;
+    enable: boolean;
     settingsPath: string;
 }
 
 export interface IDebuggingSettings {
-    createTemporaryIntegratedConsole?: boolean;
+    createTemporaryIntegratedConsole: boolean;
 }
 
 export interface IDeveloperSettings {
-    featureFlags?: string[];
+    featureFlags: string[];
     bundledModulesPath: string;
     editorServicesLogLevel: string;
-    editorServicesWaitForDebugger?: boolean;
+    editorServicesWaitForDebugger: boolean;
     waitForSessionFileTimeoutSeconds: number;
 }
 
 export interface ISettings {
-    powerShellAdditionalExePaths?: IPowerShellAdditionalExePathSettings;
-    powerShellDefaultVersion?: string;
+    powerShellAdditionalExePaths: IPowerShellAdditionalExePathSettings | undefined;
+    powerShellDefaultVersion: string | undefined;
     // This setting is no longer used but is here to assist in cleaning up the users settings.
-    powerShellExePath?: string;
-    promptToUpdatePowerShell?: boolean;
+    powerShellExePath: string | undefined;
+    promptToUpdatePowerShell: boolean;
     bundledModulesPath: string;
     startAsLoginShell: IStartAsLoginShellSettings;
-    startAutomatically?: boolean;
+    startAutomatically: boolean;
     enableProfileLoading: boolean;
     helpCompletion: string;
-    scriptAnalysis?: IScriptAnalysisSettings;
+    scriptAnalysis: IScriptAnalysisSettings;
     debugging: IDebuggingSettings;
     developer: IDeveloperSettings;
-    codeFolding?: ICodeFoldingSettings;
-    codeFormatting?: ICodeFormattingSettings;
+    codeFolding: ICodeFoldingSettings;
+    codeFormatting: ICodeFormattingSettings;
     integratedConsole: IIntegratedConsoleSettings;
     bugReporting: IBugReportingSettings;
     sideBar: ISideBarSettings;
     pester: IPesterSettings;
-    buttons?: IButtonSettings;
-    cwd?: string;
-    enableReferencesCodeLens?: boolean;
-    analyzeOpenDocumentsOnly?: boolean;
+    buttons: IButtonSettings;
+    cwd: string | undefined;
+    enableReferencesCodeLens: boolean;
+    analyzeOpenDocumentsOnly: boolean;
 }
 
 export interface IStartAsLoginShellSettings {
@@ -108,12 +108,12 @@ export interface IStartAsLoginShellSettings {
 }
 
 export interface IIntegratedConsoleSettings {
-    showOnStartup?: boolean;
-    startInBackground?: boolean;
+    showOnStartup: boolean;
+    startInBackground: boolean;
     focusConsoleOnExecute: boolean;
-    useLegacyReadLine?: boolean;
-    forceClearScrollbackBuffer?: boolean;
-    suppressStartupBanner?: boolean;
+    useLegacyReadLine: boolean;
+    forceClearScrollbackBuffer: boolean;
+    suppressStartupBanner: boolean;
 }
 
 export interface ISideBarSettings {
@@ -127,8 +127,8 @@ export interface IPesterSettings {
 }
 
 export interface IButtonSettings {
-    showRunButtons?: boolean;
-    showPanelMovementButtons?: boolean;
+    showRunButtons: boolean;
+    showPanelMovementButtons: boolean;
 }
 
 // TODO: This could probably be async, and call `validateCwdSetting()` directly.
@@ -197,6 +197,7 @@ export function load(): ISettings {
         focusConsoleOnExecute: true,
         useLegacyReadLine: false,
         forceClearScrollbackBuffer: false,
+        suppressStartupBanner: false,
     };
 
     const defaultSideBarSettings: ISideBarSettings = {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,7 +25,6 @@ export class Settings extends PartialSettings {
     codeFolding = new CodeFoldingSettings();
     codeFormatting = new CodeFormattingSettings();
     integratedConsole = new IntegratedConsoleSettings();
-    bugReporting = new BugReportingSettings();
     sideBar = new SideBarSettings();
     pester = new PesterSettings();
     buttons = new ButtonSettings();
@@ -65,10 +64,6 @@ export enum CommentType {
 }
 
 export type PowerShellAdditionalExePathSettings = Record<string, string>;
-
-class BugReportingSettings extends PartialSettings {
-    project = "https://github.com/PowerShell/vscode-powershell";
-}
 
 class CodeFoldingSettings extends PartialSettings {
     enable = true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -98,7 +98,6 @@ export interface ISettings {
     pester: IPesterSettings;
     buttons?: IButtonSettings;
     cwd?: string;
-    notebooks?: INotebooksSettings;
     enableReferencesCodeLens?: boolean;
     analyzeOpenDocumentsOnly?: boolean;
 }
@@ -130,10 +129,6 @@ export interface IPesterSettings {
 export interface IButtonSettings {
     showRunButtons?: boolean;
     showPanelMovementButtons?: boolean;
-}
-
-export interface INotebooksSettings {
-    saveMarkdownCellsAs?: CommentType;
 }
 
 // TODO: This could probably be async, and call `validateCwdSetting()` directly.
@@ -219,10 +214,6 @@ export function load(): ISettings {
         debugOutputVerbosity: "Diagnostic",
     };
 
-    const defaultNotebooksSettings: INotebooksSettings = {
-        saveMarkdownCellsAs: CommentType.BlockComment,
-    };
-
     // TODO: I believe all the defaults can be removed, as the `package.json` should supply them (and be the source of truth).
     return {
         startAutomatically:
@@ -261,8 +252,6 @@ export function load(): ISettings {
             configuration.get<IPesterSettings>("pester", defaultPesterSettings),
         buttons:
             configuration.get<IButtonSettings>("buttons", defaultButtonSettings),
-        notebooks:
-            configuration.get<INotebooksSettings>("notebooks", defaultNotebooksSettings),
         startAsLoginShell:
             // We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107
             //   "Unlike on Linux, ~/.profile is not sourced when logging into a macOS session. This

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,29 +6,32 @@ import utils = require("./utils");
 import os = require("os");
 import { Logger } from "./logging";
 
-export interface ISettings {
-    powerShellAdditionalExePaths: IPowerShellAdditionalExePathSettings;
-    powerShellDefaultVersion: string;
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+class PartialSettings { }
+
+export class Settings extends PartialSettings {
+    powerShellAdditionalExePaths: PowerShellAdditionalExePathSettings = {};
+    powerShellDefaultVersion = "";
     // This setting is no longer used but is here to assist in cleaning up the users settings.
-    powerShellExePath: string;
-    promptToUpdatePowerShell: boolean;
-    startAsLoginShell: IStartAsLoginShellSettings;
-    startAutomatically: boolean;
-    enableProfileLoading: boolean;
-    helpCompletion: string;
-    scriptAnalysis: IScriptAnalysisSettings;
-    debugging: IDebuggingSettings;
-    developer: IDeveloperSettings;
-    codeFolding: ICodeFoldingSettings;
-    codeFormatting: ICodeFormattingSettings;
-    integratedConsole: IIntegratedConsoleSettings;
-    bugReporting: IBugReportingSettings;
-    sideBar: ISideBarSettings;
-    pester: IPesterSettings;
-    buttons: IButtonSettings;
-    cwd: string;
-    enableReferencesCodeLens: boolean;
-    analyzeOpenDocumentsOnly: boolean;
+    powerShellExePath = "";
+    promptToUpdatePowerShell = true;
+    startAsLoginShell = new StartAsLoginShellSettings();
+    startAutomatically = true;
+    enableProfileLoading = true;
+    helpCompletion = CommentType.BlockComment;
+    scriptAnalysis = new ScriptAnalysisSettings();
+    debugging = new DebuggingSettings();
+    developer = new DeveloperSettings();
+    codeFolding = new CodeFoldingSettings();
+    codeFormatting = new CodeFormattingSettings();
+    integratedConsole = new IntegratedConsoleSettings();
+    bugReporting = new BugReportingSettings();
+    sideBar = new SideBarSettings();
+    pester = new PesterSettings();
+    buttons = new ButtonSettings();
+    cwd = "";
+    enableReferencesCodeLens = true;
+    analyzeOpenDocumentsOnly = false;
     // TODO: Add (deprecated) useX86Host (for testing)
 }
 
@@ -61,202 +64,96 @@ export enum CommentType {
     LineComment = "LineComment",
 }
 
-export type IPowerShellAdditionalExePathSettings = Record<string, string>;
+export type PowerShellAdditionalExePathSettings = Record<string, string>;
 
-export interface IBugReportingSettings {
-    project: string;
+class BugReportingSettings extends PartialSettings {
+    project = "https://github.com/PowerShell/vscode-powershell";
 }
 
-export interface ICodeFoldingSettings {
-    enable: boolean;
-    showLastLine: boolean;
+class CodeFoldingSettings extends PartialSettings {
+    enable = true;
+    showLastLine = true;
 }
 
-export interface ICodeFormattingSettings {
-    autoCorrectAliases: boolean;
-    avoidSemicolonsAsLineTerminators: boolean;
-    preset: CodeFormattingPreset;
-    openBraceOnSameLine: boolean;
-    newLineAfterOpenBrace: boolean;
-    newLineAfterCloseBrace: boolean;
-    pipelineIndentationStyle: PipelineIndentationStyle;
-    whitespaceBeforeOpenBrace: boolean;
-    whitespaceBeforeOpenParen: boolean;
-    whitespaceAroundOperator: boolean;
-    whitespaceAfterSeparator: boolean;
-    whitespaceBetweenParameters: boolean;
-    whitespaceInsideBrace: boolean;
-    addWhitespaceAroundPipe: boolean;
-    trimWhitespaceAroundPipe: boolean;
-    ignoreOneLineBlock: boolean;
-    alignPropertyValuePairs: boolean;
-    useConstantStrings: boolean;
-    useCorrectCasing: boolean;
+class CodeFormattingSettings extends PartialSettings {
+    autoCorrectAliases = false;
+    avoidSemicolonsAsLineTerminators = false;
+    preset = CodeFormattingPreset.Custom;
+    openBraceOnSameLine = true;
+    newLineAfterOpenBrace = true;
+    newLineAfterCloseBrace = true;
+    pipelineIndentationStyle = PipelineIndentationStyle.NoIndentation;
+    whitespaceBeforeOpenBrace = true;
+    whitespaceBeforeOpenParen = true;
+    whitespaceAroundOperator = true;
+    whitespaceAfterSeparator = true;
+    whitespaceBetweenParameters = false;
+    whitespaceInsideBrace = true;
+    addWhitespaceAroundPipe = true;
+    trimWhitespaceAroundPipe = false;
+    ignoreOneLineBlock = true;
+    alignPropertyValuePairs = true;
+    useConstantStrings = false;
+    useCorrectCasing = false;
 }
 
-export interface IScriptAnalysisSettings {
-    enable: boolean;
-    settingsPath: string;
+class ScriptAnalysisSettings extends PartialSettings {
+    enable = true;
+    settingsPath = "PSScriptAnalyzerSettings.psd1";
 }
 
-export interface IDebuggingSettings {
-    createTemporaryIntegratedConsole: boolean;
+class DebuggingSettings extends PartialSettings {
+    createTemporaryIntegratedConsole = false;
 }
 
-export interface IDeveloperSettings {
-    featureFlags: string[];
-    bundledModulesPath: string;
-    editorServicesLogLevel: LogLevel;
-    editorServicesWaitForDebugger: boolean;
-    waitForSessionFileTimeoutSeconds: number;
+class DeveloperSettings extends PartialSettings {
+    featureFlags = [];
+    // From `<root>/out/main.js` we go to the directory before <root> and
+    // then into the other repo.
+    bundledModulesPath = "../../PowerShellEditorServices/module";
+    editorServicesLogLevel = LogLevel.Normal;
+    editorServicesWaitForDebugger = false;
+    waitForSessionFileTimeoutSeconds = 240;
 }
 
-export interface IStartAsLoginShellSettings {
-    osx: boolean;
-    linux: boolean;
+// We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107
+//   "Unlike on Linux, ~/.profile is not sourced when logging into a macOS session. This
+//   is the reason terminals on macOS typically run login shells by default which set up
+//   the environment. See http://unix.stackexchange.com/a/119675/115410"
+class StartAsLoginShellSettings extends PartialSettings {
+    osx = true;
+    linux = false;
 }
 
-export interface IIntegratedConsoleSettings {
-    showOnStartup: boolean;
-    startInBackground: boolean;
-    focusConsoleOnExecute: boolean;
-    useLegacyReadLine: boolean;
-    forceClearScrollbackBuffer: boolean;
-    suppressStartupBanner: boolean;
+class IntegratedConsoleSettings extends PartialSettings {
+    showOnStartup = true;
+    startInBackground = false;
+    focusConsoleOnExecute = true;
+    useLegacyReadLine = false;
+    forceClearScrollbackBuffer = false;
+    suppressStartupBanner = false;
 }
 
-export interface ISideBarSettings {
+class SideBarSettings extends PartialSettings {
     // TODO: add CommandExplorerExcludeFilter
-    CommandExplorerVisibility: boolean;
+    CommandExplorerVisibility = true;
 }
 
-export interface IPesterSettings {
-    // TODO: add codeLens property
-    useLegacyCodeLens: boolean;
-    outputVerbosity: string;
-    debugOutputVerbosity: string;
+class PesterSettings extends PartialSettings {
+    useLegacyCodeLens = true;
+    outputVerbosity = "FromPreference";
+    debugOutputVerbosity = "Diagnostic";
 }
 
-export interface IButtonSettings {
-    showRunButtons: boolean;
-    showPanelMovementButtons: boolean;
-}
-
-export function getDefaultSettings() {
-    const defaultBugReportingSettings: IBugReportingSettings = {
-        project: "https://github.com/PowerShell/vscode-powershell",
-    };
-
-    const defaultScriptAnalysisSettings: IScriptAnalysisSettings = {
-        enable: true,
-        settingsPath: "PSScriptAnalyzerSettings.psd1",
-    };
-
-    const defaultDebuggingSettings: IDebuggingSettings = {
-        createTemporaryIntegratedConsole: false,
-    };
-
-    const defaultDeveloperSettings: IDeveloperSettings = {
-        featureFlags: [],
-        // From `<root>/out/main.js` we go to the directory before <root> and
-        // then into the other repo.
-        bundledModulesPath: "../../PowerShellEditorServices/module",
-        editorServicesLogLevel: LogLevel.Normal,
-        editorServicesWaitForDebugger: false,
-        waitForSessionFileTimeoutSeconds: 240,
-    };
-
-    const defaultCodeFoldingSettings: ICodeFoldingSettings = {
-        enable: true,
-        showLastLine: true,
-    };
-
-    const defaultCodeFormattingSettings: ICodeFormattingSettings = {
-        autoCorrectAliases: false,
-        avoidSemicolonsAsLineTerminators: false,
-        preset: CodeFormattingPreset.Custom,
-        openBraceOnSameLine: true,
-        newLineAfterOpenBrace: true,
-        newLineAfterCloseBrace: true,
-        pipelineIndentationStyle: PipelineIndentationStyle.NoIndentation,
-        whitespaceBeforeOpenBrace: true,
-        whitespaceBeforeOpenParen: true,
-        whitespaceAroundOperator: true,
-        whitespaceAfterSeparator: true,
-        whitespaceBetweenParameters: false,
-        whitespaceInsideBrace: true,
-        addWhitespaceAroundPipe: true,
-        trimWhitespaceAroundPipe: false,
-        ignoreOneLineBlock: true,
-        alignPropertyValuePairs: true,
-        useConstantStrings: false,
-        useCorrectCasing: false,
-    };
-
-    // We follow the same convention as VS Code - https://github.com/microsoft/vscode/blob/ff00badd955d6cfcb8eab5f25f3edc86b762f49f/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts#L105-L107
-    //   "Unlike on Linux, ~/.profile is not sourced when logging into a macOS session. This
-    //   is the reason terminals on macOS typically run login shells by default which set up
-    //   the environment. See http://unix.stackexchange.com/a/119675/115410"
-    const defaultStartAsLoginShellSettings: IStartAsLoginShellSettings = {
-        osx: true,
-        linux: false,
-    };
-
-    const defaultIntegratedConsoleSettings: IIntegratedConsoleSettings = {
-        showOnStartup: true,
-        startInBackground: false,
-        focusConsoleOnExecute: true,
-        useLegacyReadLine: false,
-        forceClearScrollbackBuffer: false,
-        suppressStartupBanner: false,
-    };
-
-    const defaultSideBarSettings: ISideBarSettings = {
-        CommandExplorerVisibility: true,
-    };
-
-    const defaultButtonSettings: IButtonSettings = {
-        showRunButtons: true,
-        showPanelMovementButtons: false
-    };
-
-    const defaultPesterSettings: IPesterSettings = {
-        useLegacyCodeLens: true,
-        outputVerbosity: "FromPreference",
-        debugOutputVerbosity: "Diagnostic",
-    };
-
-    const defaultSettings: ISettings = {
-        startAutomatically: true,
-        powerShellAdditionalExePaths: {},
-        powerShellDefaultVersion: "",
-        powerShellExePath: "",
-        promptToUpdatePowerShell: true,
-        enableProfileLoading: true,
-        helpCompletion: CommentType.BlockComment,
-        scriptAnalysis: defaultScriptAnalysisSettings,
-        debugging: defaultDebuggingSettings,
-        developer: defaultDeveloperSettings,
-        codeFolding: defaultCodeFoldingSettings,
-        codeFormatting: defaultCodeFormattingSettings,
-        integratedConsole: defaultIntegratedConsoleSettings,
-        bugReporting: defaultBugReportingSettings,
-        sideBar: defaultSideBarSettings,
-        pester: defaultPesterSettings,
-        buttons: defaultButtonSettings,
-        startAsLoginShell: defaultStartAsLoginShellSettings,
-        cwd: "",
-        enableReferencesCodeLens: true,
-        analyzeOpenDocumentsOnly: false,
-    };
-
-    return defaultSettings;
+class ButtonSettings extends PartialSettings {
+    showRunButtons = true;
+    showPanelMovementButtons = false;
 }
 
 // This is a recursive function which unpacks a WorkspaceConfiguration into our settings.
 function getSetting<TSetting>(key: string | undefined, value: TSetting, configuration: vscode.WorkspaceConfiguration): TSetting {
     // Base case where we're looking at a primitive type (or our special record).
-    if (key !== undefined && (typeof (value) !== "object" || key === "powerShellAdditionalExePaths")) {
+    if (key !== undefined && !(value instanceof PartialSettings)) {
         return configuration.get<TSetting>(key, value);
     }
 
@@ -269,11 +166,11 @@ function getSetting<TSetting>(key: string | undefined, value: TSetting, configur
     return value;
 }
 
-export function getSettings(): ISettings {
+export function getSettings(): Settings {
     const configuration: vscode.WorkspaceConfiguration =
         vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
 
-    return getSetting(undefined, getDefaultSettings(), configuration);
+    return getSetting(undefined, new Settings(), configuration);
 }
 
 // Get the ConfigurationTarget (read: scope) of where the *effective* setting value comes from

--- a/test/.vscode/settings.json
+++ b/test/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
   "terminal.integrated.shellIntegration.enabled": false,
   "powershell.enableProfileLoading": false,
+  "powershell.powerShellAdditionalExePaths": {
+    "Some PowerShell": "somePath"
+  },
 }

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -3,25 +3,34 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { CommentType, getSettings, changeSetting, getEffectiveConfigurationTarget } from "../../src/settings";
+import * as settings from "../../src/settings";
 
 describe("Settings module", function () {
     it("Loads without error", function () {
-        assert.doesNotThrow(getSettings);
+        assert.doesNotThrow(settings.getSettings);
     });
 
+    it("Loads the correct defaults", function () {
+        const testSettings = settings.getDefaultSettings();
+        testSettings.enableProfileLoading = false;
+        testSettings.powerShellAdditionalExePaths = { "Some PowerShell": "somePath" };
+        const actualSettings = settings.getSettings();
+        assert.deepStrictEqual(actualSettings, testSettings);
+    });
+
+
     it("Updates correctly", async function () {
-        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
-        assert.strictEqual(getSettings().helpCompletion, CommentType.LineComment);
+        await settings.changeSetting("helpCompletion", settings.CommentType.LineComment, false, undefined);
+        assert.strictEqual(settings.getSettings().helpCompletion, settings.CommentType.LineComment);
     });
 
     it("Gets the effective configuration target", async function () {
-        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
-        let target = getEffectiveConfigurationTarget("helpCompletion");
+        await settings.changeSetting("helpCompletion", settings.CommentType.LineComment, false, undefined);
+        let target = settings.getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
 
-        await changeSetting("helpCompletion", undefined, false, undefined);
-        target = getEffectiveConfigurationTarget("helpCompletion");
+        await settings.changeSetting("helpCompletion", undefined, false, undefined);
+        target = settings.getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, undefined);
     });
 });

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -11,7 +11,7 @@ describe("Settings module", function () {
     });
 
     it("Loads the correct defaults", function () {
-        const testSettings = settings.getDefaultSettings();
+        const testSettings = new settings.Settings();
         testSettings.enableProfileLoading = false;
         testSettings.powerShellAdditionalExePaths = { "Some PowerShell": "somePath" };
         const actualSettings = settings.getSettings();

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -3,25 +3,25 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import Settings = require("../../src/settings");
+import { CommentType, getSettings, changeSetting, getEffectiveConfigurationTarget } from "../../src/settings";
 
 describe("Settings module", function () {
     it("Loads without error", function () {
-        assert.doesNotThrow(Settings.load);
+        assert.doesNotThrow(getSettings);
     });
 
     it("Updates correctly", async function () {
-        await Settings.change("helpCompletion", "LineComment", false, undefined);
-        assert.strictEqual(Settings.load().helpCompletion, "LineComment");
+        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
+        assert.strictEqual(getSettings().helpCompletion, CommentType.LineComment);
     });
 
     it("Gets the effective configuration target", async function () {
-        await Settings.change("helpCompletion", "LineComment", false, undefined);
-        let target = Settings.getEffectiveConfigurationTarget("helpCompletion");
+        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
+        let target = getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
 
-        await Settings.change("helpCompletion", undefined, false, undefined);
-        target = Settings.getEffectiveConfigurationTarget("helpCompletion");
+        await changeSetting("helpCompletion", undefined, false, undefined);
+        target = getEffectiveConfigurationTarget("helpCompletion");
         assert.strictEqual(target, undefined);
     });
 });


### PR DESCRIPTION
This adds logging to our `changeSetting()` function so we can track what settings the extension makes changes to (mostly because we're really confused how `editorServicesWaitForDebugger` keeps getting turned on). It also finishes a clean up started in the strict-mode refactor to make the settings fields non-optional and uses a recursive function to populate `ISettings` from the `WorkspaceConfiguration`, complete with a regression test (which will fail if you run the tests from the launch config and have modified settings).