### PR TITLE
Fix `attachDotnetDebugger` with custom config

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -404,7 +404,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
 
     private getDotnetNamedConfigOrDefault(configName?: string): ResolveDebugConfigurationResult {
         if (configName) {
-            const debugConfigs = workspace.getConfiguration("launch").get<DebugConfiguration[]>("configurations") ?? [];
+            const debugConfigs = this.getLaunchConfigurations();
             return debugConfigs.find(({ type, request, name }) =>
                 type === "coreclr" &&
                 request === "attach" &&
@@ -423,6 +423,11 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 moduleLoad: false
             }
         };
+    }
+
+    /** Fetches all available vscode launch configurations. This is abstracted out for easier testing */
+    private getLaunchConfigurations(): DebugConfiguration[] {
+        return workspace.getConfiguration("launch").get<DebugConfiguration[]>("configurations") ?? [];
     }
 
     private async resolveAttachDebugConfiguration(config: DebugConfiguration): Promise<ResolveDebugConfigurationResult> {
@@ -742,3 +747,4 @@ export class PickRunspaceFeature extends LanguageClientConsumer {
         this.waitingForClientToken = undefined;
     }
 }
+

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -405,10 +405,10 @@ export class DebugSessionFeature extends LanguageClientConsumer
     private getDotnetNamedConfigOrDefault(configName?: string): ResolveDebugConfigurationResult {
         if (configName) {
             const debugConfigs = workspace.getConfiguration("launch").get<DebugConfiguration[]>("configurations") ?? [];
-            return debugConfigs.find(({ type, request, name, dotnetDebuggerConfigName }) =>
+            return debugConfigs.find(({ type, request, name }) =>
                 type === "coreclr" &&
                 request === "attach" &&
-                name === dotnetDebuggerConfigName
+                name === configName
             );
         }
 

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -354,7 +354,7 @@ describe("DebugSessionFeature", () => {
             assert.match(logger.writeAndShowError.firstCall.args[0], /matching launch config was not found/);
         });
 
-        it.only("Finds the correct dotnetDebuggerConfigName", async () => {
+        it("Finds the correct dotnetDebuggerConfigName", async () => {
             const foundDotnetConfig: DebugConfiguration = {
                 name: "TestDotnetAttachConfig",
                 request: "attach",

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -353,6 +353,56 @@ describe("DebugSessionFeature", () => {
             assert.equal(actual!, null);
             assert.match(logger.writeAndShowError.firstCall.args[0], /matching launch config was not found/);
         });
+
+        it.only("Finds the correct dotnetDebuggerConfigName", async () => {
+            const foundDotnetConfig: DebugConfiguration = {
+                name: "TestDotnetAttachConfig",
+                request: "attach",
+                type: "coreclr",
+            };
+            const candidateDotnetConfigs: DebugConfiguration[] = [
+                {
+                    name: "BadCandidate1",
+                    type: "powershell",
+                    request: "attach"
+                },
+                {
+                    name: "BadCandidate2",
+                    type: "coreclr",
+                    request: "attach"
+                },
+                { // This one has launch instead of attach and even tho it has same name, should not be matched
+                    name: foundDotnetConfig.name,
+                    type: "coreclr",
+                    request: "launch"
+                },
+                foundDotnetConfig, //This is the one we want to match
+                {
+                    name: foundDotnetConfig.name,
+                    type: "notcoreclrExactly",
+                    request: "attach"
+                },
+                {
+                    name: `${foundDotnetConfig.name}notexactlythisname`,
+                    type: "coreclr",
+                    request: "attach"
+                }
+            ];
+            const attachConfig = defaultDebugConfig;
+            attachConfig.script = "test.ps1"; // This bypasses the ${file} logic
+            attachConfig.createTemporaryIntegratedConsole = true;
+            attachConfig.attachDotnetDebugger = true;
+            attachConfig.dotnetDebuggerConfigName = foundDotnetConfig.name;
+            const debugSessionFeature = createDebugSessionFeatureStub({});
+
+            // The any is necessary to stub a private method
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            Sinon.stub(debugSessionFeature, "getLaunchConfigurations" as any).returns(candidateDotnetConfigs);
+
+            const config = await debugSessionFeature.resolveDebugConfigurationWithSubstitutedVariables(undefined, attachConfig);
+
+            assert.deepStrictEqual(config!.dotnetAttachConfig, foundDotnetConfig);
+        });
     });
 
     describe("createDebugAdapterDescriptor", () => {


### PR DESCRIPTION
## PR Summary

Fixes `dotnetDebuggerConfigName`-option in launch config when using new `attachDotnetDebugger` feature introduced in #3903. Always threw config not found-error when `dotnetDebuggerConfigName` was set.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
