### PR TITLE
Remove problematic `[RepoNames]` PowerShell class

### DIFF
--- a/tools/ReleaseTools.psm1
+++ b/tools/ReleaseTools.psm1
@@ -16,7 +16,6 @@ function Update-Branch {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
         [string]$RepositoryName
     )
     Use-Repository -RepositoryName $RepositoryName -Script {
@@ -37,7 +36,6 @@ function Get-Bullets {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
         [string]$RepositoryName,
 
         [Parameter(Mandatory, ValueFromPipeline)]
@@ -97,7 +95,7 @@ function Get-Bullets {
 
         # NOTE: The URL matcher must be explicit because the body of a PR may
         # contain other URLs with digits (like an image asset).
-        $IssueRegex = '(' + ($CloseKeywords -join '|') + ')\s+((https://github.com/PowerShell/(?<repo>(' + ([RepoNames]::Values -join '|') + '))/issues/)|#)(?<number>\d+)'
+        $IssueRegex = '(' + ($CloseKeywords -join '|') + ')\s+((https://github.com/PowerShell/(?<repo>(vscode-powershell|PowerShellEditorServices))/issues/)|#)(?<number>\d+)'
     }
 
     process {
@@ -112,7 +110,7 @@ function Get-Bullets {
                 $number = $Matches.number
                 $repo = $Matches.repo
                 # Handle links to issues in both repos, in both shortcode and URLs.
-                $name = [RepoNames]::Values | Where-Object { $repo -match $_ } | Select-Object -First 1
+                $name = ("vscode-powershell", "PowerShellEditorServices") | Where-Object { $repo -match $_ } | Select-Object -First 1
                 "$($name ?? $RepositoryName) #$number"
             } else {
                 "$RepositoryName #$($_.number)"
@@ -141,7 +139,7 @@ function Update-Changelog {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName,
 
         [Parameter(Mandatory)]
@@ -228,7 +226,7 @@ function Update-Version {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName
     )
     $Version = Get-Version -RepositoryName $RepositoryName
@@ -287,7 +285,7 @@ function New-ReleasePR {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName
     )
     $Version = Get-Version -RepositoryName $RepositoryName
@@ -340,11 +338,10 @@ function New-Release {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName,
 
         [Parameter(Mandatory)]
-        [ValidateScript({ $_.StartsWith("v") })]
         [string]$Version
     )
     # TODO: Automate rolling a preview to a stable release.
@@ -363,11 +360,9 @@ function New-ReleaseBundle {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateScript({ $_.StartsWith("v") })]
         [string]$PsesVersion,
 
         [Parameter(Mandatory)]
-        [ValidateScript({ $_.StartsWith("v") })]
         [string]$VsceVersion
     )
     "PowerShellEditorServices", "vscode-powershell" | ForEach-Object {
@@ -391,7 +386,6 @@ function New-DraftRelease {
     [CmdletBinding(SupportsShouldProcess)]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
         [string]$RepositoryName,
 
         [Parameter()]

--- a/tools/VersionTools.psm1
+++ b/tools/VersionTools.psm1
@@ -5,12 +5,6 @@
 
 using namespace System.Management.Automation
 
-class RepoNames : IValidateSetValuesGenerator {
-    # NOTE: This is super over-engineered, but it was fun.
-    static [string[]] $Values = "vscode-powershell", "PowerShellEditorServices"
-    [String[]] GetValidValues() { return [RepoNames]::Values }
-}
-
 $ChangelogFile = "CHANGELOG.md"
 
 <#
@@ -21,7 +15,7 @@ function Use-Repository {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName,
 
         [Parameter(Mandatory)]
@@ -53,7 +47,6 @@ function Use-Repository {
 function Get-FirstChangelog {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
         [string]$RepositoryName
     )
     $Changelog = Use-Repository -RepositoryName $RepositoryName -Script {
@@ -75,7 +68,6 @@ function Get-FirstChangelog {
 function Get-Version {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
         [string]$RepositoryName
     )
     # NOTE: The first line should always be the header.
@@ -116,7 +108,7 @@ function Test-IsPreRelease {
 function Test-VersionIsValid {
     param(
         [Parameter(Mandatory)]
-        [ValidateSet([RepoNames])]
+        [ValidateSet("vscode-powershell", "PowerShellEditorServices")]
         [string]$RepositoryName,
 
         [Parameter(Mandatory)]


### PR DESCRIPTION
It was admittedly over-engineered and caused problems since PowerShell classes aren't imported across modules.

Instead just use `ValidateSet` directly wherever the command is either use-facing or switches on the string directly.