### PR TITLE
Remove `preview` label from marketplace

### DIFF
--- a/.vsts-ci/templates/ci-general.yml
+++ b/.vsts-ci/templates/ci-general.yml
@@ -7,13 +7,6 @@ parameters:
     default: false
 
 steps:
-- task: PowerShell@2
-  displayName: PowerShell version
-  inputs:
-    targetType: inline
-    script: $PSVersionTable
-    pwsh: ${{ parameters.pwsh }}
-
 - checkout: self
 
 # NOTE: We either checkout the Git repo for PowerShellEditorServices, or we
@@ -62,18 +55,31 @@ steps:
     version: 6.0.x
     performMultiLevelLookup: true
 
+# The build script is always run with PowerShell Core
 - task: PowerShell@2
-  displayName: Build and test
+  displayName: Build and package
   inputs:
     targetType: inline
     script: |
+      Install-Module InvokeBuild -Scope CurrentUser -Force
+      Install-Module platyPS -Scope CurrentUser -Force
+      Invoke-Build -Configuration Release Package
+      $PackageJson = Get-Content -Raw package.json | ConvertFrom-Json
+      Write-Host "##vso[task.setvariable variable=vsixPath]$(Resolve-Path powershell-$($PackageJson.version).vsix)"
+    workingDirectory: $(Build.SourcesDirectory)/vscode-powershell
+    pwsh: true
+
+# Tests in particular are run with either PowerShell Core or Windows PowerShell
+- task: PowerShell@2
+  displayName: Run unit tests
+  inputs:
+    targetType: inline
+    script: |
+      $PSVersionTable
       Get-ChildItem env:
       Get-Module -ListAvailable Pester
       Install-Module InvokeBuild -Scope CurrentUser -Force
-      Install-Module platyPS -Scope CurrentUser -Force
-      Invoke-Build -Configuration Release
-      $PackageJson = Get-Content -Raw package.json | ConvertFrom-Json
-      Write-Host "##vso[task.setvariable variable=vsixPath]$(Resolve-Path powershell-$($PackageJson.version).vsix)"
+      Invoke-Build -Configuration Release Test
     workingDirectory: $(Build.SourcesDirectory)/vscode-powershell
     pwsh: ${{ parameters.pwsh }}
 
@@ -87,7 +93,7 @@ steps:
         Write-Host '##vso[task.LogIssue type=error;]PowerShell Editor Services bits were not built in release configuration!'
         exit 1
       }
-    pwsh: ${{ parameters.pwsh }}
+    pwsh: true
 
 - publish: $(vsixPath)
   artifact: vscode-powershell-vsix-$(System.JobId)

--- a/.vsts-ci/templates/publish-markets.yml
+++ b/.vsts-ci/templates/publish-markets.yml
@@ -7,11 +7,13 @@ steps:
 
 - pwsh: |
     npm ci --loglevel=error
-    $PackageJson = Get-Content -Raw $(Build.SourcesDirectory)/package.json | ConvertFrom-Json
+    Import-Module $(Build.SourcesDirectory)/tools/ReleaseTools.psm1
+    $Version = Get-Version -RepositoryName vscode-powershell
+    $PackageVersion = Get-MajorMinorPatch -Version $Version
     $PublishArgs = @(
-      if ($PackageJson.preview) { '--pre-release' }
+      if (Test-IsPreRelease) { '--pre-release' }
       '--packagePath'
-      "$(Pipeline.Workspace)/vscode-powershell/powershell-$($PackageJson.version).vsix"
+      "$(Pipeline.Workspace)/vscode-powershell/powershell-$PackageVersion.vsix"
       '--pat'
       '$(VsceToken)'
     )

--- a/.vsts-ci/templates/publish-markets.yml
+++ b/.vsts-ci/templates/publish-markets.yml
@@ -7,7 +7,7 @@ steps:
 
 - pwsh: |
     npm ci --loglevel=error
-    Import-Module $(Build.SourcesDirectory)/tools/ReleaseTools.psm1
+    Import-Module $(Build.SourcesDirectory)/tools/VersionTools.psm1
     $Version = Get-Version -RepositoryName vscode-powershell
     $PackageVersion = Get-MajorMinorPatch -Version $Version
     $PublishArgs = @(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -854,7 +854,7 @@ major update.
 
 These major updates have also been tested over the last 6 months, in 13 releases of our
 [PowerShell Preview extension for Visual Studio
-Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell-preview). A
+Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.powershell). A
 huge thank you to all of the community members who have tested these changes to the
 extension and have worked with us to polish the extension before releasing it through our
 stable channel.
@@ -1079,7 +1079,7 @@ are updating the stable extension to bring some bug fixes forward. Please try ou
 [PowerShell Preview extension][] for the latest and hopefully greatest experience, and
 help us squash those bugs!
 
-[PowerShell Preview extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell-Preview
+[PowerShell Preview extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.powershell
 
 #### [PowerShellEditorServices](https://github.com/PowerShell/PowerShellEditorServices)
 

--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -17,7 +17,7 @@
       "josefpihrt-vscode.roslynator",
       "ms-azure-devops.azure-pipelines",
       "ms-dotnettools.csharp",
-      "ms-vscode.powershell-preview"
+      "ms-vscode.powershell"
     ]
   },
   "settings": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "powershell",
   "displayName": "PowerShell",
   "version": "2023.3.1",
-  "preview": true,
+  "preview": false,
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",
   "engines": {
@@ -23,7 +23,7 @@
     "PowerShell",
     "pwsh"
   ],
-  "icon": "media/PowerShell_Preview_Icon.png",
+  "icon": "media/PowerShell_Icon.png",
   "galleryBanner": {
     "color": "#ACD1EC",
     "theme": "light"

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -72,9 +72,8 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
             throw new Error(`No extension installed with id '${id}'. You must use a valid extension id.`);
         }
 
-        // These are only allowed to be used in our unit tests.
-        if ((id === "ms-vscode.powershell" || id === "ms-vscode.powershell-preview")
-            && !(this.extensionContext.extensionMode === vscode.ExtensionMode.Test)) {
+        // Our ID is only only allowed to be used in our unit tests.
+        if (id === "ms-vscode.powershell" && !(this.extensionContext.extensionMode === vscode.ExtensionMode.Test)) {
             throw new Error("You can't use the PowerShell extension's id in this registration.");
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,14 +56,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
 
     telemetryReporter = new TelemetryReporter(PackageJSON.name, PackageJSON.version, AI_KEY);
 
-    // If both extensions are enabled, this will cause unexpected behavior since both register the same commands.
-    // TODO: Merge extensions and use preview channel in marketplace instead.
-    if (PackageJSON.name.toLowerCase() === "powershell-preview"
-        && vscode.extensions.getExtension("ms-vscode.powershell")) {
-        void logger.writeAndShowError(
-            "'PowerShell' and 'PowerShell Preview' are both enabled. Please disable one for best performance.");
-    }
-
     // Load and validate settings (will prompt for 'cwd' if necessary).
     await validateCwdSetting(logger);
     const settings = getSettings();

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -6,40 +6,26 @@
 using module PowerShellForGitHub
 using namespace System.Management.Automation
 
-class RepoNames: IValidateSetValuesGenerator {
-    # NOTE: This is super over-engineered, but it was fun.
-    static [string[]] $Values = "vscode-powershell", "PowerShellEditorServices"
-    [String[]] GetValidValues() { return [RepoNames]::Values }
-}
-
-$ChangelogFile = "CHANGELOG.md"
+Import-Module $PSScriptRoot/VersionTools.psm1
 
 <#
 .SYNOPSIS
-  Given the repository name, execute the script in its directory.
+  Creates and checks out `release` if not already on it.
 #>
-function Use-Repository {
-    [CmdletBinding()]
+function Update-Branch {
+    [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
         [ValidateSet([RepoNames])]
-        [string]$RepositoryName,
-
-        [Parameter(Mandatory)]
-        [scriptblock]$Script
+        [string]$RepositoryName
     )
-    try {
-        switch ($RepositoryName) {
-            "vscode-powershell" {
-                Push-Location -Path "$PSScriptRoot/../"
-            }
-            "PowerShellEditorServices" {
-                Push-Location -Path "$PSScriptRoot/../../PowerShellEditorServices"
+    Use-Repository -RepositoryName $RepositoryName -Script {
+        $Branch = git branch --show-current
+        if ($Branch -ne "release") {
+            if ($PSCmdlet.ShouldProcess("release", "git checkout -B")) {
+                git checkout -B "release"
             }
         }
-        & $Script
-    } finally {
-        Pop-Location
     }
 }
 
@@ -141,136 +127,6 @@ function Get-Bullets {
             ("-", $issueEmoji, $areaEmoji, "[$link]($($_.html_url))", "-", "$($_.title).", $thanks -join " ").Trim()
         }
     }
-}
-
-<#
-.SYNOPSIS
-  Gets the unpublished content from the changelog.
-.DESCRIPTION
-  This is used so that we can manually touch-up the automatically updated
-  changelog, and then bring its contents into the extension's changelog or
-  the GitHub release. It just gets the first header's contents.
-#>
-function Get-FirstChangelog {
-    param(
-        [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
-        [string]$RepositoryName
-    )
-    $Changelog = Use-Repository -RepositoryName $RepositoryName -Script {
-        Get-Content -Path $ChangelogFile
-    }
-    # NOTE: The space after the header marker is important! Otherwise ### matches.
-    $Header = $Changelog.Where({$_.StartsWith("## ")}, "First")
-    $Changelog.Where(
-        { $_ -eq $Header }, "SkipUntil"
-    ).Where(
-        { $_.StartsWith("## ") -and $_ -ne $Header }, "Until"
-    )
-}
-
-<#
-.SYNOPSIS
-  Creates and checks out `release` if not already on it.
-#>
-function Update-Branch {
-    [CmdletBinding(SupportsShouldProcess)]
-    param(
-        [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
-        [string]$RepositoryName
-    )
-    Use-Repository -RepositoryName $RepositoryName -Script {
-        $Branch = git branch --show-current
-        if ($Branch -ne "release") {
-            if ($PSCmdlet.ShouldProcess("release", "git checkout -B")) {
-                git checkout -B "release"
-            }
-        }
-    }
-}
-
-<#
-.SYNOPSIS
-  Gets current version from changelog as `[semver]`.
-#>
-function Get-Version {
-    param(
-        [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
-        [string]$RepositoryName
-    )
-    # NOTE: The first line should always be the header.
-    $Changelog = (Get-FirstChangelog -RepositoryName $RepositoryName)[0]
-    if ($Changelog -match '## v(?<version>\d+\.\d+\.\d+(-preview\.?\d*)?)') {
-        return [semver]$Matches.version
-    } else {
-        Write-Error "Couldn't find version from changelog!"
-    }
-}
-
-<#
-.SYNOPSIS
-  Gets the version as a semantic version string without the 'v' prefix or
-  pre-release suffix.
-#>
-function Get-MajorMinorPatch {
-    param(
-        [Parameter(Mandatory)]
-        [semver]$Version
-    )
-    return "$($Version.Major).$($Version.Minor).$($Version.Patch)"
-}
-
-<#
-.SYNOPSIS
-  Tests if this is a pre-release (specifically for the extension).
-#>
-function Test-IsPreRelease {
-    $Version = Get-Version -RepositoryName vscode-powershell
-    return [bool]$Version.PreReleaseLabel
-}
-
-<#
-.SYNOPSIS
-  Validates the given version string.
-#>
-function Test-VersionIsValid {
-    param(
-        [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
-        [string]$RepositoryName,
-
-        [Parameter(Mandatory)]
-        [string]$Version
-    )
-    if (!$Version.StartsWith("v")) {
-        throw "Version should start with 'v' prefix!"
-    }
-
-    $SemanticVersion = [semver]$Version.Substring(1)
-    switch ($RepositoryName) {
-        "vscode-powershell" {
-            $Date = Get-Date
-            if ($SemanticVersion.Major -ne $Date.Year) {
-                throw "Major version should be the current year!"
-            }
-            if ($SemanticVersion.Minor -ne $Date.Month) {
-                throw "Minor version should be the current month!"
-            }
-            if ($SemanticVersion.PreReleaseLabel) {
-                if ($SemanticVersion.PreReleaseLabel -ne "preview") {
-                    throw "Suffix should only be 'preview'!"
-                }
-            }
-        }
-        "PowerShellEditorServices" {
-            if ($SemanticVersion.PreReleaseLabel) {
-                throw "Version shouldn't have a pre-release label!"
-            }
-        }
-    }
-    return $true
 }
 
 <#

--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -145,9 +145,11 @@ function Update-Changelog {
         [string]$RepositoryName,
 
         [Parameter(Mandatory)]
-        [ValidateScript({ Test-VersionIsValid -RepositoryName $RepositoryName -Version $_ })]
         [string]$Version
     )
+
+    # Since we depend on both parameters, we can't do this with `ValidateScript`.
+    Test-VersionIsValid -RepositoryName $RepositoryName -Version $Version
 
     # Get the repo object, latest release, and commits since its tag.
     $Repo = Get-GitHubRepository -OwnerName PowerShell -RepositoryName $RepositoryName

--- a/tools/VersionTools.psm1
+++ b/tools/VersionTools.psm1
@@ -5,7 +5,7 @@
 
 using namespace System.Management.Automation
 
-class RepoNames: IValidateSetValuesGenerator {
+class RepoNames : IValidateSetValuesGenerator {
     # NOTE: This is super over-engineered, but it was fun.
     static [string[]] $Values = "vscode-powershell", "PowerShellEditorServices"
     [String[]] GetValidValues() { return [RepoNames]::Values }
@@ -150,5 +150,4 @@ function Test-VersionIsValid {
             }
         }
     }
-    return $true
 }

--- a/tools/VersionTools.psm1
+++ b/tools/VersionTools.psm1
@@ -1,0 +1,152 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#requires -Version 7.0
+
+using namespace System.Management.Automation
+
+class RepoNames: IValidateSetValuesGenerator {
+    # NOTE: This is super over-engineered, but it was fun.
+    static [string[]] $Values = "vscode-powershell", "PowerShellEditorServices"
+    [String[]] GetValidValues() { return [RepoNames]::Values }
+}
+
+$ChangelogFile = "CHANGELOG.md"
+
+<#
+.SYNOPSIS
+  Given the repository name, execute the script in its directory.
+#>
+function Use-Repository {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet([RepoNames])]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory)]
+        [scriptblock]$Script
+    )
+    try {
+        switch ($RepositoryName) {
+            "vscode-powershell" {
+                Push-Location -Path "$PSScriptRoot/../"
+            }
+            "PowerShellEditorServices" {
+                Push-Location -Path "$PSScriptRoot/../../PowerShellEditorServices"
+            }
+        }
+        & $Script
+    } finally {
+        Pop-Location
+    }
+}
+
+<#
+.SYNOPSIS
+  Gets the unpublished content from the changelog.
+.DESCRIPTION
+  This is used so that we can manually touch-up the automatically updated
+  changelog, and then bring its contents into the extension's changelog or
+  the GitHub release. It just gets the first header's contents.
+#>
+function Get-FirstChangelog {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet([RepoNames])]
+        [string]$RepositoryName
+    )
+    $Changelog = Use-Repository -RepositoryName $RepositoryName -Script {
+        Get-Content -Path $ChangelogFile
+    }
+    # NOTE: The space after the header marker is important! Otherwise ### matches.
+    $Header = $Changelog.Where({$_.StartsWith("## ")}, "First")
+    $Changelog.Where(
+        { $_ -eq $Header }, "SkipUntil"
+    ).Where(
+        { $_.StartsWith("## ") -and $_ -ne $Header }, "Until"
+    )
+}
+
+<#
+.SYNOPSIS
+  Gets current version from changelog as `[semver]`.
+#>
+function Get-Version {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet([RepoNames])]
+        [string]$RepositoryName
+    )
+    # NOTE: The first line should always be the header.
+    $Changelog = (Get-FirstChangelog -RepositoryName $RepositoryName)[0]
+    if ($Changelog -match '## v(?<version>\d+\.\d+\.\d+(-preview\.?\d*)?)') {
+        return [semver]$Matches.version
+    } else {
+        Write-Error "Couldn't find version from changelog!"
+    }
+}
+
+<#
+.SYNOPSIS
+  Gets the version as a semantic version string without the 'v' prefix or
+  pre-release suffix.
+#>
+function Get-MajorMinorPatch {
+    param(
+        [Parameter(Mandatory)]
+        [semver]$Version
+    )
+    return "$($Version.Major).$($Version.Minor).$($Version.Patch)"
+}
+
+<#
+.SYNOPSIS
+  Tests if this is a pre-release (specifically for the extension).
+#>
+function Test-IsPreRelease {
+    $Version = Get-Version -RepositoryName vscode-powershell
+    return [bool]$Version.PreReleaseLabel
+}
+
+<#
+.SYNOPSIS
+  Validates the given version string.
+#>
+function Test-VersionIsValid {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet([RepoNames])]
+        [string]$RepositoryName,
+
+        [Parameter(Mandatory)]
+        [string]$Version
+    )
+    if (!$Version.StartsWith("v")) {
+        throw "Version should start with 'v' prefix!"
+    }
+
+    $SemanticVersion = [semver]$Version.Substring(1)
+    switch ($RepositoryName) {
+        "vscode-powershell" {
+            $Date = Get-Date
+            if ($SemanticVersion.Major -ne $Date.Year) {
+                throw "Major version should be the current year!"
+            }
+            if ($SemanticVersion.Minor -ne $Date.Month) {
+                throw "Minor version should be the current month!"
+            }
+            if ($SemanticVersion.PreReleaseLabel) {
+                if ($SemanticVersion.PreReleaseLabel -ne "preview") {
+                    throw "Suffix should only be 'preview'!"
+                }
+            }
+        }
+        "PowerShellEditorServices" {
+            if ($SemanticVersion.PreReleaseLabel) {
+                throw "Version shouldn't have a pre-release label!"
+            }
+        }
+    }
+    return $true
+}

--- a/tools/VersionTools.psm1
+++ b/tools/VersionTools.psm1
@@ -144,7 +144,9 @@ function Test-VersionIsValid {
         }
         "PowerShellEditorServices" {
             if ($SemanticVersion.PreReleaseLabel) {
-                throw "Version shouldn't have a pre-release label!"
+                if ($SemanticVersion.PreReleaseLabel -ne "preview") {
+                    throw "Suffix should only be 'preview'!"
+                }
             }
         }
     }

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -9,14 +9,6 @@ param(
 
 #Requires -Modules @{ ModuleName = "InvokeBuild"; ModuleVersion = "3.0.0" }
 
-# Sanity check our changelog version versus package.json (which lacks pre-release label)
-Import-Module $PSScriptRoot/tools/VersionTools.psm1
-$script:Version = Get-Version -RepositoryName vscode-powershell
-$script:PackageVersion = Get-MajorMinorPatch -Version $Version
-$script:PackageJson = Get-Content -Raw $PSScriptRoot/package.json | ConvertFrom-Json
-Assert-Build ($script:PackageJson.version -eq $script:PackageVersion)
-Write-Host "`n### Building Extension Version: $script:Version`n" -ForegroundColor Green
-
 function Get-EditorServicesPath {
     $psesRepoPath = if ($EditorServicesRepoPath) {
         $EditorServicesRepoPath
@@ -133,7 +125,14 @@ task TestEditorServices -If (Get-EditorServicesPath) {
 #region Package tasks
 
 task Package Build, {
-    Write-Host "`n### Packaging powershell-$script:PackageVersion.vsix`n" -ForegroundColor Green
+    # Sanity check our changelog version versus package.json (which lacks pre-release label)
+    Import-Module $PSScriptRoot/tools/VersionTools.psm1
+    $version = Get-Version -RepositoryName vscode-powershell
+    $packageVersion = Get-MajorMinorPatch -Version $version
+    $packageJson = Get-Content -Raw $PSScriptRoot/package.json | ConvertFrom-Json
+    Assert-Build ($packageJson.version -eq $packageVersion)
+
+    Write-Host "`n### Packaging powershell-$packageVersion.vsix`n" -ForegroundColor Green
     Assert-Build ((Get-Item ./modules).LinkType -ne "SymbolicLink") "Packaging requires a copy of PSES, not a symlink!"
     if (Test-IsPreRelease) {
         Write-Host "`n### This is a pre-release!`n" -ForegroundColor Green

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -10,7 +10,7 @@ param(
 #Requires -Modules @{ ModuleName = "InvokeBuild"; ModuleVersion = "3.0.0" }
 
 # Sanity check our changelog version versus package.json (which lacks pre-release label)
-Import-Module $PSScriptRoot/tools/ReleaseTools.psm1
+Import-Module $PSScriptRoot/tools/VersionTools.psm1
 $script:Version = Get-Version -RepositoryName vscode-powershell
 $script:PackageVersion = Get-MajorMinorPatch -Version $Version
 $script:PackageJson = Get-Content -Raw $PSScriptRoot/package.json | ConvertFrom-Json


### PR DESCRIPTION
This was a lot of annoying work just to remove the `preview` label from the marketplace web page, since it shows from the "latest" (inclusive of pre-release) releases. Our only other way to determine at package and release time that a version is a pre-release is to re-use the version-from-changelog logic of the release tools. But that meant splitting out the relevant parts so the build script didn't take a dependency on the `PowerShellForGitHub` module, and splitting the CI into a "build and package" step separate from a "test" step. The latter happened because in CI we test against PowerShell 5.1...and that doesn't have the `semver` type, so it _couldn't_ use the version logic, hence the "build and package" step now requires PowerShell Core. 🙃

But hey, at least I snuck in a fix for a long-standing `TODO` to better validate the version number we hand to the release tools when doing a release.