### PR TITLE
Remove LinkEditorServices comment in development.md

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -38,11 +38,6 @@ This will compile the TypeScript files in the project to JavaScript files.
 Invoke-Build Build
 ```
 
-As a developer, you may want to use `Invoke-Build LinkEditorServices` to setup a symbolic
-link to its modules instead of copying the files. This will mean the built extension will
-always have the latest version of your PowerShell Editor Services build, but this cannot
-be used to package the extension into a VSIX. So it is a manual step.
-
 ### Launching the extension
 
 #### From Visual Studio Code


### PR DESCRIPTION
## PR Summary

Cleanup in development docs.
LinkEditorServices task was removed in #3775. It's default for Debug-builds.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready