### PR TITLE
Add developer setting to disable `-ExecutionPolicy Bypass` flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -957,6 +957,11 @@
           "default": false,
           "markdownDescription": "Launches the LSP server with the `/waitForDebugger` flag to force it to wait for a .NET debugger to attach before proceeding, and emit its PID until then. **This setting is only meant for extension developers and requires the extension to be run in development mode!**"
         },
+        "powershell.developer.setExecutionPolicy": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "On Windows we launch the PowerShell executable with `-ExecutionPolicy Bypass` so that the LSP server (PowerShell Editor Services module) will launch without issue. Some anti-virus programs disallow this command-line argument and this flag can be used to remove it. **Using this setting may require trusting the script manually in order for it to launch!**"
+        },
         "powershell.developer.featureFlags": {
           "type": "array",
           "items": {

--- a/src/process.ts
+++ b/src/process.ts
@@ -71,7 +71,7 @@ export class PowerShellProcess {
         powerShellArgs.push("-NoProfile");
 
         // Only add ExecutionPolicy param on Windows
-        if (utils.isWindows) {
+        if (utils.isWindows && this.sessionSettings.developer.setExecutionPolicy) {
             powerShellArgs.push("-ExecutionPolicy", "Bypass");
         }
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -449,6 +449,7 @@ export class SessionManager implements Middleware {
                 || settings.developer.editorServicesLogLevel !== this.sessionSettings.developer.editorServicesLogLevel
                 || settings.developer.bundledModulesPath !== this.sessionSettings.developer.bundledModulesPath
                 || settings.developer.editorServicesWaitForDebugger !== this.sessionSettings.developer.editorServicesWaitForDebugger
+                || settings.developer.setExecutionPolicy !== this.sessionSettings.developer.setExecutionPolicy
                 || settings.integratedConsole.useLegacyReadLine !== this.sessionSettings.integratedConsole.useLegacyReadLine
                 || settings.integratedConsole.startInBackground !== this.sessionSettings.integratedConsole.startInBackground
                 || settings.integratedConsole.startLocation !== this.sessionSettings.integratedConsole.startLocation)) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -116,6 +116,7 @@ class DeveloperSettings extends PartialSettings {
     bundledModulesPath = "../../PowerShellEditorServices/module";
     editorServicesLogLevel = LogLevel.Normal;
     editorServicesWaitForDebugger = false;
+    setExecutionPolicy = true;
     waitForSessionFileTimeoutSeconds = 240;
 }
 


### PR DESCRIPTION
Resolves https://github.com/PowerShell/vscode-powershell/issues/3034 by giving users the (advanced/developer) option to _not_ add `-ExecutionPolicy Bypass` to the start-up of PSES.