### PR TITLE
Update extension telemetry dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2023.9.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@vscode/extension-telemetry": "0.8.2",
+        "@vscode/extension-telemetry": "0.8.3",
         "node-fetch": "2.6.13",
         "semver": "7.5.4",
         "untildify": "4.0.0",
@@ -27,7 +27,7 @@
         "@types/sinon": "10.0.16",
         "@types/ungap__structured-clone": "0.3.0",
         "@types/uuid": "9.0.2",
-        "@types/vscode": "1.67.0",
+        "@types/vscode": "1.79.0",
         "@typescript-eslint/eslint-plugin": "6.4.1",
         "@typescript-eslint/parser": "6.4.1",
         "@ungap/structured-clone": "1.2.0",
@@ -48,7 +48,7 @@
         "typescript": "5.1.6"
       },
       "engines": {
-        "vscode": "^1.79.0"
+        "vscode": "^1.79.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -72,15 +72,16 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-      "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
+      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
+        "@azure/core-util": "^1.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
@@ -180,15 +181,15 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
       "dependencies": {
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.14.0",
-        "@opentelemetry/instrumentation": "^0.40.0",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/instrumentation": "^0.41.2",
         "tslib": "^2.2.0"
       },
       "engines": {
@@ -637,21 +638,21 @@
       "dev": true
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.12.tgz",
-      "integrity": "sha512-cHpxZZ+pbtOyqFMFB/c1COpaOE3VPFU6phYVHVvOA9DvoeMZfI/Xrxaj7B/vfq4MmkiE7nOAPhv5ZRn+i6OogA==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.13.tgz",
+      "integrity": "sha512-CluYTRWcEk0ObG5EWFNWhs87e2qchJUn0p2D21ZUa3PWojPZfPSBs4//WIE0MYV8Qg1Hdif2ZTwlM7TbYUjfAg==",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "2.8.14",
+        "@microsoft/applicationinsights-core-js": "2.8.15",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.12.tgz",
-      "integrity": "sha512-vhIVYg4FzBfwtM8tBqDUq3xU+cFu6SQ7biuJHtQpd5PVjDgvAovVOMRF1khsZE/k2rttRRBpmBgNEqG3Ptoysw==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.13.tgz",
+      "integrity": "sha512-HgS574fdD19Bo2vPguyznL4eDw7Pcm1cVNpvbvBLWiW3x4e1FCQ3VMXChWnAxCae8Hb0XqlA2sz332ZobBavTA==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "3.2.12",
+        "@microsoft/1ds-core-js": "3.2.13",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
@@ -747,9 +748,9 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.14.tgz",
-      "integrity": "sha512-XacWUHdjSHMUwdngMZBp0oiCBifD56CQK2Egu2PiBiF4xu2AO2yNCtWSXsQX2g5OkEhVwaEjfa/aH3WbpYxB1g==",
+      "version": "2.8.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.15.tgz",
+      "integrity": "sha512-yYAs9MyjGr2YijQdUSN9mVgT1ijI1FPMgcffpaPmYbHAVbQmF7bXudrBWHxmLzJlwl5rfep+Zgjli2e67lwUqQ==",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.9"
@@ -883,11 +884,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -897,14 +898,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.3.5",
-        "require-in-the-middle": "^7.1.0",
-        "semver": "^7.3.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -915,12 +916,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -930,13 +931,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -946,9 +947,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
       "engines": {
         "node": ">=14"
       }
@@ -1098,9 +1099,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
+      "integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1305,14 +1306,14 @@
       "dev": true
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.8.2.tgz",
-      "integrity": "sha512-bBvlyRpjJEmNXBaPkfJSpfD88kEWzbTpdavpo+NwW5uZguWHllbQebavjt6jH+Pm1k7hWnaJoS5PIULk7uuSgw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.8.3.tgz",
+      "integrity": "sha512-HXOnUINiDPZWJ1lXFFxNTcVXCojdg1fqyItDOv9W5V1t27p9V3GrC1PiNtzR4ba2pX/DIQSPrEPymXJ6Z+w2pQ==",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^3.2.10",
-        "@microsoft/1ds-post-js": "^3.2.10",
-        "@microsoft/applicationinsights-web-basic": "^3.0.0",
-        "applicationinsights": "^2.7.0"
+        "@microsoft/1ds-core-js": "^3.2.13",
+        "@microsoft/1ds-post-js": "^3.2.13",
+        "@microsoft/applicationinsights-web-basic": "^3.0.2",
+        "applicationinsights": "^2.7.1"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -1394,12 +1395,19 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -1482,23 +1490,23 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.0.tgz",
-      "integrity": "sha512-/vV5X6M4TlRA5NxNZAdCE0gukzfK24mb3z18D5Kl/CyIfSVIkafsIji3mK+Zi5q+7dn6H1CkFazlcnLf40anHw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.3.tgz",
+      "integrity": "sha512-JY8+kTEkjbA+kAVNWDtpfW2lqsrDALfDXuxOs74KLPu2y13fy/9WB52V4LfYVTVcW1/jYOXjTxNS2gPZIDh1iw==",
       "dependencies": {
-        "@azure/core-auth": "^1.4.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-rest-pipeline": "1.10.1",
         "@azure/core-util": "1.2.0",
-        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-        "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/core": "^1.12.0",
-        "@opentelemetry/sdk-trace-base": "^1.12.0",
-        "@opentelemetry/semantic-conventions": "^1.12.0",
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/sdk-trace-base": "^1.15.2",
+        "@opentelemetry/semantic-conventions": "^1.15.2",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.1.0",
-        "diagnostic-channel-publishers": "1.0.6"
+        "diagnostic-channel": "1.1.1",
+        "diagnostic-channel-publishers": "1.0.7"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -1826,6 +1834,11 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -2035,27 +2048,19 @@
       }
     },
     "node_modules/diagnostic-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
-      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+      "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "dependencies": {
-        "semver": "^5.3.0"
+        "semver": "^7.5.3"
       }
     },
     "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
-      "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
+      "integrity": "sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==",
       "peerDependencies": {
         "diagnostic-channel": "*"
-      }
-    },
-    "node_modules/diagnostic-channel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/diff": {
@@ -2953,10 +2958,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -3005,9 +3013,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -4183,9 +4191,9 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.1.1.tgz",
-      "integrity": "sha512-OScOjQjrrjhAdFpQmnkE/qbIBGCRFhQB/YaJhcC3CPOlmhe7llnW46Ac1J5+EjcNXOTnDdpF96Erw/yedsGksQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -4196,11 +4204,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -5251,11 +5259,12 @@
       }
     },
     "@azure/core-auth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-      "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
+      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
       "requires": {
         "@azure/abort-controller": "^1.0.0",
+        "@azure/core-util": "^1.1.0",
         "tslib": "^2.2.0"
       }
     },
@@ -5334,15 +5343,15 @@
       }
     },
     "@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
       "requires": {
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.14.0",
-        "@opentelemetry/instrumentation": "^0.40.0",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/instrumentation": "^0.41.2",
         "tslib": "^2.2.0"
       }
     },
@@ -5562,21 +5571,21 @@
       "dev": true
     },
     "@microsoft/1ds-core-js": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.12.tgz",
-      "integrity": "sha512-cHpxZZ+pbtOyqFMFB/c1COpaOE3VPFU6phYVHVvOA9DvoeMZfI/Xrxaj7B/vfq4MmkiE7nOAPhv5ZRn+i6OogA==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-3.2.13.tgz",
+      "integrity": "sha512-CluYTRWcEk0ObG5EWFNWhs87e2qchJUn0p2D21ZUa3PWojPZfPSBs4//WIE0MYV8Qg1Hdif2ZTwlM7TbYUjfAg==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "2.8.14",
+        "@microsoft/applicationinsights-core-js": "2.8.15",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
     },
     "@microsoft/1ds-post-js": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.12.tgz",
-      "integrity": "sha512-vhIVYg4FzBfwtM8tBqDUq3xU+cFu6SQ7biuJHtQpd5PVjDgvAovVOMRF1khsZE/k2rttRRBpmBgNEqG3Ptoysw==",
+      "version": "3.2.13",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-3.2.13.tgz",
+      "integrity": "sha512-HgS574fdD19Bo2vPguyznL4eDw7Pcm1cVNpvbvBLWiW3x4e1FCQ3VMXChWnAxCae8Hb0XqlA2sz332ZobBavTA==",
       "requires": {
-        "@microsoft/1ds-core-js": "3.2.12",
+        "@microsoft/1ds-core-js": "3.2.13",
         "@microsoft/applicationinsights-shims": "^2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.7"
       }
@@ -5664,9 +5673,9 @@
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.14.tgz",
-      "integrity": "sha512-XacWUHdjSHMUwdngMZBp0oiCBifD56CQK2Egu2PiBiF4xu2AO2yNCtWSXsQX2g5OkEhVwaEjfa/aH3WbpYxB1g==",
+      "version": "2.8.15",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-2.8.15.tgz",
+      "integrity": "sha512-yYAs9MyjGr2YijQdUSN9mVgT1ijI1FPMgcffpaPmYbHAVbQmF7bXudrBWHxmLzJlwl5rfep+Zgjli2e67lwUqQ==",
       "requires": {
         "@microsoft/applicationinsights-shims": "2.0.2",
         "@microsoft/dynamicproto-js": "^1.1.9"
@@ -5776,48 +5785,48 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
     "@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/semantic-conventions": "1.15.2"
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "requires": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.3.5",
-        "require-in-the-middle": "^7.1.0",
-        "semver": "^7.3.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
       "requires": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
       "requires": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5960,9 +5969,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.67.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
-      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
+      "integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -6078,14 +6087,14 @@
       "dev": true
     },
     "@vscode/extension-telemetry": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.8.2.tgz",
-      "integrity": "sha512-bBvlyRpjJEmNXBaPkfJSpfD88kEWzbTpdavpo+NwW5uZguWHllbQebavjt6jH+Pm1k7hWnaJoS5PIULk7uuSgw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.8.3.tgz",
+      "integrity": "sha512-HXOnUINiDPZWJ1lXFFxNTcVXCojdg1fqyItDOv9W5V1t27p9V3GrC1PiNtzR4ba2pX/DIQSPrEPymXJ6Z+w2pQ==",
       "requires": {
-        "@microsoft/1ds-core-js": "^3.2.10",
-        "@microsoft/1ds-post-js": "^3.2.10",
-        "@microsoft/applicationinsights-web-basic": "^3.0.0",
-        "applicationinsights": "^2.7.0"
+        "@microsoft/1ds-core-js": "^3.2.13",
+        "@microsoft/1ds-post-js": "^3.2.13",
+        "@microsoft/applicationinsights-web-basic": "^3.0.2",
+        "applicationinsights": "^2.7.1"
       }
     },
     "@vscode/test-electron": {
@@ -6148,8 +6157,13 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -6210,23 +6224,23 @@
       }
     },
     "applicationinsights": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.0.tgz",
-      "integrity": "sha512-/vV5X6M4TlRA5NxNZAdCE0gukzfK24mb3z18D5Kl/CyIfSVIkafsIji3mK+Zi5q+7dn6H1CkFazlcnLf40anHw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.3.tgz",
+      "integrity": "sha512-JY8+kTEkjbA+kAVNWDtpfW2lqsrDALfDXuxOs74KLPu2y13fy/9WB52V4LfYVTVcW1/jYOXjTxNS2gPZIDh1iw==",
       "requires": {
-        "@azure/core-auth": "^1.4.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-rest-pipeline": "1.10.1",
         "@azure/core-util": "1.2.0",
-        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-        "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/core": "^1.12.0",
-        "@opentelemetry/sdk-trace-base": "^1.12.0",
-        "@opentelemetry/semantic-conventions": "^1.12.0",
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/sdk-trace-base": "^1.15.2",
+        "@opentelemetry/semantic-conventions": "^1.15.2",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.1.0",
-        "diagnostic-channel-publishers": "1.0.6"
+        "diagnostic-channel": "1.1.1",
+        "diagnostic-channel-publishers": "1.0.7"
       }
     },
     "argparse": {
@@ -6460,6 +6474,11 @@
       "dev": true,
       "optional": true
     },
+    "cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -6618,24 +6637,17 @@
       "optional": true
     },
     "diagnostic-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
-      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+      "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "requires": {
-        "semver": "^5.3.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
-        }
+        "semver": "^7.5.3"
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
-      "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
+      "integrity": "sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==",
       "requires": {}
     },
     "diff": {
@@ -7292,10 +7304,13 @@
       }
     },
     "import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "requires": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },
@@ -7338,9 +7353,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -8234,9 +8249,9 @@
       "dev": true
     },
     "require-in-the-middle": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.1.1.tgz",
-      "integrity": "sha512-OScOjQjrrjhAdFpQmnkE/qbIBGCRFhQB/YaJhcC3CPOlmhe7llnW46Ac1J5+EjcNXOTnDdpF96Erw/yedsGksQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
       "requires": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -8244,11 +8259,11 @@
       }
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.79.0"
+    "vscode": "^1.79.2"
   },
   "author": "Microsoft Corporation",
   "license": "SEE LICENSE IN LICENSE.txt",
@@ -74,7 +74,7 @@
     "onWalkthrough:PowerShell"
   ],
   "dependencies": {
-    "@vscode/extension-telemetry": "0.8.2",
+    "@vscode/extension-telemetry": "0.8.3",
     "node-fetch": "2.6.13",
     "semver": "7.5.4",
     "untildify": "4.0.0",
@@ -92,7 +92,7 @@
     "@types/sinon": "10.0.16",
     "@types/ungap__structured-clone": "0.3.0",
     "@types/uuid": "9.0.2",
-    "@types/vscode": "1.67.0",
+    "@types/vscode": "1.79.0",
     "@typescript-eslint/eslint-plugin": "6.4.1",
     "@typescript-eslint/parser": "6.4.1",
     "@ungap/structured-clone": "1.2.0",


### PR DESCRIPTION
Which wasn't working in #4709 because our `@types/vscode` package was out of date, so that was updated too.