### PR TITLE
Add new debug configurations to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -501,6 +501,52 @@
               "request": "attach",
               "processId": "current"
             }
+          },
+          {
+            "label": "PowerShell: Run Pester Tests",
+            "description": "Debug Pester Tests detected in your current directory (runs Invoke-Pester)",
+            "body": {
+              "name": "PowerShell Run Pester Tests",
+              "type": "PowerShell",
+              "request": "launch",
+              "script": "Invoke-Pester",
+              "createTemporaryIntegratedConsole": true,
+              "attachDotnetDebugger": true
+            }
+          },
+          {
+            "label": "PowerShell: Interactive Session (Module)",
+            "description": "Debug commands executed from the PowerShell Extension Terminal after auto-loading your module",
+            "body": {
+              "name": "PowerShell: Module Interactive Session",
+              "type": "PowerShell",
+              "request": "launch",
+              "script": "Enter command to import your binary module, for example: \"Import-Module -Force ${workspaceFolder}/path/to/module.psd1|dll\""
+            }
+          },
+          {
+            "label": "PowerShell: Interactive Session (Binary Module)",
+            "description": "Debug a .NET binary or hybrid module loaded into a PowerShell session. Breakpoints you set in your .NET (C#/F#/VB/etc.) code will be hit upon command execution. You may want to add a compile or watch action as a pre-launch task to this configuration.",
+            "body": {
+              "name": "PowerShell: Binary Module Interactive",
+              "type": "PowerShell",
+              "request": "launch",
+              "script": "Enter command to import your binary module, for example: \"Import-Module -Force ${workspaceFolder}/path/to/module.psd1|dll\"",
+              "createTemporaryIntegratedConsole": true,
+              "attachDotnetDebugger": true
+            }
+          },
+          {
+            "label": "Run Pester Tests (Binary Module)",
+            "description": "Debug a .NET binary or hybrid module by running Pester tests. Breakpoints you set in your .NET (C#/F#/VB/etc.) code will be hit upon command execution. You may want to add a compile or watch action as a pre-launch task to this configuration.",
+            "body": {
+              "name": "PowerShell: Binary Module Pester Tests",
+              "type": "PowerShell",
+              "request": "launch",
+              "script": "Invoke-Pester",
+              "createTemporaryIntegratedConsole": true,
+              "attachDotnetDebugger": true
+            }
           }
         ],
         "configurationAttributes": {

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -64,10 +64,9 @@ describe("DebugSessionFeature", () => {
             });
 
             createDebugSessionFeatureStub({context: context});
-
             assert.ok(registerFactoryStub.calledOnce, "Debug adapter factory method called");
-            assert.ok(registerProviderStub.calledOnce, "Debug config provider method called");
-            assert.equal(context.subscriptions.length, 2, "DebugSessionFeature disposables populated");
+            assert.ok(registerProviderStub.calledTwice, "Debug config provider registered for both Initial and Dynamic");
+            assert.equal(context.subscriptions.length, 3, "DebugSessionFeature disposables populated");
             // TODO: Validate the registration content, such as the language name
         });
     });


### PR DESCRIPTION
## PR Summary

Currently, the initial debug configurations are not populating from `provideDebugConfiguration`. They must be manually populated into the package.json to work with the `Add Configuration` button in an existing launch.json

Reference: https://github.com/microsoft/vscode/issues/150663#issuecomment-1506134754

Also register debug session handler for both dynamic and initial in the event this ever does get fixed.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
