### PR TITLE
Fix flaky test

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -6,6 +6,7 @@
     ".jsx"
   ],
   "require": "source-map-support/register",
-  "timeout": 10000,
+  "timeout": 30000,
+  "slow": 2000,
   "spec": "out/test/**/*.test.js"
 }

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -6,7 +6,6 @@ import * as vscode from "vscode";
 import { Settings, getSettings, getEffectiveConfigurationTarget, changeSetting, CommentType } from "../../src/settings";
 
 describe("Settings E2E", function () {
-    this.slow(800);
     it("Loads without error", function () {
         assert.doesNotThrow(getSettings);
     });

--- a/test/features/CustomViews.test.ts
+++ b/test/features/CustomViews.test.ts
@@ -30,7 +30,6 @@ function convertToVSCodeResourceScheme(filePath: string): string {
 }
 
 describe("CustomViews feature", function () {
-    this.slow(1500);
     const testCases: IHtmlContentViewTestCase[] = [
         {
             name: "with no JavaScript or CSS",

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -429,10 +429,7 @@ describe("DebugSessionFeature", () => {
     });
 });
 
-describe("DebugSessionFeature E2E", function slowTests() {
-    this.slow(20 * 1000); // Will warn if test takes longer than 10s and show red if longer than 20s
-    this.timeout(5 * 60 * 1000); // Give it five minutes, some CI is slow!
-
+describe("DebugSessionFeature E2E", () => {
     before(async () => {
         // Registers and warms up the debug adapter and the PowerShell Extension Terminal
         await ensureEditorServicesIsConnected();

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -73,7 +73,6 @@ describe("ISE compatibility feature", function () {
     });
 
     describe("Color theme interactions", function () {
-        this.slow(4000);
         beforeEach(enableISEMode);
 
         function assertISESettings(): void {

--- a/test/features/RunCode.test.ts
+++ b/test/features/RunCode.test.ts
@@ -40,7 +40,6 @@ describe("RunCode feature", function () {
     });
 
     it("Runs Pester tests from a file", async function () {
-        this.slow(5000);
         const pesterTests = path.resolve(__dirname, "../../../examples/Tests/SampleModule.Tests.ps1");
         assert(checkIfFileExists(pesterTests));
         const pesterTestDebugStarted = utils.WaitEvent<vscode.DebugSession>(vscode.debug.onDidStartDebugSession,

--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -107,7 +107,6 @@ describe("UpdatePowerShell feature", function () {
     });
 
     describe("Which version it gets", function () {
-        this.slow(2000);
         it("Would update to LTS", async function() {
             process.env.POWERSHELL_UPDATECHECK = "LTS";
             const version: IPowerShellVersionDetails = {


### PR DESCRIPTION
I believe this test was flaky due to race conditions caused by the events. Awaiting promises instead should eliminate those races.