### PR TITLE
Robustify startup, error handling, and logging

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -6,7 +6,7 @@
     ".jsx"
   ],
   "require": "source-map-support/register",
-  "timeout": 30000,
+  "timeout": 60000,
   "slow": 2000,
   "spec": "out/test/**/*.test.js"
 }

--- a/.vsts-ci/azure-pipelines-ci.yml
+++ b/.vsts-ci/azure-pipelines-ci.yml
@@ -1,4 +1,11 @@
-name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+name: CI-$(Build.SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rr)
+
+trigger:
+  - main
+pr:
+  paths:
+    exclude:
+    - '**/*.md'
 
 variables:
   # Don't download unneeded packages

--- a/.vsts-ci/misc-analysis.yml
+++ b/.vsts-ci/misc-analysis.yml
@@ -1,12 +1,10 @@
-name: PR-$(System.PullRequest.PullRequestNumber)-$(Date:yyyyMMdd)$(Rev:.rr)
+name: Misc-$(Build.SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.rr)
 
-trigger:
-  branches:
-    include:
-    - main
-
+trigger: none
 pr:
-- main
+  paths:
+    exclude:
+    - '**/*.md'
 
 resources:
   repositories:
@@ -23,6 +21,7 @@ jobs:
   - checkout: self
   - checkout: ComplianceRepo
   - template: ci-compliance.yml@ComplianceRepo
+
 # NOTE: This enables our project to work with Visual Studio's Rich Navigation:
 # https://visualstudio.microsoft.com/services/rich-code-navigation/
 - job: RichCodeNav

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -176,7 +176,7 @@ export class ConsoleFeature extends LanguageClientConsumer {
             vscode.commands.registerCommand("PowerShell.RunSelection", async () => {
                 if (vscode.window.activeTerminal &&
                     vscode.window.activeTerminal.name !== "PowerShell Extension") {
-                    this.logger.write("PowerShell Extension Terminal is not active! Running in current terminal using 'runSelectedText'");
+                    this.logger.write("PowerShell Extension Terminal is not active! Running in current terminal using 'runSelectedText'.");
                     await vscode.commands.executeCommand("workbench.action.terminal.runSelectedText");
 
                     // We need to honor the focusConsoleOnExecute setting here too. However, the boolean that `show`

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -4,6 +4,7 @@
 import {
     debug,
     CancellationToken,
+    CancellationTokenSource,
     DebugAdapterDescriptor,
     DebugAdapterDescriptorFactory,
     DebugAdapterExecutable,
@@ -18,7 +19,6 @@ import {
     extensions,
     workspace,
     commands,
-    CancellationTokenSource,
     InputBoxOptions,
     QuickPickItem,
     QuickPickOptions,
@@ -297,7 +297,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         this.sessionManager.showDebugTerminal(true);
 
         this.logger.writeVerbose(`Connecting to pipe: ${sessionDetails.debugServicePipeName}`);
-        this.logger.writeVerbose(`Debug configuration: ${JSON.stringify(session.configuration)}`);
+        this.logger.writeVerbose(`Debug configuration: ${JSON.stringify(session.configuration, undefined, 2)}`);
 
         return new DebugAdapterNamedPipeServer(sessionDetails.debugServicePipeName);
     }
@@ -379,16 +379,16 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 // HACK: This seems like you would be calling a method on a variable not assigned yet, but it does work in the flow.
                 // The dispose shorthand demonry for making an event one-time courtesy of: https://github.com/OmniSharp/omnisharp-vscode/blob/b8b07bb12557b4400198895f82a94895cb90c461/test/integrationTests/launchConfiguration.integration.test.ts#L41-L45
                 startDebugEvent.dispose();
-                this.logger.write(`Debugger session detected: ${dotnetAttachSession.name} (${dotnetAttachSession.id})`);
+                this.logger.writeVerbose(`Debugger session detected: ${dotnetAttachSession.name} (${dotnetAttachSession.id})`);
                 if (dotnetAttachSession.configuration.name == dotnetAttachConfig.name) {
                     const stopDebugEvent = debug.onDidTerminateDebugSession(async (terminatedDebugSession) => {
                         // Makes the event one-time
                         stopDebugEvent.dispose();
 
-                        this.logger.write(`Debugger session stopped: ${terminatedDebugSession.name} (${terminatedDebugSession.id})`);
+                        this.logger.writeVerbose(`Debugger session stopped: ${terminatedDebugSession.name} (${terminatedDebugSession.id})`);
 
                         if (terminatedDebugSession === session) {
-                            this.logger.write("Terminating dotnet debugger session associated with PowerShell debug session");
+                            this.logger.writeVerbose("Terminating dotnet debugger session associated with PowerShell debug session!");
                             await debug.stopDebugging(dotnetAttachSession);
                         }
                     });
@@ -398,8 +398,8 @@ export class DebugSessionFeature extends LanguageClientConsumer
             // Start a child debug session to attach the dotnet debugger
             // TODO: Accommodate multi-folder workspaces if the C# code is in a different workspace folder
             await debug.startDebugging(undefined, dotnetAttachConfig, session);
-            this.logger.writeVerbose(`Dotnet Attach Debug configuration: ${JSON.stringify(dotnetAttachConfig)}`);
-            this.logger.write(`Attached dotnet debugger to process ${pid}`);
+            this.logger.writeVerbose(`Dotnet attach debug configuration: ${JSON.stringify(dotnetAttachConfig, undefined, 2)}`);
+            this.logger.writeVerbose(`Attached dotnet debugger to process: ${pid}`);
         }
         return this.tempSessionDetails;
     }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -359,7 +359,10 @@ export class DebugSessionFeature extends LanguageClientConsumer
     private async createTemporaryIntegratedConsole(session: DebugSession): Promise<IEditorServicesSessionDetails | undefined> {
         const settings = getSettings();
         this.tempDebugProcess = await this.sessionManager.createDebugSessionProcess(settings);
-        this.tempSessionDetails = await this.tempDebugProcess.start(`DebugSession-${this.sessionCount++}`);
+        // TODO: Maybe set a timeout on the cancellation token?
+        const cancellationTokenSource = new CancellationTokenSource();
+        this.tempSessionDetails = await this.tempDebugProcess.start(
+            `DebugSession-${this.sessionCount++}`, cancellationTokenSource.token);
 
         // NOTE: Dotnet attach debugging is only currently supported if a temporary debug terminal is used, otherwise we get lots of lock conflicts from loading the assemblies.
         if (session.configuration.attachDotnetDebugger) {

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -439,7 +439,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
 
         default: {
             // Other URI schemes are not supported
-            const msg = JSON.stringify(saveFileDetails);
+            const msg = JSON.stringify(saveFileDetails, undefined, 2);
             this.logger.writeVerbose(
                 `<${ExtensionCommandsFeature.name}>: Saving a document with scheme '${currentFileUri.scheme}' ` +
                         `is currently unsupported. Message: '${msg}'`);
@@ -467,9 +467,9 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
             await vscode.workspace.fs.writeFile(
                 vscode.Uri.file(destinationAbsolutePath),
                 Buffer.from(oldDocument.getText()));
-        } catch (e) {
+        } catch (err) {
             void this.logger.writeAndShowWarning(`<${ExtensionCommandsFeature.name}>: ` +
-                `Unable to save file to path '${destinationAbsolutePath}': ${e}`);
+                `Unable to save file to path '${destinationAbsolutePath}': ${err}`);
             return;
         }
 

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -57,7 +57,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
         string session uuid
     */
     public registerExternalExtension(id: string, apiVersion = "v1"): string {
-        this.logger.writeDiagnostic(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
+        this.logger.writeVerbose(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const [_name, externalExtension] of ExternalApiFeature.registeredExternalExtension) {
@@ -98,7 +98,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
         true if it worked, otherwise throws an error.
     */
     public unregisterExternalExtension(uuid = ""): boolean {
-        this.logger.writeDiagnostic(`Unregistering extension with session UUID: ${uuid}`);
+        this.logger.writeVerbose(`Unregistering extension with session UUID: ${uuid}`);
         if (!ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
             throw new Error(`No extension registered with session UUID: ${uuid}`);
         }
@@ -135,7 +135,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
     */
     public async getPowerShellVersionDetails(uuid = ""): Promise<IExternalPowerShellDetails> {
         const extension = this.getRegisteredExtension(uuid);
-        this.logger.writeDiagnostic(`Extension '${extension.id}' called 'getPowerShellVersionDetails'`);
+        this.logger.writeVerbose(`Extension '${extension.id}' called 'getPowerShellVersionDetails'.`);
 
         await this.sessionManager.waitUntilStarted();
         const versionDetails = this.sessionManager.getPowerShellVersionDetails();
@@ -163,7 +163,7 @@ export class ExternalApiFeature extends LanguageClientConsumer implements IPower
     */
     public async waitUntilStarted(uuid = ""): Promise<void> {
         const extension = this.getRegisteredExtension(uuid);
-        this.logger.writeDiagnostic(`Extension '${extension.id}' called 'waitUntilStarted'`);
+        this.logger.writeVerbose(`Extension '${extension.id}' called 'waitUntilStarted'.`);
         await this.sessionManager.waitUntilStarted();
     }
 

--- a/src/features/GetCommands.ts
+++ b/src/features/GetCommands.ts
@@ -65,7 +65,7 @@ export class GetCommandsFeature extends LanguageClientConsumer {
 
     private async CommandExplorerRefresh(): Promise<void> {
         if (this.languageClient === undefined) {
-            this.logger.writeVerbose(`<${GetCommandsFeature.name}>: Unable to send getCommand request`);
+            this.logger.writeVerbose(`<${GetCommandsFeature.name}>: Unable to send getCommand request!`);
             return;
         }
         await this.languageClient.sendRequest(GetCommandRequestType).then((result) => {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -57,7 +57,7 @@ export class Logger implements ILogger {
 
         // Early logging of the log paths for debugging.
         if (LogLevel.Diagnostic >= this.logLevel) {
-            const uriMessage = Logger.timestampMessage(`Global storage URI: '${globalStorageUri}', log file path: '${this.logFilePath}'`, LogLevel.Diagnostic);
+            const uriMessage = Logger.timestampMessage(`Log file path: '${this.logFilePath}'`, LogLevel.Verbose);
             this.logChannel.appendLine(uriMessage);
         }
 
@@ -211,7 +211,7 @@ export class Logger implements ILogger {
             try {
                 this.writingLog = true;
                 if (!this.logDirectoryCreated) {
-                    this.logChannel.appendLine(Logger.timestampMessage(`Creating log directory at: '${this.logDirectoryPath}'`, level));
+                    this.writeVerbose(`Creating log directory at: '${this.logDirectoryPath}'`);
                     await vscode.workspace.fs.createDirectory(this.logDirectoryPath);
                     this.logDirectoryCreated = true;
                 }
@@ -222,8 +222,8 @@ export class Logger implements ILogger {
                 await vscode.workspace.fs.writeFile(
                     this.logFilePath,
                     Buffer.concat([log, Buffer.from(timestampedMessage)]));
-            } catch (e) {
-                console.log(`Error writing to vscode-powershell log file: ${e}`);
+            } catch (err) {
+                console.log(`Error writing to vscode-powershell log file: ${err}`);
             } finally {
                 this.writingLog = false;
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
     // Load and validate settings (will prompt for 'cwd' if necessary).
     await validateCwdSetting(logger);
     const settings = getSettings();
-    logger.writeDiagnostic(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
+    logger.writeVerbose(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
 
     languageConfigurationDisposable = vscode.languages.setLanguageConfiguration(
         PowerShellLanguageId,

--- a/src/process.ts
+++ b/src/process.ts
@@ -12,14 +12,15 @@ import { promisify } from "util";
 
 export class PowerShellProcess {
     // This is used to warn the user that the extension is taking longer than expected to startup.
-    // After the 15th try we've hit 30 seconds and should warn.
-    private static warnUserThreshold = 15;
+    private static warnUserThreshold = 30;
 
     public onExited: vscode.Event<void>;
     private onExitedEmitter = new vscode.EventEmitter<void>();
 
     private consoleTerminal?: vscode.Terminal;
     private consoleCloseSubscription?: vscode.Disposable;
+
+    private pid?: number;
 
     constructor(
         public exePath: string,
@@ -33,7 +34,7 @@ export class PowerShellProcess {
         this.onExited = this.onExitedEmitter.event;
     }
 
-    public async start(logFileName: string): Promise<IEditorServicesSessionDetails> {
+    public async start(logFileName: string, cancellationToken: vscode.CancellationToken): Promise<IEditorServicesSessionDetails | undefined> {
         const editorServicesLogPath = this.logger.getLogFilePath(logFileName);
 
         const psesModulePath =
@@ -95,7 +96,7 @@ export class PowerShellProcess {
         this.logger.writeVerbose(`Starting process: ${this.exePath} ${powerShellArgs.slice(0, -2).join(" ")} -Command ${startEditorServices}`);
 
         // Make sure no old session file exists
-        await PowerShellProcess.deleteSessionFile(this.sessionFilePath);
+        await this.deleteSessionFile(this.sessionFilePath);
 
         // Launch PowerShell in the integrated terminal
         const terminalOptions: vscode.TerminalOptions = {
@@ -113,15 +114,9 @@ export class PowerShellProcess {
         // subscription should happen before we create the terminal so if it
         // fails immediately, the event fires.
         this.consoleCloseSubscription = vscode.window.onDidCloseTerminal((terminal) => this.onTerminalClose(terminal));
-
         this.consoleTerminal = vscode.window.createTerminal(terminalOptions);
-
-        const pwshName = path.basename(this.exePath);
-        this.logger.write(`${pwshName} started.`);
-
-        // Log that the PowerShell terminal process has been started
-        const pid = await this.getPid();
-        this.logTerminalPid(pid ?? 0, pwshName);
+        this.pid = await this.getPid();
+        this.logger.write(`PowerShell process started with PID: ${this.pid}`);
 
         if (this.sessionSettings.integratedConsole.showOnStartup
             && !this.sessionSettings.integratedConsole.startInBackground) {
@@ -129,7 +124,7 @@ export class PowerShellProcess {
             this.consoleTerminal.show(true);
         }
 
-        return await this.waitForSessionFile();
+        return await this.waitForSessionFile(cancellationToken);
     }
 
     // This function should only be used after a failure has occurred because it is slow!
@@ -141,25 +136,23 @@ export class PowerShellProcess {
 
     // Returns the process Id of the consoleTerminal
     public async getPid(): Promise<number | undefined> {
-        if (!this.consoleTerminal) { return undefined; }
-        return await this.consoleTerminal.processId;
+        return await this.consoleTerminal?.processId;
     }
 
     public showTerminal(preserveFocus?: boolean): void {
         this.consoleTerminal?.show(preserveFocus);
     }
 
-    public async dispose(): Promise<void> {
-        // Clean up the session file
-        this.logger.write("Disposing PowerShell Extension Terminal...");
+    public dispose(): void {
+        this.logger.writeVerbose(`Disposing PowerShell process with PID: ${this.pid}`);
+
+        void this.deleteSessionFile(this.sessionFilePath);
 
         this.consoleTerminal?.dispose();
         this.consoleTerminal = undefined;
 
         this.consoleCloseSubscription?.dispose();
         this.consoleCloseSubscription = undefined;
-
-        await PowerShellProcess.deleteSessionFile(this.sessionFilePath);
     }
 
     public sendKeyPress(): void {
@@ -168,10 +161,6 @@ export class PowerShellProcess {
         // languages and terminal settings. We discard the character server-side
         // anyway, so it doesn't matter what we send.
         this.consoleTerminal?.sendText("p", false);
-    }
-
-    private logTerminalPid(pid: number, exeName: string): void {
-        this.logger.write(`${exeName} PID: ${pid}`);
     }
 
     private isLoginShell(pwshPath: string): boolean {
@@ -184,16 +173,15 @@ export class PowerShellProcess {
         } catch {
             return false;
         }
-
         return true;
     }
 
-    private static async readSessionFile(sessionFilePath: vscode.Uri): Promise<IEditorServicesSessionDetails> {
+    private async readSessionFile(sessionFilePath: vscode.Uri): Promise<IEditorServicesSessionDetails> {
         const fileContents = await vscode.workspace.fs.readFile(sessionFilePath);
         return JSON.parse(fileContents.toString());
     }
 
-    private static async deleteSessionFile(sessionFilePath: vscode.Uri): Promise<void> {
+    private async deleteSessionFile(sessionFilePath: vscode.Uri): Promise<void> {
         try {
             await vscode.workspace.fs.delete(sessionFilePath);
         } catch {
@@ -201,38 +189,38 @@ export class PowerShellProcess {
         }
     }
 
-    private async waitForSessionFile(): Promise<IEditorServicesSessionDetails> {
-        // Determine how many tries by dividing by 2000 thus checking every 2 seconds.
-        const numOfTries = this.sessionSettings.developer.waitForSessionFileTimeoutSeconds / 2;
+    private async waitForSessionFile(cancellationToken: vscode.CancellationToken): Promise<IEditorServicesSessionDetails | undefined> {
+        const numOfTries = this.sessionSettings.developer.waitForSessionFileTimeoutSeconds;
         const warnAt = numOfTries - PowerShellProcess.warnUserThreshold;
 
-        // Check every 2 seconds
-        this.logger.write("Waiting for session file...");
+        // Check every second.
+        this.logger.writeVerbose(`Waiting for session file: ${this.sessionFilePath}`);
         for (let i = numOfTries; i > 0; i--) {
+            if (cancellationToken.isCancellationRequested) {
+                this.logger.writeWarning("Canceled while waiting for session file.");
+                return undefined;
+            }
+
             if (this.consoleTerminal === undefined) {
-                const err = "PowerShell Extension Terminal didn't start!";
-                this.logger.write(err);
-                throw new Error(err);
+                this.logger.writeError("Extension Terminal is undefined.");
+                return undefined;
             }
 
             if (await utils.checkIfFileExists(this.sessionFilePath)) {
-                this.logger.write("Session file found!");
-                const sessionDetails = await PowerShellProcess.readSessionFile(this.sessionFilePath);
-                await PowerShellProcess.deleteSessionFile(this.sessionFilePath);
-                return sessionDetails;
+                this.logger.writeVerbose("Session file found.");
+                return await this.readSessionFile(this.sessionFilePath);
             }
 
             if (warnAt === i) {
                 void this.logger.writeAndShowWarning("Loading the PowerShell extension is taking longer than expected. If you're using privilege enforcement software, this can affect start up performance.");
             }
 
-            // Wait a bit and try again
-            await utils.sleep(2000);
+            // Wait a bit and try again.
+            await utils.sleep(1000);
         }
 
-        const err = "Timed out waiting for session file to appear!";
-        this.logger.write(err);
-        throw new Error(err);
+        this.logger.writeError("Timed out waiting for session file!");
+        return undefined;
     }
 
     private onTerminalClose(terminal: vscode.Terminal): void {
@@ -240,8 +228,8 @@ export class PowerShellProcess {
             return;
         }
 
-        this.logger.write("PowerShell process terminated or Extension Terminal was closed!");
+        this.logger.writeWarning(`PowerShell process terminated or Extension Terminal was closed, PID: ${this.pid}`);
         this.onExitedEmitter.fire();
-        void this.dispose();
+        this.dispose();
     }
 }

--- a/src/process.ts
+++ b/src/process.ts
@@ -86,16 +86,13 @@ export class PowerShellProcess {
                 startEditorServices);
         } else {
             // Otherwise use -EncodedCommand for better quote support.
+            this.logger.writeVerbose("Using Base64 -EncodedCommand but logging as -Command equivalent.");
             powerShellArgs.push(
                 "-EncodedCommand",
                 Buffer.from(startEditorServices, "utf16le").toString("base64"));
         }
 
-        this.logger.write(
-            "Language server starting --",
-            "    PowerShell executable: " + this.exePath,
-            "    PowerShell args: " + powerShellArgs.join(" "),
-            "    PowerShell Editor Services args: " + startEditorServices);
+        this.logger.writeVerbose(`Starting process: ${this.exePath} ${powerShellArgs.slice(0, -2).join(" ")} -Command ${startEditorServices}`);
 
         // Make sure no old session file exists
         await PowerShellProcess.deleteSessionFile(this.sessionFilePath);

--- a/src/session.ts
+++ b/src/session.ts
@@ -875,59 +875,24 @@ Type 'help' to get help.
             this.logger);
         const availablePowerShellExes = await powershellExeFinder.getAllAvailablePowerShellInstallations();
 
-        let sessionText: string;
-
-        switch (this.sessionStatus) {
-        case SessionStatus.Running:
-        case SessionStatus.Initializing:
-        case SessionStatus.NotStarted:
-        case SessionStatus.NeverStarted:
-        case SessionStatus.Stopping:
-            if (this.PowerShellExeDetails && this.versionDetails) {
-                const currentPowerShellExe =
-                        availablePowerShellExes
-                            .find((item) => item.displayName.toLowerCase() === this.PowerShellExeDetails!.displayName.toLowerCase());
-
-                const powerShellSessionName =
-                        currentPowerShellExe ?
-                            currentPowerShellExe.displayName :
-                            `PowerShell ${this.versionDetails.version} ` +
-                            `(${this.versionDetails.architecture.toLowerCase()}) ${this.versionDetails.edition} Edition ` +
-                            `[${this.versionDetails.version}]`;
-
-                sessionText = `Current session: ${powerShellSessionName}`;
-            } else {
-                sessionText = "Current session: Unknown";
-            }
-            break;
-
-        case SessionStatus.Failed:
-            sessionText = "Session initialization failed, click here to show PowerShell extension logs";
-            break;
-
-        default:
-            throw new TypeError("Not a valid value for the enum 'SessionStatus'");
-        }
-
-        const powerShellItems =
-            availablePowerShellExes
-                .filter((item) => item.displayName !== this.PowerShellExeDetails?.displayName)
-                .map((item) => {
-                    return new SessionMenuItem(
-                        `Switch to: ${item.displayName}`,
-                        async () => { await this.changePowerShellDefaultVersion(item); });
-                });
+        const powerShellItems = availablePowerShellExes
+            .filter((item) => item.displayName !== this.PowerShellExeDetails?.displayName)
+            .map((item) => {
+                return new SessionMenuItem(
+                    `Switch to: ${item.displayName}`,
+                    async () => { await this.changePowerShellDefaultVersion(item); });
+            });
 
         const menuItems: SessionMenuItem[] = [
             new SessionMenuItem(
-                sessionText,
+                `Current session: ${this.PowerShellExeDetails?.displayName ?? "Unknown"} (click to show logs)`,
                 async () => { await vscode.commands.executeCommand("PowerShell.ShowLogs"); }),
 
             // Add all of the different PowerShell options
             ...powerShellItems,
 
             new SessionMenuItem(
-                "Restart Current Session",
+                "Restart current session",
                 async () => {
                     // We pass in the display name so we guarantee that the session
                     // will be the same PowerShell.
@@ -939,7 +904,7 @@ Type 'help' to get help.
                 }),
 
             new SessionMenuItem(
-                "Open Session Logs Folder",
+                "Open session logs folder",
                 async () => { await vscode.commands.executeCommand("PowerShell.OpenLogFolder"); }),
 
             new SessionMenuItem(

--- a/src/session.ts
+++ b/src/session.ts
@@ -27,13 +27,12 @@ import { LanguageClientConsumer } from "./languageClientConsumer";
 import { SemVer, satisfies } from "semver";
 
 export enum SessionStatus {
-    NeverStarted,
-    NotStarted,
-    Initializing,
-    Running,
-    Busy,
-    Stopping,
-    Failed,
+    NotStarted = "Not Started",
+    Starting = "Starting",
+    Running = "Running",
+    Busy = "Busy",
+    Stopping = "Stopping",
+    Failed = "Failed",
 }
 
 export enum RunspaceType {
@@ -77,23 +76,22 @@ export class SessionManager implements Middleware {
     public HostVersion: string;
     public Publisher: string;
     public PowerShellExeDetails: IPowerShellExeDetails | undefined;
-    private ShowSessionMenuCommandName = "PowerShell.ShowSessionMenu";
-    private sessionStatus: SessionStatus = SessionStatus.NeverStarted;
-    private suppressRestartPrompt = false;
-    private platformDetails: IPlatformDetails;
-    private languageClientConsumers: LanguageClientConsumer[] = [];
-    private languageStatusItem: vscode.LanguageStatusItem;
-    private languageServerProcess: PowerShellProcess | undefined;
-    private debugSessionProcess: PowerShellProcess | undefined;
+    private readonly ShowSessionMenuCommandName = "PowerShell.ShowSessionMenu";
     private debugEventHandler: vscode.Disposable | undefined;
-    private versionDetails: IPowerShellVersionDetails | undefined;
-    private registeredHandlers: vscode.Disposable[] = [];
-    private registeredCommands: vscode.Disposable[] = [];
+    private debugSessionProcess: PowerShellProcess | undefined;
     private languageClient: LanguageClient | undefined;
+    private languageClientConsumers: LanguageClientConsumer[] = [];
+    private languageServerProcess: PowerShellProcess | undefined;
+    private languageStatusItem: vscode.LanguageStatusItem;
+    private platformDetails: IPlatformDetails;
+    private registeredCommands: vscode.Disposable[] = [];
+    private registeredHandlers: vscode.Disposable[] = [];
     private sessionDetails: IEditorServicesSessionDetails | undefined;
     private sessionsFolder: vscode.Uri;
-    private starting = false;
-    private started = false;
+    private sessionStatus: SessionStatus = SessionStatus.NotStarted;
+    private startCancellationTokenSource: vscode.CancellationTokenSource | undefined;
+    private suppressRestartPrompt = false;
+    private versionDetails: IPowerShellVersionDetails | undefined;
 
     constructor(
         private extensionContext: vscode.ExtensionContext,
@@ -134,7 +132,9 @@ export class SessionManager implements Middleware {
     }
 
     public async dispose(): Promise<void> {
-        await this.stop();
+        await this.stop(); // A whole lot of disposals.
+
+        this.languageStatusItem.dispose();
 
         for (const handler of this.registeredHandlers) {
             handler.dispose();
@@ -143,69 +143,116 @@ export class SessionManager implements Middleware {
         for (const command of this.registeredCommands) {
             command.dispose();
         }
-
-        await this.languageClient?.dispose();
-    }
-
-    public setLanguageClientConsumers(languageClientConsumers: LanguageClientConsumer[]): void {
-        this.languageClientConsumers = languageClientConsumers;
     }
 
     // The `exeNameOverride` is used by `restartSession` to override ANY other setting.
     public async start(exeNameOverride?: string): Promise<void> {
         // A simple lock because this function isn't re-entrant.
-        if (this.started || this.starting) {
+        if (this.sessionStatus === SessionStatus.Starting) {
+            this.logger.writeWarning("Re-entered 'start' so waiting...");
             return await this.waitUntilStarted();
         }
-        try {
-            this.starting = true;
-            if (exeNameOverride) {
-                this.sessionSettings.powerShellDefaultVersion = exeNameOverride;
+
+        this.setSessionStatus("Starting...", SessionStatus.Starting);
+        this.startCancellationTokenSource = new vscode.CancellationTokenSource();
+        const cancellationToken = this.startCancellationTokenSource.token;
+
+        if (exeNameOverride != undefined) {
+            this.logger.writeVerbose(`Starting with executable overriden to: ${exeNameOverride}`);
+            this.sessionSettings.powerShellDefaultVersion = exeNameOverride;
+        }
+
+        // Create a folder for the session files.
+        await vscode.workspace.fs.createDirectory(this.sessionsFolder);
+
+        // Migrate things.
+        await this.promptPowerShellExeSettingsCleanup();
+        await this.migrateWhitespaceAroundPipeSetting();
+
+        // Find the PowerShell executable to use for the server.
+        this.PowerShellExeDetails = await this.findPowerShell();
+
+        if (this.PowerShellExeDetails === undefined) {
+            const message = "Unable to find PowerShell!"
+                + " Do you have it installed?"
+                + " You can also configure custom installations"
+                + " with the 'powershell.powerShellAdditionalExePaths' setting.";
+            void this.setSessionFailedGetPowerShell(message);
+            return;
+        }
+
+        this.logger.write(`Starting '${this.PowerShellExeDetails.displayName}' at: ${this.PowerShellExeDetails.exePath}`);
+
+        // Start the server.
+        this.languageServerProcess = await this.startLanguageServerProcess(
+            this.PowerShellExeDetails,
+            cancellationToken);
+
+        // Check that we got session details and that they had a "started" status.
+        if (this.sessionDetails === undefined || !this.sessionStarted(this.sessionDetails)) {
+            if (!cancellationToken.isCancellationRequested) {
+                // If it failed but we didn't cancel it, handle the common reasons.
+                await this.handleFailedProcess(this.languageServerProcess);
             }
-            // Create a folder for the session files.
-            await vscode.workspace.fs.createDirectory(this.sessionsFolder);
-            await this.promptPowerShellExeSettingsCleanup();
-            await this.migrateWhitespaceAroundPipeSetting();
-            this.PowerShellExeDetails = await this.findPowerShell();
-            this.languageServerProcess = await this.startPowerShell();
-        } finally {
-            this.starting = false;
+            this.languageServerProcess.dispose();
+            this.languageServerProcess = undefined;
+            return;
+        }
+
+        // If we got good session details from the server, try to connect to it.
+        this.languageClient = await this.startLanguageClient(this.sessionDetails);
+
+        if (this.languageClient.isRunning()) {
+            this.versionDetails = await this.getVersionDetails();
+            if (this.versionDetails === undefined) {
+                void this.setSessionFailedOpenBug("Unable to get version details!");
+                return;
+            }
+
+            this.logger.write(`Started PowerShell v${this.versionDetails.version}.`);
+            this.setSessionRunningStatus(); // Yay, we made it!
+
+            // Fire and forget the updater.
+            const updater = new UpdatePowerShell(this.sessionSettings, this.logger, this.versionDetails);
+            void updater.checkForUpdate();
+        } else {
+            void this.setSessionFailedOpenBug("Never finished startup!");
         }
     }
 
     public async stop(): Promise<void> {
-        this.logger.write("Shutting down language client...");
+        this.setSessionStatus("Stopping...", SessionStatus.Stopping);
+        // Cancel start-up if we're still waiting.
+        this.startCancellationTokenSource?.cancel();
 
+        // Stop and dispose the language client.
         try {
-            if (this.sessionStatus === SessionStatus.Failed) {
-                // Before moving further, clear out the client and process if
-                // the process is already dead (i.e. it crashed).
-                await this.languageClient?.dispose();
-                this.languageClient = undefined;
-                await this.languageServerProcess?.dispose();
-                this.languageServerProcess = undefined;
-            }
-
-            this.sessionStatus = SessionStatus.Stopping;
-
-            // Stop the language client.
-            await this.languageClient?.stop();
+            // If the stop fails, so will the dispose, I think this is a bug in
+            // the client library.
+            await this.languageClient?.stop(3000);
             await this.languageClient?.dispose();
-            this.languageClient = undefined;
-
-            // Kill the PowerShell process(es) we spawned.
-            await this.debugSessionProcess?.dispose();
-            this.debugSessionProcess = undefined;
-            this.debugEventHandler?.dispose();
-            this.debugEventHandler = undefined;
-
-            await this.languageServerProcess?.dispose();
-            this.languageServerProcess = undefined;
-
-        } finally {
-            this.sessionStatus = SessionStatus.NotStarted;
-            this.started = false;
+        } catch (err) {
+            this.logger.writeError(`Error occurred while stopping language client:\n${err}`);
         }
+
+        this.languageClient = undefined;
+
+        // Stop and dispose the PowerShell process(es).
+        this.debugSessionProcess?.dispose();
+        this.debugSessionProcess = undefined;
+        this.debugEventHandler?.dispose();
+        this.debugEventHandler = undefined;
+
+        this.languageServerProcess?.dispose();
+        this.languageServerProcess = undefined;
+
+        // Clean up state to start again.
+        this.startCancellationTokenSource?.dispose();
+        this.startCancellationTokenSource = undefined;
+        this.sessionDetails = undefined;
+        this.versionDetails = undefined;
+
+        this.setSessionStatus("Not Started", SessionStatus.NotStarted);
     }
 
     public async restartSession(exeNameOverride?: string): Promise<void> {
@@ -240,12 +287,16 @@ export class SessionManager implements Middleware {
         return vscode.Uri.joinPath(this.sessionsFolder, `PSES-VSCode-${process.env.VSCODE_PID}-${uniqueId}.json`);
     }
 
+    public setLanguageClientConsumers(languageClientConsumers: LanguageClientConsumer[]): void {
+        this.languageClientConsumers = languageClientConsumers;
+    }
+
     public async createDebugSessionProcess(settings: Settings): Promise<PowerShellProcess> {
         // NOTE: We only support one temporary Extension Terminal at a time. To
         // support more, we need to track each separately, and tie the session
         // for the event handler to the right process (and dispose of the event
         // handler when the process is disposed).
-        await this.debugSessionProcess?.dispose();
+        this.debugSessionProcess?.dispose();
         this.debugEventHandler?.dispose();
 
         if (this.PowerShellExeDetails === undefined) {
@@ -264,7 +315,7 @@ export class SessionManager implements Middleware {
                 bundledModulesPath,
                 "[TEMP] PowerShell Extension",
                 this.logger,
-                this.buildEditorServicesArgs(bundledModulesPath, this.PowerShellExeDetails) + "-DebugServiceOnly ",
+                this.getEditorServicesArgs(bundledModulesPath, this.PowerShellExeDetails) + "-DebugServiceOnly ",
                 this.getNewSessionFilePath(),
                 this.sessionSettings);
 
@@ -283,7 +334,10 @@ export class SessionManager implements Middleware {
     }
 
     public async waitUntilStarted(): Promise<void> {
-        while (!this.started) {
+        while (this.sessionStatus === SessionStatus.Starting) {
+            if (this.startCancellationTokenSource?.token.isCancellationRequested) {
+                return;
+            }
             await utils.sleep(300);
         }
     }
@@ -433,87 +487,8 @@ export class SessionManager implements Middleware {
         ];
     }
 
-    private async startPowerShell(): Promise<PowerShellProcess | undefined> {
-        if (this.PowerShellExeDetails === undefined) {
-            void this.setSessionFailedGetPowerShell("Unable to find PowerShell, try installing it?");
-            return;
-        }
-
-        this.setSessionStatus("Starting...", SessionStatus.Initializing);
-
-        const bundledModulesPath = await this.getBundledModulesPath();
-        const languageServerProcess =
-            new PowerShellProcess(
-                this.PowerShellExeDetails.exePath,
-                bundledModulesPath,
-                "PowerShell Extension",
-                this.logger,
-                this.buildEditorServicesArgs(bundledModulesPath, this.PowerShellExeDetails),
-                this.getNewSessionFilePath(),
-                this.sessionSettings);
-
-        languageServerProcess.onExited(
-            async () => {
-                if (this.sessionStatus === SessionStatus.Running) {
-                    this.setSessionStatus("Session Exited!", SessionStatus.Failed);
-                    await this.promptForRestart();
-                }
-            });
-
-        try {
-            this.sessionDetails = await languageServerProcess.start("EditorServices");
-        } catch (err) {
-            // PowerShell never started, probably a bad version!
-            const version = await languageServerProcess.getVersionCli();
-            let shouldUpdate = true;
-            if (satisfies(version, "<5.1.0")) {
-                void this.setSessionFailedGetPowerShell(`PowerShell ${version} is not supported, please update!`);
-            } else if (satisfies(version, ">=5.1.0 <6.0.0")) {
-                void this.setSessionFailedGetPowerShell("It looks like you're trying to use Windows PowerShell, which is supported on a best-effort basis. Can you try PowerShell 7?");
-            } else if (satisfies(version, ">=6.0.0 <7.2.0")) {
-                void this.setSessionFailedGetPowerShell(`PowerShell ${version} has reached end-of-support, please update!`);
-            } else {
-                shouldUpdate = false;
-                void this.setSessionFailedOpenBug("PowerShell language server process didn't start!");
-            }
-            if (shouldUpdate) {
-                // Run the update notifier since it won't run later as we failed
-                // to start, but we have enough details to do so now.
-                const versionDetails: IPowerShellVersionDetails = {
-                    "version": version,
-                    "edition": "", // Unused by UpdatePowerShell
-                    "commit": version, // Actually used by UpdatePowerShell
-                    "architecture": process.arch // Best guess based off Code's architecture
-                };
-                const updater = new UpdatePowerShell(this.sessionSettings, this.logger, versionDetails);
-                void updater.checkForUpdate();
-            }
-            return;
-        }
-
-        if (this.sessionDetails.status === "started") { // Successful server start with a session file
-            this.logger.write("Language server started.");
-            try {
-                await this.startLanguageClient(this.sessionDetails);
-                return languageServerProcess;
-            } catch (err) {
-                void this.setSessionFailedOpenBug("Language client failed to start: " + (err instanceof Error ? err.message : "unknown"));
-            }
-        } else if (this.sessionDetails.status === "failed") { // Server started but indicated it failed
-            if (this.sessionDetails.reason === "powerShellVersion") {
-                void this.setSessionFailedGetPowerShell(`PowerShell ${this.sessionDetails.powerShellVersion} is not supported, please update!`);
-            } else if (this.sessionDetails.reason === "dotNetVersion") { // Only applies to PowerShell 5.1
-                void this.setSessionFailedGetDotNet(".NET Framework is out-of-date, please install at least 4.8!");
-            } else {
-                void this.setSessionFailedOpenBug(`PowerShell could not be started for an unknown reason: ${this.sessionDetails.reason}`);
-            }
-        } else {
-            void this.setSessionFailedOpenBug(`PowerShell could not be started with an unknown status: ${this.sessionDetails.status}, and reason: ${this.sessionDetails.reason}`);
-        }
-        return;
-    }
-
     private async findPowerShell(): Promise<IPowerShellExeDetails | undefined> {
+        this.logger.writeVerbose("Finding PowerShell...");
         const powershellExeFinder = new PowerShellExeFinder(
             this.platformDetails,
             this.sessionSettings.powerShellAdditionalExePaths,
@@ -538,110 +513,94 @@ export class SessionManager implements Middleware {
                 void this.logger.writeAndShowWarning(`The 'powerShellDefaultVersion' setting was '${wantedName}' but this was not found!`
                     + ` Instead using first available installation '${foundPowerShell.displayName}' at '${foundPowerShell.exePath}'!`);
             }
-        } catch (e) {
-            this.logger.writeError(`Error occurred while searching for a PowerShell executable:\n${e}`);
-        }
-
-        if (foundPowerShell === undefined) {
-            const message = "Unable to find PowerShell."
-                + " Do you have PowerShell installed?"
-                + " You can also configure custom PowerShell installations"
-                + " with the 'powershell.powerShellAdditionalExePaths' setting.";
-            void this.setSessionFailedGetPowerShell(message);
+        } catch (err) {
+            this.logger.writeError(`Error occurred while searching for a PowerShell executable:\n${err}`);
         }
 
         return foundPowerShell;
     }
 
-    private async getBundledModulesPath(): Promise<string> {
-        // Because the extension is always at `<root>/out/main.js`
-        let bundledModulesPath = path.resolve(__dirname, "../modules");
+    private async startLanguageServerProcess(
+        powerShellExeDetails: IPowerShellExeDetails,
+        cancellationToken: vscode.CancellationToken): Promise<PowerShellProcess> {
 
-        if (this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
-            const devBundledModulesPath = path.resolve(__dirname, this.sessionSettings.developer.bundledModulesPath);
+        const bundledModulesPath = await this.getBundledModulesPath();
+        const languageServerProcess =
+            new PowerShellProcess(
+                powerShellExeDetails.exePath,
+                bundledModulesPath,
+                "PowerShell Extension",
+                this.logger,
+                this.getEditorServicesArgs(bundledModulesPath, powerShellExeDetails),
+                this.getNewSessionFilePath(),
+                this.sessionSettings);
 
-            // Make sure the module's bin path exists
-            if (await utils.checkIfDirectoryExists(devBundledModulesPath)) {
-                bundledModulesPath = devBundledModulesPath;
-            } else {
-                void this.logger.writeAndShowWarning(
-                    "In development mode but PowerShellEditorServices dev module path cannot be " +
-                    `found (or has not been built yet): ${devBundledModulesPath}\n`);
-            }
-        }
-
-        return bundledModulesPath;
-    }
-
-    private buildEditorServicesArgs(bundledModulesPath: string, powerShellExeDetails: IPowerShellExeDetails): string {
-        let editorServicesArgs =
-            "-HostName 'Visual Studio Code Host' " +
-            "-HostProfileId 'Microsoft.VSCode' " +
-            `-HostVersion '${this.HostVersion}' ` +
-            "-AdditionalModules @('PowerShellEditorServices.VSCode') " +
-            `-BundledModulesPath '${utils.escapeSingleQuotes(bundledModulesPath)}' ` +
-            "-EnableConsoleRepl ";
-
-        if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
-            editorServicesArgs += "-StartupBanner '' ";
-        } else if (utils.isWindows && !powerShellExeDetails.supportsProperArguments) {
-            // NOTE: On Windows we don't Base64 encode the startup command
-            // because it annoys some poorly implemented anti-virus scanners.
-            // Unfortunately this means that for some installs of PowerShell
-            // (such as through the `dotnet` package manager), we can't include
-            // a multi-line startup banner as the quotes break the command.
-            editorServicesArgs += `-StartupBanner '${this.DisplayName} Extension v${this.HostVersion}' `;
-        } else {
-            const startupBanner = `${this.DisplayName} Extension v${this.HostVersion}
-Copyright (c) Microsoft Corporation.
-
-https://aka.ms/vscode-powershell
-Type 'help' to get help.
-`;
-            editorServicesArgs += `-StartupBanner "${startupBanner}" `;
-        }
-
-        // We guard this here too out of an abundance of precaution.
-        if (this.sessionSettings.developer.editorServicesWaitForDebugger
-            && this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
-            editorServicesArgs += "-WaitForDebugger ";
-        }
-
-        editorServicesArgs += `-LogLevel '${this.sessionSettings.developer.editorServicesLogLevel}' `;
-
-        return editorServicesArgs;
-    }
-
-    private async promptForRestart(): Promise<void> {
-        await this.logger.writeAndShowErrorWithActions(
-            "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
-            [
-                {
-                    prompt: "Yes",
-                    action: async (): Promise<void> => { await this.restartSession(); }
-                },
-                {
-                    prompt: "No",
-                    action: undefined
+        languageServerProcess.onExited(
+            async () => {
+                if (this.sessionStatus === SessionStatus.Running
+                    || this.sessionStatus === SessionStatus.Busy) {
+                    this.setSessionStatus("Session Exited!", SessionStatus.Failed);
+                    await this.promptForRestart();
                 }
-            ]
-        );
+            });
+
+        this.sessionDetails = await languageServerProcess.start("EditorServices", cancellationToken);
+
+        return languageServerProcess;
     }
 
-    private sendTelemetryEvent(
-        eventName: string,
-        properties?: TelemetryEventProperties,
-        measures?: TelemetryEventMeasurements): void {
+    // The process failed to start, so check for common user errors (generally
+    // out-of-support versions of PowerShell).
+    private async handleFailedProcess(powerShellProcess: PowerShellProcess): Promise<void> {
+        const version = await powerShellProcess.getVersionCli();
+        let shouldUpdate = true;
 
-        if (this.extensionContext.extensionMode === vscode.ExtensionMode.Production) {
-            this.telemetryReporter.sendTelemetryEvent(eventName, properties, measures);
+        if (satisfies(version, "<5.1.0")) {
+            void this.setSessionFailedGetPowerShell(`PowerShell v${version} is not supported, please update!`);
+        } else if (satisfies(version, ">=5.1.0 <6.0.0")) {
+            void this.setSessionFailedGetPowerShell("It looks like you're trying to use Windows PowerShell, which is supported on a best-effort basis. Can you try PowerShell 7?");
+        } else if (satisfies(version, ">=6.0.0 <7.2.0")) {
+            void this.setSessionFailedGetPowerShell(`PowerShell v${version} has reached end-of-support, please update!`);
+        } else {
+            shouldUpdate = false;
+            void this.setSessionFailedOpenBug("PowerShell Language Server process didn't start!");
+        }
+
+        if (shouldUpdate) {
+            // Run the update notifier since it won't run later as we failed
+            // to start, but we have enough details to do so now.
+            const versionDetails: IPowerShellVersionDetails = {
+                "version": version,
+                "edition": "", // Unused by UpdatePowerShell
+                "commit": version, // Actually used by UpdatePowerShell
+                "architecture": process.arch // Best guess based off Code's architecture
+            };
+            const updater = new UpdatePowerShell(this.sessionSettings, this.logger, versionDetails);
+            void updater.checkForUpdate();
         }
     }
 
-    private async startLanguageClient(sessionDetails: IEditorServicesSessionDetails): Promise<void> {
-        this.logger.write(`Connecting to language service on pipe: ${sessionDetails.languageServicePipeName}`);
-        this.logger.write("Session details: " + JSON.stringify(sessionDetails));
+    private sessionStarted(sessionDetails: IEditorServicesSessionDetails): boolean {
+        this.logger.writeVerbose(`Session details: ${JSON.stringify(sessionDetails, undefined, 2)}`);
+        if (sessionDetails.status === "started") { // Successful server start with a session file
+            return true;
+        }
+        if (sessionDetails.status === "failed") { // Server started but indicated it failed
+            if (sessionDetails.reason === "powerShellVersion") {
+                void this.setSessionFailedGetPowerShell(`PowerShell ${sessionDetails.powerShellVersion} is not supported, please update!`);
+            } else if (sessionDetails.reason === "dotNetVersion") { // Only applies to PowerShell 5.1
+                void this.setSessionFailedGetDotNet(".NET Framework is out-of-date, please install at least 4.8!");
+            } else {
+                void this.setSessionFailedOpenBug(`PowerShell could not be started for an unknown reason: ${sessionDetails.reason}`);
+            }
+        } else {
+            void this.setSessionFailedOpenBug(`PowerShell could not be started with an unknown status: ${sessionDetails.status}, and reason: ${sessionDetails.reason}`);
+        }
+        return false;
+    }
 
+    private async startLanguageClient(sessionDetails: IEditorServicesSessionDetails): Promise<LanguageClient> {
+        this.logger.writeVerbose("Connecting to language service...");
         const connectFunc = (): Promise<StreamInfo> => {
             return new Promise<StreamInfo>(
                 (resolve, _reject) => {
@@ -649,7 +608,7 @@ Type 'help' to get help.
                     socket.on(
                         "connect",
                         () => {
-                            this.logger.write("Language service socket connected.");
+                            this.logger.writeVerbose("Language service connected.");
                             resolve({ writer: socket, reader: socket });
                         });
                 });
@@ -689,13 +648,13 @@ Type 'help' to get help.
             middleware: this,
         };
 
-        this.languageClient = new LanguageClient("PowerShell Editor Services", connectFunc, clientOptions);
+        const languageClient = new LanguageClient("PowerShell Editor Services", connectFunc, clientOptions);
 
         // This enables handling Semantic Highlighting messages in PowerShell Editor Services
         // TODO: We should only turn this on in preview.
-        this.languageClient.registerProposedFeatures();
+        languageClient.registerProposedFeatures();
 
-        this.languageClient.onTelemetry((event) => {
+        languageClient.onTelemetry((event) => {
             const eventName: string = event.eventName ? event.eventName : "PSESEvent";
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const data: any = event.data ? event.data : event;
@@ -706,7 +665,7 @@ Type 'help' to get help.
         // so that they can register their message handlers
         // before the connection is established.
         for (const consumer of this.languageClientConsumers) {
-            consumer.setLanguageClient(this.languageClient);
+            consumer.setLanguageClient(languageClient);
         }
 
         this.registeredHandlers = [
@@ -714,11 +673,11 @@ Type 'help' to get help.
             // Console.ReadKey, since it's not cancellable. On
             // "cancellation" the server asks us to send pretend to
             // press a key, thus mitigating all the quirk.
-            this.languageClient.onNotification(
+            languageClient.onNotification(
                 SendKeyPressNotificationType,
                 () => { this.languageServerProcess?.sendKeyPress(); }),
 
-            this.languageClient.onNotification(
+            languageClient.onNotification(
                 ExecutionBusyStatusNotificationType,
                 (isBusy: boolean) => {
                     if (isBusy) { this.setSessionBusyStatus(); }
@@ -728,22 +687,111 @@ Type 'help' to get help.
         ];
 
         try {
-            await this.languageClient.start();
+            await languageClient.start();
         } catch (err) {
-            void this.setSessionFailedOpenBug("Could not start language service: " + (err instanceof Error ? err.message : "unknown"));
-            return;
+            void this.setSessionFailedOpenBug("Language client failed to start: " + (err instanceof Error ? err.message : "unknown"));
         }
 
-        this.versionDetails = await this.languageClient.sendRequest(PowerShellVersionRequestType);
-        this.setSessionRunningStatus();
-        this.sendTelemetryEvent("powershellVersionCheck", { powershellVersion: this.versionDetails.version });
+        return languageClient;
+    }
 
-        // We haven't "started" until we're done getting the version information.
-        this.started = true;
+    private async getBundledModulesPath(): Promise<string> {
+        // Because the extension is always at `<root>/out/main.js`
+        let bundledModulesPath = path.resolve(__dirname, "../modules");
 
-        const updater = new UpdatePowerShell(this.sessionSettings, this.logger, this.versionDetails);
-        // NOTE: We specifically don't want to wait for this.
-        void updater.checkForUpdate();
+        if (this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
+            const devBundledModulesPath = path.resolve(__dirname, this.sessionSettings.developer.bundledModulesPath);
+
+            // Make sure the module's bin path exists
+            if (await utils.checkIfDirectoryExists(devBundledModulesPath)) {
+                bundledModulesPath = devBundledModulesPath;
+            } else {
+                void this.logger.writeAndShowWarning(
+                    "In development mode but PowerShellEditorServices dev module path cannot be " +
+                    `found (or has not been built yet): ${devBundledModulesPath}\n`);
+            }
+        }
+
+        return bundledModulesPath;
+    }
+
+    private getEditorServicesArgs(bundledModulesPath: string, powerShellExeDetails: IPowerShellExeDetails): string {
+        let editorServicesArgs =
+            "-HostName 'Visual Studio Code Host' " +
+            "-HostProfileId 'Microsoft.VSCode' " +
+            `-HostVersion '${this.HostVersion}' ` +
+            "-AdditionalModules @('PowerShellEditorServices.VSCode') " +
+            `-BundledModulesPath '${utils.escapeSingleQuotes(bundledModulesPath)}' ` +
+            "-EnableConsoleRepl ";
+
+        if (this.sessionSettings.integratedConsole.suppressStartupBanner) {
+            editorServicesArgs += "-StartupBanner '' ";
+        } else if (utils.isWindows && !powerShellExeDetails.supportsProperArguments) {
+            // NOTE: On Windows we don't Base64 encode the startup command
+            // because it annoys some poorly implemented anti-virus scanners.
+            // Unfortunately this means that for some installs of PowerShell
+            // (such as through the `dotnet` package manager), we can't include
+            // a multi-line startup banner as the quotes break the command.
+            editorServicesArgs += `-StartupBanner '${this.DisplayName} Extension v${this.HostVersion}' `;
+        } else {
+            const startupBanner = `${this.DisplayName} Extension v${this.HostVersion}
+Copyright (c) Microsoft Corporation.
+
+https://aka.ms/vscode-powershell
+Type 'help' to get help.
+`;
+            editorServicesArgs += `-StartupBanner "${startupBanner}" `;
+        }
+
+        // We guard this here too out of an abundance of precaution.
+        if (this.sessionSettings.developer.editorServicesWaitForDebugger
+            && this.extensionContext.extensionMode === vscode.ExtensionMode.Development) {
+            editorServicesArgs += "-WaitForDebugger ";
+        }
+
+        editorServicesArgs += `-LogLevel '${this.sessionSettings.developer.editorServicesLogLevel}' `;
+
+        return editorServicesArgs;
+    }
+
+    private async getVersionDetails(): Promise<IPowerShellVersionDetails | undefined> {
+        // Take one minute to get version details, otherwise cancel and fail.
+        const timeout = new vscode.CancellationTokenSource();
+        setTimeout(() => { timeout.cancel(); }, 60 * 1000);
+
+        const versionDetails = await this.languageClient?.sendRequest(
+            PowerShellVersionRequestType, timeout.token);
+
+        this.sendTelemetryEvent("powershellVersionCheck",
+            { powershellVersion: versionDetails?.version ?? "unknown" });
+
+        return versionDetails;
+    }
+
+    private async promptForRestart(): Promise<void> {
+        await this.logger.writeAndShowErrorWithActions(
+            "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
+            [
+                {
+                    prompt: "Yes",
+                    action: async (): Promise<void> => { await this.restartSession(); }
+                },
+                {
+                    prompt: "No",
+                    action: undefined
+                }
+            ]
+        );
+    }
+
+    private sendTelemetryEvent(
+        eventName: string,
+        properties?: TelemetryEventProperties,
+        measures?: TelemetryEventMeasurements): void {
+
+        if (this.extensionContext.extensionMode === vscode.ExtensionMode.Production) {
+            this.telemetryReporter.sendTelemetryEvent(eventName, properties, measures);
+        }
     }
 
     private createStatusBarItem(): vscode.LanguageStatusItem {
@@ -776,7 +824,6 @@ Type 'help' to get help.
 
         switch (status) {
         case SessionStatus.Running:
-        case SessionStatus.NeverStarted:
         case SessionStatus.NotStarted:
             this.languageStatusItem.busy = false;
             this.languageStatusItem.severity = vscode.LanguageStatusSeverity.Information;
@@ -785,7 +832,7 @@ Type 'help' to get help.
             this.languageStatusItem.busy = true;
             this.languageStatusItem.severity = vscode.LanguageStatusSeverity.Information;
             break;
-        case SessionStatus.Initializing:
+        case SessionStatus.Starting:
         case SessionStatus.Stopping:
             this.languageStatusItem.busy = true;
             this.languageStatusItem.severity = vscode.LanguageStatusSeverity.Warning;

--- a/src/session.ts
+++ b/src/session.ts
@@ -403,6 +403,7 @@ export class SessionManager implements Middleware {
                 || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
                 || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()
                 || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
+            || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
                 || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground)) {
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -195,7 +195,7 @@ export async function changeSetting(
     configurationTarget: vscode.ConfigurationTarget | boolean | undefined,
     logger: ILogger | undefined): Promise<void> {
 
-    logger?.writeDiagnostic(`Changing '${settingName}' at scope '${configurationTarget} to '${newValue}'`);
+    logger?.writeVerbose(`Changing '${settingName}' at scope '${configurationTarget}' to '${newValue}'.`);
 
     try {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,6 @@ async function checkIfFileOrDirectoryExists(targetPath: string | vscode.Uri, typ
                 : vscode.Uri.file(targetPath));
         return (stat.type & type) !== 0;
     } catch {
-        // TODO: Maybe throw if it's not a FileNotFound exception.
         return false;
     }
 }


### PR DESCRIPTION
This was a couple late nights that resulted in an overhaul of our startup, error handling, and logging logic. Mostly because I realized how dang easy it was to get things into a funky state when I added `editorServicesWaitForDebugger` to the list of settings that will prompt for a restart. This made it really easy to test, especially in the "still starting up" state. It is still possible to generate perhaps more error messages than I'd like, but they mostly come from the LSP client library. In fact, the last bug I tracked down is that if the client failed to start, it can't be stopped (which throws an exception) AND it can't be disposed, the latter of which I think is an upstream bug I'll need to investigate.