### PR TITLE
Move ESLint Dependabot group to npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
+  groups:
+    ESLint:
+      patterns:
+        - "esbuild"
+        - "eslint"
+        - "@typescript-eslint/*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
-  groups:
-    ESLint:
-      patterns:
-        - esbuild
-        - eslint
-        - "@typescript-eslint/*"


### PR DESCRIPTION
## PR Summary

Fixes `ESlint` dependabot group. Was misplaced under wrong package-manager. 

Related #4665

/cc @andyleejordan  

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
