### PR TITLE
Use named debug configurations instead of duplicating them

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -62,7 +62,7 @@ const PREVENT_DEBUG_START_AND_OPEN_DEBUGCONFIG = null;
 
 /** Represents the various built-in debug configurations that will be advertised to the user if they choose "Add Config" from the launch debug config window */
 // NOTE: These are duplicated with what is in package.json until https://github.com/microsoft/vscode/issues/150663#issuecomment-1506134754 is resolved.
-export const defaultDebugConfigurations: Record<DebugConfig, DebugConfiguration> = {
+export const DebugConfigurations: Record<DebugConfig, DebugConfiguration> = {
     [DebugConfig.LaunchCurrentFile]: {
         name: "PowerShell: Launch Current File",
         type: "PowerShell",
@@ -150,12 +150,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         this.handlers = [
             languageClient.onNotification(
                 StartDebuggerNotificationType,
-                // TODO: Use a named debug configuration.
-                () => void debug.startDebugging(undefined, {
-                    request: "launch",
-                    type: "PowerShell",
-                    name: "PowerShell: Interactive Session"
-                })),
+                () => void debug.startDebugging(undefined, DebugConfigurations[DebugConfig.InteractiveSession])),
 
             languageClient.onNotification(
                 StopDebuggerNotificationType,
@@ -216,10 +211,10 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 { placeHolder: "Select a PowerShell debug configuration" });
 
         if (launchSelection) {
-            return [defaultDebugConfigurations[launchSelection.id]];
+            return [DebugConfigurations[launchSelection.id]];
         }
 
-        return [defaultDebugConfigurations[DebugConfig.LaunchCurrentFile]];
+        return [DebugConfigurations[DebugConfig.LaunchCurrentFile]];
     }
 
     // We don't use await here but we are returning a promise and the return syntax is easier in an async function
@@ -234,7 +229,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         if (!config.request) {
             // No launch.json, create the default configuration for both unsaved
             // (Untitled) and saved documents.
-            const LaunchCurrentFileConfig = defaultDebugConfigurations[DebugConfig.LaunchCurrentFile];
+            const LaunchCurrentFileConfig = DebugConfigurations[DebugConfig.LaunchCurrentFile];
             config = { ...config, ...LaunchCurrentFileConfig };
             config.current_document = true;
         }
@@ -401,7 +396,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
             });
 
             // Start a child debug session to attach the dotnet debugger
-            // TODO: Accomodate multi-folder workspaces if the C# code is in a different workspace folder
+            // TODO: Accommodate multi-folder workspaces if the C# code is in a different workspace folder
             await debug.startDebugging(undefined, dotnetAttachConfig, session);
             this.logger.writeVerbose(`Dotnet Attach Debug configuration: ${JSON.stringify(dotnetAttachConfig)}`);
             this.logger.write(`Attached dotnet debugger to process ${pid}`);
@@ -754,4 +749,3 @@ export class PickRunspaceFeature extends LanguageClientConsumer {
         this.waitingForClientToken = undefined;
     }
 }
-

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -12,6 +12,7 @@ import { LanguageClient } from "vscode-languageclient/node";
 import { ILogger } from "../logging";
 import { getSettings, validateCwdSetting } from "../settings";
 import { LanguageClientConsumer } from "../languageClientConsumer";
+import { DebugConfig, DebugConfigurations } from "./DebugSession";
 
 export interface IExtensionCommand {
     name: string;
@@ -187,13 +188,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
 
             vscode.commands.registerCommand("PowerShell.Debug.Start",
                 async () => {
-                    // TODO: Use a named debug configuration.
-                    await vscode.debug.startDebugging(undefined, {
-                        name: "PowerShell: Launch Current File",
-                        type: "PowerShell",
-                        request: "launch",
-                        script: "${file}",
-                    });
+                    await vscode.debug.startDebugging(undefined, DebugConfigurations[DebugConfig.LaunchCurrentFile]);
                 })
         ];
     }

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -32,7 +32,6 @@ export class ISECompatibilityFeature implements vscode.Disposable {
     private _originalSettings: Record<string, boolean | string | undefined> = {};
 
     constructor() {
-        // TODO: This test isn't great.
         const testSetting = ISECompatibilityFeature.settings[ISECompatibilityFeature.settings.length - 1];
         this._iseModeEnabled = vscode.workspace.getConfiguration(testSetting.path).get(testSetting.name) === testSetting.value;
         this._commandRegistrations = [

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -6,7 +6,7 @@ import * as assert from "assert";
 import Sinon from "sinon";
 import { DebugAdapterNamedPipeServer, DebugConfiguration, DebugSession, Extension, ExtensionContext, Range, SourceBreakpoint, TextDocument, TextEditor, Uri, commands, debug, extensions, window, workspace } from "vscode";
 import { Disposable } from "vscode-languageserver-protocol";
-import { DebugConfig, DebugSessionFeature, defaultDebugConfigurations } from "../../src/features/DebugSession";
+import { DebugConfig, DebugSessionFeature, DebugConfigurations } from "../../src/features/DebugSession";
 import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import * as platform from "../../src/platform";
 import { IPlatformDetails } from "../../src/platform";
@@ -14,12 +14,12 @@ import { IEditorServicesSessionDetails, IPowerShellVersionDetails, SessionManage
 import * as utils from "../../src/utils";
 import { BuildBinaryModuleMock, WaitEvent, ensureEditorServicesIsConnected, stubInterface, testLogger } from "../utils";
 
-const TEST_NUMBER = 7357; //7357 = TEST. Get it? :)
+const TEST_NUMBER = 7357; // 7357 = TEST. Get it? :)
 
 let defaultDebugConfig: DebugConfiguration;
 beforeEach(() => {
     // This prevents state from creeping into the template between test runs
-    defaultDebugConfig = structuredClone(defaultDebugConfigurations[DebugConfig.LaunchCurrentFile]);
+    defaultDebugConfig = structuredClone(DebugConfigurations[DebugConfig.LaunchCurrentFile]);
 });
 
 describe("DebugSessionFeature", () => {
@@ -81,7 +81,7 @@ describe("DebugSessionFeature", () => {
             const actual = await createDebugSessionFeatureStub({}).resolveDebugConfiguration(undefined, noRequestConfig);
 
             assert.equal(actual!.current_document, true);
-            assert.equal(actual!.request, defaultDebugConfigurations[DebugConfig.LaunchCurrentFile].request);
+            assert.equal(actual!.request, DebugConfigurations[DebugConfig.LaunchCurrentFile].request);
         });
 
         it("Errors if current file config was specified but no file is open in the editor", async () => {
@@ -450,7 +450,7 @@ describe("DebugSessionFeature E2E", () => {
             });
         });
 
-        const config = defaultDebugConfigurations[DebugConfig.InteractiveSession];
+        const config = DebugConfigurations[DebugConfig.InteractiveSession];
         assert.ok(await debug.startDebugging(undefined, config), "Debug session should start");
         assert.equal((await startDebugSession).name, config.name, "Debug session name should match when started");
 
@@ -482,7 +482,7 @@ describe("DebugSessionFeature E2E", () => {
         });
 
         it("Debugs a binary module script", async () => {
-            const launchScriptConfig = structuredClone(defaultDebugConfigurations[DebugConfig.LaunchScript]);
+            const launchScriptConfig = structuredClone(DebugConfigurations[DebugConfig.LaunchScript]);
             launchScriptConfig.script = Uri.joinPath(binaryModulePath, "BinaryModuleTest.ps1").fsPath;
             launchScriptConfig.attachDotnetDebugger = true;
             launchScriptConfig.createTemporaryIntegratedConsole = true;
@@ -504,7 +504,7 @@ describe("DebugSessionFeature E2E", () => {
         });
 
         it("Stops at a binary module breakpoint", async () => {
-            const launchScriptConfig = structuredClone(defaultDebugConfigurations[DebugConfig.LaunchCurrentFile]);
+            const launchScriptConfig = structuredClone(DebugConfigurations[DebugConfig.LaunchCurrentFile]);
             launchScriptConfig.attachDotnetDebugger = true;
             launchScriptConfig.createTemporaryIntegratedConsole = true;
             const testScriptPath = Uri.joinPath(binaryModulePath, "BinaryModuleTest.ps1");


### PR DESCRIPTION
Now that we have a record of debug configurations we can fix these TODOs.