### PR TITLE
Move `--sourcemap` to scripts instead of `Invoke-Build`

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
   "main": "./out/main.js",
   "scripts": {
     "lint": "eslint . --ext .ts",
-    "build": "esbuild ./src/main.ts --outdir=out --bundle --external:vscode --platform=node",
+    "build": "esbuild ./src/main.ts --outdir=out --sourcemap --bundle --external:vscode --platform=node",
     "build-watch": "npm run build -- --watch",
     "build-test": "tsc --incremental",
     "build-test-watch": "npm run build-test -- --watch",

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -101,7 +101,7 @@ task Build Restore, {
     # Unfortunately `esbuild` doesn't support emitting 1:1 files (yet).
     # https://github.com/evanw/esbuild/issues/944
     switch ($Configuration) {
-        "Debug" { Invoke-BuildExec { & npm run build -- --sourcemap } }
+        "Debug" { Invoke-BuildExec { & npm run build } }
         "Release" { Invoke-BuildExec { & npm run build -- --minify } }
     }
 }


### PR DESCRIPTION
## PR Summary

ESBuild does not currently generate sourcemaps for debugging. This enables that generation and I verified that `vsce` does not include the sourcemaps when packaging.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
