### PR TITLE
Support `~`, `./` and named workspace folders in `cwd`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
         - "esbuild"
         - "eslint"
         - "@typescript-eslint/*"
+  ignore:
+    - dependency-name: "untildify"
+      versions: ["5.x"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -6,7 +6,7 @@
     ".jsx"
   ],
   "require": "source-map-support/register",
-  "timeout": 60000,
+  "timeout": 600000,
   "slow": 2000,
   "spec": "out/test/**/*.test.js"
 }

--- a/extension-dev.code-workspace
+++ b/extension-dev.code-workspace
@@ -59,7 +59,7 @@
     "mochaExplorer.autoload": false, // The test instance pops up every time discovery or run is done, this could be annoying on startup.
     "mochaExplorer.debuggerPort": 59229, // Matches the launch config, we dont want to use the default port as we are launching a duplicate instance of vscode and it might conflict.
     "mochaExplorer.ipcRole": "server",
-    "mochaExplorer.ipcTimeout": 10000,
+    "mochaExplorer.ipcTimeout": 30000, // 30 seconds
     "testExplorer.useNativeTesting": true,
     "mochaExplorer.env": {
       "VSCODE_VERSION": "insiders",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@vscode/extension-telemetry": "0.8.2",
         "node-fetch": "2.6.12",
         "semver": "7.5.4",
+        "untildify": "4.0.0",
         "uuid": "9.0.0",
         "vscode-languageclient": "8.1.0",
         "vscode-languageserver-protocol": "3.17.3"
@@ -5318,6 +5319,14 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -9468,6 +9477,11 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -735,7 +735,7 @@
         "powershell.cwd": {
           "type": "string",
           "default": "",
-          "markdownDescription": "An explicit start path where the Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. **Path must be fully resolved: variables are not supported!**"
+          "markdownDescription": "A path where the Extension Terminal will be launched. Both the PowerShell process's and the shell's location will be set to this directory. Does not support variables, but does support the use of '~' and paths relative to a single workspace. **For multi-root workspaces, use the name of the folder you wish to have as the cwd.**"
         },
         "powershell.scriptAnalysis.enable": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@vscode/extension-telemetry": "0.8.2",
     "node-fetch": "2.6.12",
     "semver": "7.5.4",
+    "untildify": "4.0.0",
     "uuid": "9.0.0",
     "vscode-languageclient": "8.1.0",
     "vscode-languageserver-protocol": "3.17.3"

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import vscode = require("vscode");
 import { ILogger } from "../logging";
 import { SessionManager } from "../session";
-import { getSettings, chosenWorkspace, validateCwdSetting } from "../settings";
+import { getSettings, getChosenWorkspace } from "../settings";
 import utils = require("../utils");
 
 enum LaunchType {
@@ -132,8 +132,7 @@ export class PesterTestsFeature implements vscode.Disposable {
 
         // Ensure the necessary script exists (for testing). The debugger will
         // start regardless, but we also pass its success along.
-        await validateCwdSetting(this.logger);
         return await utils.checkIfFileExists(this.invokePesterStubScriptPath)
-            && vscode.debug.startDebugging(chosenWorkspace, launchConfig);
+            && vscode.debug.startDebugging(await getChosenWorkspace(this.logger), launchConfig);
     }
 }

--- a/src/features/RunCode.ts
+++ b/src/features/RunCode.ts
@@ -4,7 +4,7 @@
 import vscode = require("vscode");
 import { SessionManager } from "../session";
 import { ILogger } from "../logging";
-import { getSettings, chosenWorkspace, validateCwdSetting } from "../settings";
+import { getSettings, getChosenWorkspace } from "../settings";
 
 enum LaunchType {
     Debug,
@@ -40,9 +40,7 @@ export class RunCodeFeature implements vscode.Disposable {
         // Create or show the interactive console
         // TODO: #367: Check if "newSession" mode is configured
         this.sessionManager.showDebugTerminal(true);
-
-        await validateCwdSetting(this.logger);
-        await vscode.debug.startDebugging(chosenWorkspace, launchConfig);
+        await vscode.debug.startDebugging(await getChosenWorkspace(this.logger), launchConfig);
     }
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -100,8 +100,8 @@ export class Logger implements ILogger {
     public async writeAndShowInformation(message: string, ...additionalMessages: string[]): Promise<void> {
         this.write(message, ...additionalMessages);
 
-        const selection = await vscode.window.showInformationMessage(message, "Show Logs");
-        if (selection !== undefined) {
+        const selection = await vscode.window.showInformationMessage(message, "Show Logs", "Okay");
+        if (selection === "Show Logs") {
             this.showLogPanel();
         }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,7 @@ import { ShowHelpFeature } from "./features/ShowHelp";
 import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { Logger } from "./logging";
 import { SessionManager } from "./session";
-import { LogLevel, getSettings, validateCwdSetting } from "./settings";
+import { LogLevel, getSettings } from "./settings";
 import { PowerShellLanguageId } from "./utils";
 import { LanguageClientConsumer } from "./languageClientConsumer";
 
@@ -57,8 +57,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
 
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);
 
-    // Load and validate settings (will prompt for 'cwd' if necessary).
-    await validateCwdSetting(logger);
     const settings = getSettings();
     logger.writeVerbose(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -8,6 +8,7 @@ import vscode = require("vscode");
 import { integer } from "vscode-languageserver-protocol";
 import { ILogger } from "./logging";
 import { changeSetting, getSettings, PowerShellAdditionalExePathSettings } from "./settings";
+import untildify from "untildify";
 
 // This uses require so we can rewire it in unit tests!
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-var-requires
@@ -232,10 +233,12 @@ export class PowerShellExeFinder {
     private *enumerateAdditionalPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
         for (const versionName in this.additionalPowerShellExes) {
             if (Object.prototype.hasOwnProperty.call(this.additionalPowerShellExes, versionName)) {
-                const exePath = utils.stripQuotePair(this.additionalPowerShellExes[versionName]);
+                let exePath = utils.stripQuotePair(this.additionalPowerShellExes[versionName]);
                 if (!exePath) {
                     continue;
                 }
+
+                exePath = untildify(exePath);
 
                 // Always search for what the user gave us first
                 yield new PossiblePowerShellExe(exePath, versionName);

--- a/src/process.ts
+++ b/src/process.ts
@@ -5,7 +5,7 @@ import cp = require("child_process");
 import path = require("path");
 import vscode = require("vscode");
 import { ILogger } from "./logging";
-import Settings = require("./settings");
+import { Settings, validateCwdSetting } from "./settings";
 import utils = require("./utils");
 import { IEditorServicesSessionDetails } from "./session";
 import { promisify } from "util";
@@ -29,7 +29,7 @@ export class PowerShellProcess {
         private logger: ILogger,
         private startPsesArgs: string,
         private sessionFilePath: vscode.Uri,
-        private sessionSettings: Settings.Settings) {
+        private sessionSettings: Settings) {
 
         this.onExited = this.onExitedEmitter.event;
     }
@@ -103,7 +103,7 @@ export class PowerShellProcess {
             name: this.title,
             shellPath: this.exePath,
             shellArgs: powerShellArgs,
-            cwd: this.sessionSettings.cwd,
+            cwd: await validateCwdSetting(this.logger),
             iconPath: new vscode.ThemeIcon("terminal-powershell"),
             isTransient: true,
             hideFromUser: this.sessionSettings.integratedConsole.startInBackground,

--- a/src/session.ts
+++ b/src/session.ts
@@ -283,8 +283,7 @@ export class SessionManager implements Middleware {
         this.logger.write("Restarting session...");
         await this.stop();
 
-        // Re-load and validate the settings.
-        await validateCwdSetting(this.logger);
+        // Re-load the settings.
         this.sessionSettings = getSettings();
 
         await this.start(exeNameOverride);
@@ -475,7 +474,7 @@ export class SessionManager implements Middleware {
                 || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
                 || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()
                 || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
-            || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
+                || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
                 || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground
                 || settings.integratedConsole.startLocation !== this.sessionSettings.integratedConsole.startLocation)) {
@@ -644,7 +643,7 @@ export class SessionManager implements Middleware {
             // NOTE: Some settings are only applicable on startup, so we send them during initialization.
             initializationOptions: {
                 enableProfileLoading: this.sessionSettings.enableProfileLoading,
-                initialWorkingDirectory: this.sessionSettings.cwd,
+                initialWorkingDirectory: await validateCwdSetting(this.logger),
                 shellIntegrationEnabled: vscode.workspace.getConfiguration("terminal.integrated.shellIntegration").get<boolean>("enabled"),
             },
             errorHandler: {

--- a/src/session.ts
+++ b/src/session.ts
@@ -469,7 +469,7 @@ export class SessionManager implements Middleware {
         this.logger.updateLogLevel(settings.developer.editorServicesLogLevel);
 
         // Detect any setting changes that would affect the session.
-        if (!this.suppressRestartPrompt &&
+        if (!this.suppressRestartPrompt && this.sessionStatus === SessionStatus.Running &&
             (settings.cwd.toLowerCase() !== this.sessionSettings.cwd.toLowerCase()
                 || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
                 || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,7 +37,7 @@ export class Settings extends PartialSettings {
     sideBar = new SideBarSettings();
     pester = new PesterSettings();
     buttons = new ButtonSettings();
-    cwd = "";
+    cwd = "";  // NOTE: use validateCwdSetting() instead of this directly!
     enableReferencesCodeLens = true;
     analyzeOpenDocumentsOnly = false;
     // TODO: Add (deprecated) useX86Host (for testing)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -240,6 +240,14 @@ export async function getChosenWorkspace(logger: ILogger | undefined): Promise<v
         logger?.writeVerbose(`User selected workspace: '${chosenWorkspace?.name}'`);
         if (chosenWorkspace === undefined) {
             chosenWorkspace = vscode.workspace.workspaceFolders[0];
+        } else {
+            const response = await vscode.window.showInformationMessage(
+                `Would you like to save this choice by setting this workspace's 'powershell.cwd' value to '${chosenWorkspace.name}'?`,
+                "Yes", "No");
+
+            if (response === "Yes") {
+                await changeSetting("cwd", chosenWorkspace.name, vscode.ConfigurationTarget.Workspace, logger);
+            }
         }
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,6 +5,7 @@ import vscode = require("vscode");
 import utils = require("./utils");
 import os = require("os");
 import { ILogger } from "./logging";
+import untildify from "untildify";
 
 // TODO: Quite a few of these settings are unused in the client and instead
 // exist just for the server. Those settings do not need to be represented in
@@ -221,8 +222,11 @@ export async function validateCwdSetting(logger: ILogger): Promise<string> {
         vscode.workspace.getConfiguration(utils.PowerShellLanguageId).get<string>("cwd"));
 
     // Only use the cwd setting if it exists.
-    if (cwd !== undefined && await utils.checkIfDirectoryExists(cwd)) {
-        return cwd;
+    if (cwd !== undefined) {
+        cwd = untildify(cwd);
+        if (await utils.checkIfDirectoryExists(cwd)) {
+            return cwd;
+        }
     }
 
     // If there is no workspace, or there is but it has no folders, fallback.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -217,7 +217,7 @@ export async function changeSetting(
 let hasPrompted = false;
 export let chosenWorkspace: vscode.WorkspaceFolder | undefined = undefined;
 
-export async function validateCwdSetting(logger: ILogger): Promise<string> {
+export async function validateCwdSetting(logger: ILogger | undefined): Promise<string> {
     let cwd: string | undefined = utils.stripQuotePair(
         vscode.workspace.getConfiguration(utils.PowerShellLanguageId).get<string>("cwd"));
 

--- a/test/TestEnvironment.code-workspace
+++ b/test/TestEnvironment.code-workspace
@@ -8,6 +8,6 @@
   "settings": {
     "git.openRepositoryInParentFolders": "never",
     "csharp.suppressDotnetRestoreNotification": true,
-    "extensions.ignoreRecommendations": true
+    "extensions.ignoreRecommendations": true,
   }
 }

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -451,6 +451,7 @@ if (process.platform === "win32") {
 
     additionalPowerShellExes = {
         "pwsh": "C:\\Users\\test\\pwsh\\pwsh.exe",
+        "pwsh-tilde": "~\\pwsh\\pwsh.exe",
         "pwsh-no-exe": "C:\\Users\\test\\pwsh\\pwsh",
         "pwsh-folder": "C:\\Users\\test\\pwsh\\",
         "pwsh-folder-no-slash": "C:\\Users\\test\\pwsh",
@@ -466,13 +467,16 @@ if (process.platform === "win32") {
                 isOS64Bit: true,
                 isProcess64Bit: true,
             },
-            environmentVars: {
-                "USERPROFILE": "C:\\Users\\test",
-            },
+            environmentVars: {},
             expectedPowerShellSequence: [
                 {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
                     displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: path.join(os.homedir(), "pwsh", "pwsh.exe"),
+                    displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {
@@ -747,6 +751,7 @@ if (process.platform === "win32") {
 
     additionalPowerShellExes = {
         "pwsh": "/home/bin/pwsh",
+        "pwsh-tilde": "~/bin/pwsh",
         "pwsh-folder": "/home/bin/",
         "pwsh-folder-no-slash": "/home/bin",
         "pwsh-single-quotes": "'/home/bin/pwsh'",
@@ -761,13 +766,16 @@ if (process.platform === "win32") {
                 isOS64Bit: true,
                 isProcess64Bit: true,
             },
-            environmentVars: {
-                "HOME": "/home/test",
-            },
+            environmentVars: {},
             expectedPowerShellSequence: [
                 {
                     exePath: "/home/bin/pwsh",
                     displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: path.join(os.homedir(), "bin", "pwsh"),
+                    displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -2,32 +2,79 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
+import * as os from "os";
 import * as vscode from "vscode";
-import { Settings, getSettings, getEffectiveConfigurationTarget, changeSetting, CommentType } from "../../src/settings";
+import {
+    Settings,
+    getSettings,
+    getEffectiveConfigurationTarget,
+    changeSetting,
+    CommentType,
+    validateCwdSetting
+} from "../../src/settings";
+import path from "path";
 
 describe("Settings E2E", function () {
-    it("Loads without error", function () {
-        assert.doesNotThrow(getSettings);
+    describe("The 'getSettings' method loads the 'Settings' class", function () {
+        it("Loads without error", function () {
+            assert.doesNotThrow(getSettings);
+        });
+
+        it("Loads the correct defaults", function () {
+            const testSettings = new Settings();
+            const actualSettings = getSettings();
+            assert.deepStrictEqual(actualSettings, testSettings);
+        });
     });
 
-    it("Loads the correct defaults", function () {
-        const testSettings = new Settings();
-        const actualSettings = getSettings();
-        assert.deepStrictEqual(actualSettings, testSettings);
+    describe("The 'changeSetting' method", function () {
+        it("Updates correctly", async function () {
+            await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
+            assert.strictEqual(getSettings().helpCompletion, CommentType.LineComment);
+        });
     });
 
-    it("Updates correctly", async function () {
-        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
-        assert.strictEqual(getSettings().helpCompletion, CommentType.LineComment);
+    describe("The 'getEffectiveConfigurationTarget' method'", function () {
+        it("Works for 'Workspace' target", async function () {
+            await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
+            const target = getEffectiveConfigurationTarget("helpCompletion");
+            assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
+        });
+
+        it("Works for 'undefined' target", async function () {
+            await changeSetting("helpCompletion", undefined, false, undefined);
+            const target = getEffectiveConfigurationTarget("helpCompletion");
+            assert.strictEqual(target, undefined);
+        });
     });
 
-    it("Gets the effective configuration target", async function () {
-        await changeSetting("helpCompletion", CommentType.LineComment, false, undefined);
-        let target = getEffectiveConfigurationTarget("helpCompletion");
-        assert.strictEqual(target, vscode.ConfigurationTarget.Workspace);
+    describe("The CWD setting", function () {
+        beforeEach(async function () {
+            await changeSetting("cwd", undefined, undefined, undefined);
+        });
 
-        await changeSetting("helpCompletion", undefined, false, undefined);
-        target = getEffectiveConfigurationTarget("helpCompletion");
-        assert.strictEqual(target, undefined);
+        const workspace = vscode.workspace.workspaceFolders![0].uri.fsPath;
+
+        it("Defaults to the 'mocks' workspace folder", async function () {
+            assert.strictEqual(await validateCwdSetting(undefined), workspace);
+        });
+
+        it("Uses the default when given a non-existent folder", async function () {
+            await changeSetting("cwd", "/a/totally/fake/folder", undefined, undefined);
+            assert.strictEqual(await validateCwdSetting(undefined), workspace);
+        });
+
+        it("Uses the given folder when it exists", async function () {
+            // A different than default folder that definitely exists
+            const cwd = path.resolve(path.join(process.cwd(), ".."));
+            await changeSetting("cwd", cwd, undefined, undefined);
+            assert.strictEqual(await validateCwdSetting(undefined), cwd);
+        });
+
+        it("Uses the home folder for ~ (tilde)", async function () {
+            // A different than default folder that definitely exists
+            await changeSetting("cwd", "~", undefined, undefined);
+            assert.strictEqual(await validateCwdSetting(undefined), os.homedir());
+        });
     });
 });

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -88,11 +88,18 @@ describe("Settings E2E", function () {
             assert.strictEqual(await validateCwdSetting(undefined), os.homedir());
         });
 
-        it("Resolves relative paths", async function () {
+        it("Accepts relative paths", async function () {
             // A different than default folder that definitely exists and is relative
             const cwd = path.join("~", "somewhere", "..");
+            const expected = path.join(os.homedir(), "somewhere", "..");
             await changeCwdSetting(cwd);
-            assert.strictEqual(await validateCwdSetting(undefined), os.homedir());
+            assert.strictEqual(await validateCwdSetting(undefined), expected);
+        });
+
+        it("Handles relative paths", async function () {
+            await changeCwdSetting("./BinaryModule");
+            const expected = path.join(workspace, "./BinaryModule");
+            assert.strictEqual(await validateCwdSetting(undefined), expected);
         });
     });
 });


### PR DESCRIPTION
This makes them way less annoying. I'm ok taking a dependency on untildify as it's a very simple package, and the Python extension for VS Code also uses it. However, it must remain at v4.0.0, as the latest version, v5.0.0, is pure ESM and therefore cannot be loaded by VS Code.

https://github.com/sindresorhus/untildify/releases/tag/v5.0.0

Now also handles paths relative to a single workspace folder, or understands the name of a workspace folder in multi-root workspaces. Resolves #4557.