### PR TITLE
Update `dotnet` in CI because PSES was updated

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -43,9 +43,17 @@ steps:
 
 - task: UseDotNet@2
   condition: not(${{ parameters.usePipelineArtifact }})
-  displayName: Install .NET 6.0.x SDK
+  displayName: Install .NET 7.0.x SDK
   inputs:
     packageType: sdk
+    version: 7.0.x
+    performMultiLevelLookup: true
+
+- task: UseDotNet@2
+  condition: not(${{ parameters.usePipelineArtifact }})
+  displayName: Install .NET 6.0.x runtime
+  inputs:
+    packageType: runtime
     version: 6.0.x
     performMultiLevelLookup: true
 


### PR DESCRIPTION
PowerShell Editor Services now requires .NET 7 for building and testing against PowerShell 7.3.