### PR TITLE
Update startup logic to handle session failure reasons

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -757,6 +757,9 @@ Type 'help' to get help.
             const semver = new SemVer(this.versionDetails.version);
             this.languageStatusItem.text = `$(terminal-powershell) ${semver.major}.${semver.minor}`;
             this.languageStatusItem.detail += ` ${this.versionDetails.commit} (${this.versionDetails.architecture.toLowerCase()})`;
+        } else if (this.PowerShellExeDetails?.displayName) { // In case it didn't start.
+            this.languageStatusItem.text = `$(terminal-powershell) ${this.PowerShellExeDetails.displayName}`;
+            this.languageStatusItem.detail += `: ${this.PowerShellExeDetails.exePath}`;
         }
 
         if (statusText) {

--- a/src/session.ts
+++ b/src/session.ts
@@ -457,9 +457,6 @@ export class SessionManager implements Middleware {
         try {
             this.sessionDetails = await languageServerProcess.start("EditorServices");
         } catch (err) {
-            // We should kill the process in case it's stuck.
-            void languageServerProcess.dispose();
-
             // PowerShell never started, probably a bad version!
             const version = await languageServerProcess.getVersionCli();
             let shouldUpdate = true;

--- a/src/session.ts
+++ b/src/session.ts
@@ -862,7 +862,8 @@ Type 'help' to get help.
     private async showSessionMenu(): Promise<void> {
         const powershellExeFinder = new PowerShellExeFinder(
             this.platformDetails,
-            this.sessionSettings.powerShellAdditionalExePaths,
+            // We don't pull from session settings because we want them fresh!
+            getSettings().powerShellAdditionalExePaths,
             this.logger);
         const availablePowerShellExes = await powershellExeFinder.getAllAvailablePowerShellInstallations();
 


### PR DESCRIPTION
These used to be sent given that the logic existed, but the server was no longer sending them at all. Now that it does, we can handle them. Also see https://github.com/PowerShell/PowerShellEditorServices/pull/2018.