### PR TITLE
Add `startLocation` setting for Extension Terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -886,6 +886,19 @@
           "default": false,
           "markdownDescription": "Starts the Extension Terminal in the background. **If this is enabled, to access the terminal you must run the [Show Extension Terminal command](command:PowerShell.ShowSessionConsole), and once shown it cannot be put back into the background.** This option completely hides the Extension Terminal from the terminals view. You are probably looking for the `#powershell.integratedConsole.showOnStartup#` option instead."
         },
+        "powershell.integratedConsole.startLocation": {
+          "type": "string",
+          "default": "Panel",
+          "enum": [
+            "Editor",
+            "Panel"
+          ],
+          "markdownEnumDescriptions": [
+            "Creates the Extension Terminal in Editor area",
+            "Creates the Extension Terminal in Panel area"
+          ],
+          "markdownDescription": "Sets the startup location for Extension Terminal."
+        },
         "powershell.integratedConsole.focusConsoleOnExecute": {
           "type": "boolean",
           "default": true,

--- a/src/process.ts
+++ b/src/process.ts
@@ -107,6 +107,7 @@ export class PowerShellProcess {
             iconPath: new vscode.ThemeIcon("terminal-powershell"),
             isTransient: true,
             hideFromUser: this.sessionSettings.integratedConsole.startInBackground,
+            location: vscode.TerminalLocation[this.sessionSettings.integratedConsole.startLocation],
         };
 
         // Subscribe a log event for when the terminal closes (this fires for

--- a/src/session.ts
+++ b/src/session.ts
@@ -476,7 +476,8 @@ export class SessionManager implements Middleware {
                 || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
             || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
-                || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground)) {
+                || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground
+                || settings.integratedConsole.startLocation !== this.sessionSettings.integratedConsole.startLocation)) {
 
             this.logger.writeVerbose("Settings changed, prompting to restart...");
             const response = await vscode.window.showInformationMessage(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -70,6 +70,11 @@ export enum CommentType {
     LineComment = "LineComment",
 }
 
+export enum StartLocation {
+    Editor = "Editor",
+    Panel = "Panel"
+}
+
 export type PowerShellAdditionalExePathSettings = Record<string, string>;
 
 class CodeFormattingSettings extends PartialSettings {
@@ -129,6 +134,7 @@ class IntegratedConsoleSettings extends PartialSettings {
     useLegacyReadLine = false;
     forceClearScrollbackBuffer = false;
     suppressStartupBanner = false;
+    startLocation = StartLocation.Panel;
 }
 
 class SideBarSettings extends PartialSettings {


### PR DESCRIPTION
Can be set to either `Panel` (the default) or `Editor` which opens like a tab (in another "editor" view of VS Code).

Resolves #4181 and replaces (because I accidentally closed it) #4613.