### PR TITLE
Use a CustomRequest to disconnect the dotnet debugger from attach sessions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@typescript-eslint/eslint-plugin": "6.4.0",
         "@typescript-eslint/parser": "6.4.0",
         "@ungap/structured-clone": "1.2.0",
+        "@vscode/debugprotocol": "^1.61.0",
         "@vscode/test-electron": "2.3.4",
         "@vscode/vsce": "2.20.1",
         "esbuild": "0.19.2",
@@ -1295,6 +1296,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "node_modules/@vscode/debugprotocol": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.61.0.tgz",
+      "integrity": "sha512-K/kF27jIStVFqlmUaGc2u+Dj8IR7YdEiSqShWr7MWhDudqpAW7uu7XMwoFwjpuC9LSaVwJMIX7EFC5OJ/RmnDQ==",
       "dev": true
     },
     "node_modules/@vscode/extension-telemetry": {
@@ -6062,6 +6069,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
+    "@vscode/debugprotocol": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.61.0.tgz",
+      "integrity": "sha512-K/kF27jIStVFqlmUaGc2u+Dj8IR7YdEiSqShWr7MWhDudqpAW7uu7XMwoFwjpuC9LSaVwJMIX7EFC5OJ/RmnDQ==",
       "dev": true
     },
     "@vscode/extension-telemetry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@typescript-eslint/eslint-plugin": "6.4.0",
         "@typescript-eslint/parser": "6.4.0",
         "@ungap/structured-clone": "1.2.0",
-        "@vscode/debugprotocol": "^1.61.0",
+        "@vscode/debugprotocol": "1.61.0",
         "@vscode/test-electron": "2.3.4",
         "@vscode/vsce": "2.20.1",
         "esbuild": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "6.4.0",
     "@typescript-eslint/parser": "6.4.0",
     "@ungap/structured-clone": "1.2.0",
-    "@vscode/debugprotocol": "^1.61.0",
+    "@vscode/debugprotocol": "1.61.0",
     "@vscode/test-electron": "2.3.4",
     "@vscode/vsce": "2.20.1",
     "esbuild": "0.19.2",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@typescript-eslint/eslint-plugin": "6.4.0",
     "@typescript-eslint/parser": "6.4.0",
     "@ungap/structured-clone": "1.2.0",
+    "@vscode/debugprotocol": "^1.61.0",
     "@vscode/test-electron": "2.3.4",
     "@vscode/vsce": "2.20.1",
     "esbuild": "0.19.2",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -378,7 +378,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
             // Ensure the .NET session stops before the PowerShell session so that the .NET debug session doesn't emit an error about the process unexpectedly terminating.
             let tempConsoleDotnetAttachSession: DebugSession;
             const startDebugEvent = debug.onDidStartDebugSession(dotnetAttachSession => {
-                if (dotnetAttachSession.configuration.name != dotnetAttachConfig.name) {return;}
+                if (dotnetAttachSession.configuration.name != dotnetAttachConfig.name) { return; }
 
                 // Makes the event one-time
                 // HACK: This seems like you would be calling a method on a variable not assigned yet, but it does work in the flow.
@@ -389,8 +389,8 @@ export class DebugSessionFeature extends LanguageClientConsumer
 
                 tempConsoleDotnetAttachSession = dotnetAttachSession;
 
-                const stopDebugEvent = debug.onDidTerminateDebugSession( async tempConsoleSession => {
-                    if (tempConsoleDotnetAttachSession.parentSession?.id !== tempConsoleSession.id) {return;}
+                const stopDebugEvent = debug.onDidTerminateDebugSession(async tempConsoleSession => {
+                    if (tempConsoleDotnetAttachSession.parentSession?.id !== tempConsoleSession.id) { return; }
 
                     // Makes the event one-time
                     stopDebugEvent.dispose();

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -409,10 +409,14 @@ export class DebugSessionFeature extends LanguageClientConsumer
                         }
                     };
 
-                    await dotnetAttachSession.customRequest(
-                        disconnectRequest.command,
-                        disconnectRequest.arguments
-                    );
+                    try {
+                        await dotnetAttachSession.customRequest(
+                            disconnectRequest.command,
+                            disconnectRequest.arguments
+                        );
+                    } catch (err) {
+                        this.logger.writeWarning(`Disconnect request to C# debugger failed: ${err}`);
+                    }
                 });
             });
 

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -24,6 +24,7 @@ import {
     QuickPickOptions,
     DebugConfigurationProviderTriggerKind
 } from "vscode";
+import type { DebugProtocol } from "@vscode/debugprotocol";
 import { NotificationType, RequestType } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 import { LanguageClientConsumer } from "../languageClientConsumer";
@@ -403,7 +404,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
                             restart: false,
                             terminateDebuggee: false,
                             suspendDebuggee: false
-                        }
+                        } as DebugProtocol.DisconnectArguments
                     );
                 });
             });

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -415,7 +415,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
                             disconnectRequest.arguments
                         );
                     } catch (err) {
-                        this.logger.writeWarning(`Disconnect request to C# debugger failed: ${err}`);
+                        this.logger.writeWarning(`Disconnect request to dotnet debugger failed: ${err}`);
                     }
                 });
             });

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -398,13 +398,20 @@ export class DebugSessionFeature extends LanguageClientConsumer
                     this.logger.writeVerbose(`Debugger session terminated: ${tempConsoleSession.name} (${tempConsoleSession.id})`);
 
                     // HACK: As of 2023-08-17, there is no vscode debug API to request the C# debugger to detach, so we send it a custom DAP request instead.
-                    await dotnetAttachSession.customRequest(
-                        "disconnect",
-                        {
+                    const disconnectRequest: DebugProtocol.DisconnectRequest = {
+                        command: "disconnect",
+                        seq: 0,
+                        type: "request",
+                        arguments: {
                             restart: false,
                             terminateDebuggee: false,
                             suspendDebuggee: false
-                        } as DebugProtocol.DisconnectArguments
+                        }
+                    };
+
+                    await dotnetAttachSession.customRequest(
+                        disconnectRequest.command,
+                        disconnectRequest.arguments
                     );
                 });
             });

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -428,13 +428,16 @@ describe("DebugSessionFeature", () => {
     });
 });
 
-describe("DebugSessionFeature E2E", () => {
+describe("DebugSessionFeature E2E", function() {
+    // E2E tests can take a while to run since the debugger has to start up and attach
+    this.slow(20000);
     before(async () => {
         // Registers and warms up the debug adapter and the PowerShell Extension Terminal
         await ensureEditorServicesIsConnected();
     });
 
     it("Starts and stops a debugging session", async () => {
+
         // Inspect the debug session via the started events to ensure it is correct
         const startDebugSession = new Promise<DebugSession>((resolve) => {
             const event = debug.onDidStartDebugSession((session) => {

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -73,6 +73,8 @@ describe("ISE compatibility feature", function () {
     });
 
     describe("Color theme interactions", function () {
+        // These tests are slow because they change the user's theme.
+        this.slow(3000);
         beforeEach(enableISEMode);
 
         function assertISESettings(): void {


### PR DESCRIPTION
## PR Summary

The vscode `stopDebugging` API when used with the dotnet debugger would kill the powershell process if it was in attach mode, so we use a `customRequest` DAP message to disconnect the dotnet debugger since there is no vscode direct API for disconnecting the debug session.

Fixes #4702

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
