### PR TITLE
Handle end-of-support PowerShell with error message

### DIFF
--- a/src/features/GenerateBugReport.ts
+++ b/src/features/GenerateBugReport.ts
@@ -33,10 +33,9 @@ export class GenerateBugReportFeature implements vscode.Disposable {
         if (this.sessionManager.PowerShellExeDetails === undefined) {
             return "Session's PowerShell details are unknown!";
         }
-
-        const powerShellExePath = this.sessionManager.PowerShellExeDetails.exePath;
-        const powerShellArgs = [ "-NoProfile", "-Command", "$PSVersionTable | Out-String" ];
-        const child = child_process.spawnSync(powerShellExePath, powerShellArgs);
+        const child = child_process.spawnSync(
+            this.sessionManager.PowerShellExeDetails.exePath,
+            ["-NoProfile", "-NoLogo", "-Command", "$PSVersionTable | Out-String"]);
         // Replace semicolons as they'll cause the URI component to truncate
         return child.stdout.toString().trim().replace(";", ",");
     }


### PR DESCRIPTION
Significantly improves our handling of PowerShell failing to start because it is unsupported.

Resolves https://github.com/PowerShell/vscode-powershell/issues/4521.