### PR TITLE
Bump VS Code engine

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+; We use Dependabot to update our packages, so we want to add without a prefix
+save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/mocha": "10.0.6",
         "@types/mock-fs": "4.13.4",
-        "@types/node": "16.18.12",
+        "@types/node": "18.19.3",
         "@types/node-fetch": "2.6.4",
         "@types/rewire": "2.5.30",
         "@types/semver": "7.5.6",
@@ -831,10 +831,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "16.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
-      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==",
-      "dev": true
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.4",
@@ -4436,6 +4439,12 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -5299,10 +5308,13 @@
       }
     },
     "@types/node": {
-      "version": "16.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
-      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw==",
-      "dev": true
+      "version": "18.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.3.tgz",
+      "integrity": "sha512-k5fggr14DwAytoA/t8rPrIz++lXK7/DqckthCmoZOKNsEbJkId4Z//BqgApXBUGrGddrigYa1oqheo/7YmW4rg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.4",
@@ -7961,6 +7973,12 @@
       "version": "1.13.6",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "untildify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/sinon": "17.0.2",
         "@types/ungap__structured-clone": "0.3.3",
         "@types/uuid": "9.0.7",
-        "@types/vscode": "1.79.0",
+        "@types/vscode": "1.82.0",
         "@typescript-eslint/eslint-plugin": "6.14.0",
         "@typescript-eslint/parser": "6.14.0",
         "@ungap/structured-clone": "1.2.0",
@@ -48,7 +48,7 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "vscode": "^1.79.2"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -886,9 +886,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
-      "integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5354,9 +5354,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.79.0.tgz",
-      "integrity": "sha512-Tfowu2rSW8hVGbqzQLSPlOEiIOYYryTkgJ+chMecpYiJcnw9n0essvSiclnK+Qh/TcSVJHgaK4EMrQDZjZJ/Sw==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@types/mocha": "10.0.6",
     "@types/mock-fs": "4.13.4",
-    "@types/node": "16.18.12",
+    "@types/node": "18.19.3",
     "@types/node-fetch": "2.6.4",
     "@types/rewire": "2.5.30",
     "@types/semver": "7.5.6",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@types/sinon": "17.0.2",
     "@types/ungap__structured-clone": "0.3.3",
     "@types/uuid": "9.0.7",
-    "@types/vscode": "1.79.0",
+    "@types/vscode": "1.82.0",
     "@typescript-eslint/eslint-plugin": "6.14.0",
     "@typescript-eslint/parser": "6.14.0",
     "@ungap/structured-clone": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.79.2"
+    "vscode": "^1.82.0"
   },
   "author": "Microsoft Corporation",
   "license": "SEE LICENSE IN LICENSE.txt",


### PR DESCRIPTION
Per https://github.com/microsoft/azuredatastudio/pull/24684, Azure Data Studio has bumped to v1.82.0, so we can too.