### PR TITLE
Add Additional Debug Configuration Templates for Pester and Binary Modules

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -45,6 +45,10 @@ export enum DebugConfig {
     LaunchScript,
     InteractiveSession,
     AttachHostProcess,
+    RunPester,
+    ModuleInteractiveSession,
+    BinaryModule,
+    BinaryModulePester,
 }
 
 /** Make the implicit behavior of undefined and null in the debug api more explicit  */
@@ -55,7 +59,7 @@ type ResolveDebugConfigurationResult = DebugConfiguration | PREVENT_DEBUG_START 
 const PREVENT_DEBUG_START = undefined;
 const PREVENT_DEBUG_START_AND_OPEN_DEBUGCONFIG = null;
 
-
+/** Represents the various built-in debug configurations that will be advertised to the user if they choose "Add Config" from the launch debug config window */
 export const defaultDebugConfigurations: Record<DebugConfig, DebugConfiguration> = {
     [DebugConfig.LaunchCurrentFile]: {
         name: "PowerShell: Launch Current File",
@@ -81,6 +85,36 @@ export const defaultDebugConfigurations: Record<DebugConfig, DebugConfiguration>
         type: "PowerShell",
         request: "attach",
         runspaceId: 1,
+    },
+    [DebugConfig.RunPester]: {
+        name: "PowerShell: Run Pester Tests",
+        type: "PowerShell",
+        request: "launch",
+        script: "Invoke-Pester",
+        createTemporaryIntegratedConsole: true,
+        attachDotnetDebugger: true
+    },
+    [DebugConfig.ModuleInteractiveSession]: {
+        name: "PowerShell: Module Interactive Session",
+        type: "PowerShell",
+        request: "launch",
+        script: "Enter command to import your binary module, for example: \"Import-Module -Force ${workspaceFolder}/path/to/module.psd1|dll\"",
+    },
+    [DebugConfig.BinaryModule]: {
+        name: "PowerShell: Binary Module Interactive",
+        type: "PowerShell",
+        request: "launch",
+        script: "Enter command to import your binary module, for example: \"Import-Module -Force ${workspaceFolder}/path/to/module.psd1|dll\"",
+        createTemporaryIntegratedConsole: true,
+        attachDotnetDebugger: true
+    },
+    [DebugConfig.BinaryModulePester]: {
+        name: "PowerShell: Binary Module Pester Tests",
+        type: "PowerShell",
+        request: "launch",
+        script: "Invoke-Pester",
+        createTemporaryIntegratedConsole: true,
+        attachDotnetDebugger: true
     }
 };
 
@@ -146,6 +180,26 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 id: DebugConfig.AttachHostProcess,
                 label: "Attach",
                 description: "Attach the debugger to a running PowerShell Host Process",
+            },
+            {
+                id: DebugConfig.RunPester,
+                label: "Run Pester Tests",
+                description: "Debug Pester Tests detected in your current directory (runs Invoke-Pester)",
+            },
+            {
+                id: DebugConfig.ModuleInteractiveSession,
+                label: "Interactive Session (Module)",
+                description: "Debug commands executed from the PowerShell Extension Terminal after auto-loading your module",
+            },
+            {
+                id: DebugConfig.BinaryModule,
+                label: "Interactive Session (Binary Module)",
+                description: "Debug a .NET binary or hybrid module loaded into a PowerShell session. Breakpoints you set in your .NET (C#/F#/VB/etc.) code will be hit upon command execution. You may want to add a compile or watch action as a pre-launch task to this configuration.",
+            },
+            {
+                id: DebugConfig.RunPester,
+                label: "Run Pester Tests (Binary Module)",
+                description: "Debug a .NET binary or hybrid module by running pester tests. Breakpoints you set in your .NET (C#/F#/VB/etc.) code will be hit upon command execution. You may want to add a compile or watch action as a pre-launch task to this configuration.",
             },
         ];
 


### PR DESCRIPTION
## PR Summary

Adds more built-in configurations to help users get more easily started with debugging with Pester, debugging modules, and debugging binary modules.
![image](https://user-images.githubusercontent.com/15258962/231317081-b05e7042-ba5f-4d17-ae3b-48097ddf38e4.png)


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
