### PR TITLE
Bump expected versions in updater tests

### DIFF
--- a/test/features/UpdatePowerShell.test.ts
+++ b/test/features/UpdatePowerShell.test.ts
@@ -112,22 +112,22 @@ describe("UpdatePowerShell feature", function () {
             const updater = new UpdatePowerShell(settings, testLogger, version);
             // @ts-expect-error method is private.
             const tag: string | undefined = await updater.maybeGetNewRelease();
-            // NOTE: This will need to be updated each new major LTS.
+            // NOTE: This will need to be updated each time an LTS goes out of support.
             assert(tag?.startsWith("v7.2"));
         });
 
         it("Would update to stable", async function() {
             const version: IPowerShellVersionDetails = {
-                "version": "7.0.0",
+                "version": "7.3.0",
                 "edition": "Core",
-                "commit": "7.0.0",
+                "commit": "7.3.0",
                 "architecture": "X64"
             };
             const updater = new UpdatePowerShell(settings, testLogger, version);
             // @ts-expect-error method is private.
             const tag: string | undefined = await updater.maybeGetNewRelease();
             // NOTE: This will need to be updated each new major stable.
-            assert(tag?.startsWith("v7.3"));
+            assert(tag?.startsWith("v7.4"));
         });
     });
 });


### PR DESCRIPTION
Now that a new stable and LTS release of PowerShell is out.