### PR TITLE
Fix Dependabot pull requests limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
There seems to be a bug in the backend that thinks we're hitting the default limit of 5 even when no PRs are open.