### PR TITLE
Downgrade `vscode-languageclient` to v8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "powershell",
-  "version": "2023.9.2",
+  "version": "2023.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "powershell",
-      "version": "2023.9.2",
+      "version": "2023.9.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@vscode/extension-telemetry": "0.8.5",
@@ -14,7 +14,7 @@
         "semver": "7.5.4",
         "untildify": "4.0.0",
         "uuid": "9.0.1",
-        "vscode-languageclient": "9.0.0",
+        "vscode-languageclient": "8.1.0",
         "vscode-languageserver-protocol": "3.17.5"
       },
       "devDependencies": {
@@ -4975,16 +4975,16 @@
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.0.tgz",
-      "integrity": "sha512-EXP4vhSlEj0DtyxrcWVp5aiFrY0WczKSnKSyrMmSbU7qhASPhM+pfcUzY/z8TQCfOhKvq39fidbdTbq9LnBi7g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
       "dependencies": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.4"
+        "vscode-languageserver-protocol": "3.17.3"
       },
       "engines": {
-        "vscode": "^1.82.0"
+        "vscode": "^1.67.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
@@ -5006,19 +5006,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4.tgz",
-      "integrity": "sha512-IpaHLPft+UBWf4dOIH15YEgydTbXGz52EMU2h16SfFpYu/yOQt3pY14049mtpJu+4CBHn+hq7S67e7O0AwpRqQ==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.4"
+        "vscode-jsonrpc": "8.1.0",
+        "vscode-languageserver-types": "3.17.3"
       }
     },
     "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4.tgz",
-      "integrity": "sha512-9YXi5pA3XF2V+NUQg6g+lulNS0ncRCKASYdK3Cs7kiH9sVFXWq27prjkC/B8M/xJLRPPRSPCHVMuBTgRNFh2sQ=="
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
@@ -8875,13 +8883,13 @@
       "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="
     },
     "vscode-languageclient": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.0.tgz",
-      "integrity": "sha512-EXP4vhSlEj0DtyxrcWVp5aiFrY0WczKSnKSyrMmSbU7qhASPhM+pfcUzY/z8TQCfOhKvq39fidbdTbq9LnBi7g==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
+      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
       "requires": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.4"
+        "vscode-languageserver-protocol": "3.17.3"
       },
       "dependencies": {
         "brace-expansion": {
@@ -8900,19 +8908,24 @@
             "brace-expansion": "^2.0.1"
           }
         },
+        "vscode-jsonrpc": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
+          "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw=="
+        },
         "vscode-languageserver-protocol": {
-          "version": "3.17.4",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.4.tgz",
-          "integrity": "sha512-IpaHLPft+UBWf4dOIH15YEgydTbXGz52EMU2h16SfFpYu/yOQt3pY14049mtpJu+4CBHn+hq7S67e7O0AwpRqQ==",
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
+          "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
           "requires": {
-            "vscode-jsonrpc": "8.2.0",
-            "vscode-languageserver-types": "3.17.4"
+            "vscode-jsonrpc": "8.1.0",
+            "vscode-languageserver-types": "3.17.3"
           }
         },
         "vscode-languageserver-types": {
-          "version": "3.17.4",
-          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.4.tgz",
-          "integrity": "sha512-9YXi5pA3XF2V+NUQg6g+lulNS0ncRCKASYdK3Cs7kiH9sVFXWq27prjkC/B8M/xJLRPPRSPCHVMuBTgRNFh2sQ=="
+          "version": "3.17.3",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
+          "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "semver": "7.5.4",
     "untildify": "4.0.0",
     "uuid": "9.0.1",
-    "vscode-languageclient": "9.0.0",
+    "vscode-languageclient": "8.1.0",
     "vscode-languageserver-protocol": "3.17.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Because v9.0.0 upped the VS Code requirement to v1.82.0, above our own current requirement (and also is _very_ new). Downgrading brings its minimum back to 1.67.0, below ours.

Resolves #4762.