### PR TITLE
Respect file path casing in extension commands

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -444,10 +444,10 @@ export class SessionManager implements Middleware {
 
         // Detect any setting changes that would affect the session.
         if (!this.suppressRestartPrompt && this.sessionStatus === SessionStatus.Running &&
-            (settings.cwd.toLowerCase() !== this.sessionSettings.cwd.toLowerCase()
-                || settings.powerShellDefaultVersion.toLowerCase() !== this.sessionSettings.powerShellDefaultVersion.toLowerCase()
-                || settings.developer.editorServicesLogLevel.toLowerCase() !== this.sessionSettings.developer.editorServicesLogLevel.toLowerCase()
-                || settings.developer.bundledModulesPath.toLowerCase() !== this.sessionSettings.developer.bundledModulesPath.toLowerCase()
+            (settings.cwd !== this.sessionSettings.cwd
+                || settings.powerShellDefaultVersion !== this.sessionSettings.powerShellDefaultVersion
+                || settings.developer.editorServicesLogLevel !== this.sessionSettings.developer.editorServicesLogLevel
+                || settings.developer.bundledModulesPath !== this.sessionSettings.developer.bundledModulesPath
                 || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
                 || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground
@@ -872,7 +872,8 @@ Type 'help' to get help.
             prompt: "Open an Issue",
             action: async (): Promise<void> => {
                 await vscode.commands.executeCommand("PowerShell.GenerateBugReport");
-            }}]
+            }
+        }]
         );
     }
 
@@ -883,7 +884,8 @@ Type 'help' to get help.
             action: async (): Promise<void> => {
                 await vscode.env.openExternal(
                     vscode.Uri.parse("https://aka.ms/get-powershell-vscode"));
-            }}]
+            }
+        }]
         );
     }
 
@@ -894,7 +896,8 @@ Type 'help' to get help.
             action: async (): Promise<void> => {
                 await vscode.env.openExternal(
                     vscode.Uri.parse("https://dotnet.microsoft.com/en-us/download/dotnet-framework"));
-            }}]
+            }
+        }]
         );
     }
 


### PR DESCRIPTION
Per https://nodejs.org/en/docs/guides/working-with-different-filesystems we should really just keep the file path we're given, no "normalizing" to be done especially since it is wrong to infer from the OS if the filesystem is case-sensitive or not. Gone are the days where Windows and macOS could be presumed case-insensitive, they now both support and are often found with with case-sensitive filesystems. Plus, there was really no reason to be doing this in the first place. Tested interactively, this works just fine since the VS Code APIs we're using handle case-insensitivity for us.

Resolves #2960.
