### PR TITLE
Hide last line in folded ranges for ISE Mode

### DIFF
--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -23,7 +23,8 @@ export class ISECompatibilityFeature implements vscode.Disposable {
         { path: "files", name: "defaultLanguage", value: "powershell" },
         { path: "workbench", name: "colorTheme", value: "PowerShell ISE" },
         { path: "editor", name: "wordSeparators", value: "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?" },
-        { path: "powershell.buttons", name: "showPanelMovementButtons", value: true }
+        { path: "powershell.buttons", name: "showPanelMovementButtons", value: true },
+        { path: "powershell.codeFolding", name: "showLastLine", value: false }
     ];
 
     private _commandRegistrations: vscode.Disposable[] = [];


### PR DESCRIPTION
## PR Summary

PowerShell ISE folds ranges to a single line unlike the current default in this extension:
![image](https://user-images.githubusercontent.com/3436158/219868697-0a195bd8-4bf9-4ee2-8eab-d214bbfe5df9.png)
![image](https://user-images.githubusercontent.com/3436158/219868718-2cc8e456-e567-4beb-9413-680f98db6f4f.png)

This PR sets the `powershell.codeFolding.showLastLine` option to `false` in ISE mode to be more similar with ISE behavior.
![image](https://user-images.githubusercontent.com/3436158/219868686-f6cf43a3-ace4-400d-b5ee-d3b792727156.png)

There is one major difference: ISE appended the closing char for most ranges which VSCode doesn't atm. That might be a dealbreaker, so submitting as a suggestion without discussion. Feel free to close if you don't agree.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress