### PR TITLE
Send shell integration setting to server

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -635,6 +635,7 @@ Type 'help' to get help.
             initializationOptions: {
                 enableProfileLoading: this.sessionSettings.enableProfileLoading,
                 initialWorkingDirectory: this.sessionSettings.cwd,
+                shellIntegrationEnabled: vscode.workspace.getConfiguration("terminal.integrated.shellIntegration").get<boolean>("enabled"),
             },
             errorHandler: {
                 // Override the default error handler to prevent it from


### PR DESCRIPTION
Ideally the server should just be able to query it, but OmniSharp's `getConfiguration` is a bit cryptic, and this was a surefire way to do the same thing without having to figure that out.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
