### PR TITLE
Delete skipped examples folder test

### DIFF
--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -14,13 +14,6 @@ describe("Path assumptions", function () {
         globalStorageUri = extension.getStorageUri();
     });
 
-    // TODO: This is skipped because it interferes with other tests. Either
-    // need to find a way to close the opened folder via a Code API, or find
-    // another way to test this.
-    it.skip("Opens the examples folder at the expected path", async function () {
-        assert(await vscode.commands.executeCommand("PowerShell.OpenExamplesFolder"));
-    });
-
     it("Creates the session folder at the correct path", async function () {
         assert(await checkIfDirectoryExists(vscode.Uri.joinPath(globalStorageUri, "sessions")));
     });


### PR DESCRIPTION
We never found a way to run this without breaking other tests, and it's not that important, so let's remove it.