### PR TITLE
Make `sessionManager.start()` idempotent

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -30,7 +30,7 @@ import { LanguageClientConsumer } from "../languageClientConsumer";
 import { ILogger } from "../logging";
 import { OperatingSystem, getPlatformDetails } from "../platform";
 import { PowerShellProcess } from "../process";
-import { IEditorServicesSessionDetails, SessionManager, SessionStatus } from "../session";
+import { IEditorServicesSessionDetails, SessionManager } from "../session";
 import { getSettings } from "../settings";
 import path from "path";
 import { checkIfFileExists } from "../utils";
@@ -281,9 +281,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         _executable: DebugAdapterExecutable | undefined): Promise<DebugAdapterDescriptor | undefined> {
         // NOTE: A Promise meets the shape of a ProviderResult, which allows us to make this method async.
 
-        if (this.sessionManager.getSessionStatus() !== SessionStatus.Running) {
-            await this.sessionManager.start();
-        }
+        await this.sessionManager.start();
 
         const sessionDetails = session.configuration.createTemporaryIntegratedConsole
             ? await this.createTemporaryIntegratedConsole(session)

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -10,7 +10,7 @@ import { DebugConfig, DebugSessionFeature, DebugConfigurations } from "../../src
 import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import * as platform from "../../src/platform";
 import { IPlatformDetails } from "../../src/platform";
-import { IEditorServicesSessionDetails, IPowerShellVersionDetails, SessionManager, SessionStatus } from "../../src/session";
+import { IEditorServicesSessionDetails, IPowerShellVersionDetails, SessionManager } from "../../src/session";
 import * as utils from "../../src/utils";
 import { BuildBinaryModuleMock, WaitEvent, ensureEditorServicesIsConnected, stubInterface, testLogger } from "../utils";
 
@@ -408,7 +408,6 @@ describe("DebugSessionFeature", () => {
         it("Creates a named pipe server for the debug adapter", async () => {
             const debugSessionFeature = createDebugSessionFeatureStub({
                 sessionManager: Sinon.createStubInstance(SessionManager, {
-                    getSessionStatus: SessionStatus.Running,
                     getSessionDetails: stubInterface<IEditorServicesSessionDetails>({
                         debugServicePipeName: "testPipeName"
                     })


### PR DESCRIPTION
So the debugger can just call `start()` to ensure the session has started. Also make a bunch of public methods private.

/cc @JustinGrote 