### PR TITLE
Fix race condition with displaying PowerShell name on icon

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,8 +22,6 @@ class PartialSettings { }
 export class Settings extends PartialSettings {
     powerShellAdditionalExePaths: PowerShellAdditionalExePathSettings = {};
     powerShellDefaultVersion = "";
-    // This setting is no longer used but is here to assist in cleaning up the users settings.
-    powerShellExePath = "";
     promptToUpdatePowerShell = true;
     suppressAdditionalExeNotFoundWarning = false;
     startAsLoginShell = new StartAsLoginShellSettings();


### PR DESCRIPTION
Refactors the logic a bit so the that Language Status Icon has the correct details when switching sessions. Also delete superfluous (and apparently broken) migration code.