### PR TITLE
Remove unused telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,11 +302,6 @@
         "category": "PowerShell"
       },
       {
-        "command": "PowerShell.WalkthroughTelemetry",
-        "title": "Walkthrough Telemetry",
-        "category": "PowerShell"
-      },
-      {
         "command": "PowerShell.ClosePanel",
         "title": "Close panel",
         "category": "PowerShell"
@@ -1119,14 +1114,6 @@
               "markdown": "media/walkthrough.md"
             },
             "description": "Now you are ready to start using the PowerShell Extension on your own and explore more resources!\n📚 See the PowerShell Extension's [documentation](https://docs.microsoft.com/en-us/powershell/scripting/dev-cross-plat/vscode/using-vscode?view=powershell-7.2)\nℹ️ View Visual Studio Code's [documentation](https://code.visualstudio.com/docs/languages/powershell)\n🔌 Plug into the [PowerShell Community](https://docs.microsoft.com/en-us/powershell/scripting/community/community-support?view=powershell-7.2)\n📄 Take a look at our [Release Notes](https://docs.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-73?view=powershell-7.2)"
-          },
-          {
-            "id": "feedback",
-            "title": "Share your feedback",
-            "media": {
-              "markdown": "media/walkthrough.md"
-            },
-            "description": "How has this walkthrough affected your confidence level when using the PowerShell Extension?\n[I feel less confident](command:PowerShell.WalkthroughTelemetry?%7B%22satisfaction%22%3A3%7D)\n[My confidence has not been affected](command:PowerShell.WalkthroughTelemetry?%7B%22satisfaction%22%3A2%7D)\n[I feel more confident](command:PowerShell.WalkthroughTelemetry?%7B%22satisfaction%22%3A1%7D)"
           }
         ]
       }

--- a/src/session.ts
+++ b/src/session.ts
@@ -470,12 +470,7 @@ export class SessionManager implements Middleware {
             vscode.commands.registerCommand(this.ShowSessionMenuCommandName, async () => { await this.showSessionMenu(); }),
             vscode.workspace.onDidChangeConfiguration(async () => { await this.onConfigurationUpdated(); }),
             vscode.commands.registerCommand(
-                "PowerShell.ShowSessionConsole", (isExecute?: boolean) => { this.showSessionTerminal(isExecute); }),
-            vscode.commands.registerCommand(
-                "PowerShell.WalkthroughTelemetry", (satisfaction: number) => {
-                    this.sendTelemetryEvent("powershellWalkthroughSatisfaction", undefined, { level: satisfaction });
-                }
-            )
+                "PowerShell.ShowSessionConsole", (isExecute?: boolean) => { this.showSessionTerminal(isExecute); })
         ];
     }
 
@@ -645,6 +640,8 @@ export class SessionManager implements Middleware {
         // TODO: We should only turn this on in preview.
         languageClient.registerProposedFeatures();
 
+        // NOTE: We don't currently send any events from PSES, but may again in
+        // the future so we're leaving this side wired up.
         languageClient.onTelemetry((event) => {
             const eventName: string = event.eventName ? event.eventName : "PSESEvent";
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -753,6 +750,8 @@ Type 'help' to get help.
         const versionDetails = await this.languageClient?.sendRequest(
             PowerShellVersionRequestType, timeout.token);
 
+        // This is pretty much the only telemetry event we care about.
+        // TODO: We actually could send this earlier from PSES itself.
         this.sendTelemetryEvent("powershellVersionCheck",
             { powershellVersion: versionDetails?.version ?? "unknown" });
 


### PR DESCRIPTION
We never actually used (or even received) the telemetry from the walkthrough survey, ergo we shouldn't be sending it.