### PR TITLE
Fix unit test for Windows running on arm64

### DIFF
--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -716,7 +716,7 @@ describe("Platform module", function () {
                 "Platform details operating system should be Windows");
             assert.strictEqual(
                 platformDetails.isProcess64Bit,
-                process.arch === "x64",
+                process.arch === "x64" || process.arch === "arm64",
                 "Windows process bitness should match process arch");
             assert.strictEqual(
                 platformDetails.isOS64Bit,


### PR DESCRIPTION
E.g. a VM on Apple Silicon. It's still 64-bit.