### PR TITLE
Make `Logger.WriteLine` thread-safe and fix bug with UNC paths

### DIFF
--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -169,7 +169,9 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
     }
 
     public getStorageUri(): vscode.Uri {
-        return this.extensionContext.globalStorageUri;
+        // We have to override the scheme because it defaults to
+        // 'vscode-userdata' which breaks UNC paths.
+        return this.extensionContext.globalStorageUri.with({ scheme: "file"});
     }
 
     public dispose() {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -40,8 +40,10 @@ export class Logger implements ILogger {
     constructor(logLevelName: string, globalStorageUri: vscode.Uri) {
         this.logLevel = Logger.logLevelNameToValue(logLevelName);
         this.logChannel = vscode.window.createOutputChannel("PowerShell Extension Logs");
+        // We have to override the scheme because it defaults to
+        // 'vscode-userdata' which breaks UNC paths.
         this.logDirectoryPath = vscode.Uri.joinPath(
-            globalStorageUri,
+            globalStorageUri.with({ scheme: "file" }),
             "logs",
             `${Math.floor(Date.now() / 1000)}-${vscode.env.sessionId}`);
         this.logFilePath = this.getLogFilePath("vscode-powershell");

--- a/src/session.ts
+++ b/src/session.ts
@@ -111,7 +111,9 @@ export class SessionManager implements Middleware {
 
         // Create the language status item
         this.languageStatusItem = this.createStatusBarItem();
-        this.sessionsFolder = vscode.Uri.joinPath(extensionContext.globalStorageUri, "sessions");
+        // We have to override the scheme because it defaults to
+        // 'vscode-userdata' which breaks UNC paths.
+        this.sessionsFolder = vscode.Uri.joinPath(extensionContext.globalStorageUri.with({ scheme: "file"}), "sessions");
         this.platformDetails = getPlatformDetails();
         this.HostName = hostName;
         this.HostVersion = hostVersion;


### PR DESCRIPTION
This adds a simple lock to `Logger.WriteLine` since it's not re-entrant, hence we were losing logs. Now concurrent calls to it wait for each other to finish. It also _should_ fix https://github.com/PowerShell/vscode-powershell/issues/4202, as the bug appears to be with the scheme used in `globalStorageUri` being `vscode-userdata` instead of `file`, and `vscode.Uri.fsPath` claiming it does not care about the scheme, but in fact essentially requires it to be `file`.