### PR TITLE
Stop installing .NET 3.1 runtime

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -57,14 +57,6 @@ steps:
     version: 6.0.x
     performMultiLevelLookup: true
 
-- task: UseDotNet@2
-  condition: not(${{ parameters.usePipelineArtifact }})
-  displayName: Install .NET 3.1.x runtime
-  inputs:
-    packageType: runtime
-    version: 3.1.x
-    performMultiLevelLookup: true
-
 - task: PowerShell@2
   displayName: Build and test
   inputs:


### PR DESCRIPTION
Since PSES no longer needs it after deprecating PowerShell 7.0, per https://github.com/PowerShell/PowerShellEditorServices/pull/1967.