### PR TITLE
Fix up debugger configuration resolvers 

### DIFF
--- a/package.json
+++ b/package.json
@@ -486,18 +486,7 @@
             "body": {
               "name": "PowerShell Attach to Host Process",
               "type": "PowerShell",
-              "request": "attach",
-              "runspaceId": 1
-            }
-          },
-          {
-            "label": "PowerShell: Attach Interactive Session Runspace",
-            "description": "Open runspace picker to select runspace to attach debugger to",
-            "body": {
-              "name": "PowerShell Attach Interactive Session Runspace",
-              "type": "PowerShell",
-              "request": "attach",
-              "processId": "current"
+              "request": "attach"
             }
           },
           {
@@ -588,29 +577,27 @@
             "properties": {
               "computerName": {
                 "type": "string",
-                "description": "Optional: The computer name to which a remote session will be established.  Works only on PowerShell 4 and above."
+                "description": "Optional: The computer name to which a remote session will be established.",
+                "default": null
               },
               "processId": {
-                "type": "string",
-                "description": "The process id of the PowerShell host process to attach to.  Works only on PowerShell 5 and above.",
+                "type": "number",
+                "description": "Optional: The ID of the PowerShell host process that should be attached. Will prompt if unspecified.",
                 "default": null
               },
               "runspaceId": {
-                "type": [
-                  "string",
-                  "number"
-                ],
-                "description": "Optional: The ID of the runspace to debug in the attached process.  Defaults to 1.  Works only on PowerShell 5 and above.",
+                "type": "number",
+                "description": "Optional: The ID of the runspace to debug in the attached process. Will prompt if unspecified.",
                 "default": null
               },
               "runspaceName": {
                 "type": "string",
-                "description": "Optional: The Name of the runspace to debug in the attached process.  Works only on PowerShell 5 and above.",
+                "description": "Optional: The name of the runspace to debug in the attached process.",
                 "default": null
               },
               "customPipeName": {
                 "type": "string",
-                "description": "The custom pipe name of the PowerShell host process to attach to.  Works only on PowerShell 6.2 and above.",
+                "description": "The custom pipe name of the PowerShell host process to attach to.",
                 "default": null
               }
             }

--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -5,7 +5,7 @@ import vscode = require("vscode");
 import { ILogger } from "../logging";
 
 export class CodeActionsFeature implements vscode.Disposable {
-    private showDocumentationCommand: vscode.Disposable;
+    private command: vscode.Disposable;
 
     constructor(private log: ILogger) {
         // NOTE: While not exposed to the user via package.json, this is
@@ -13,17 +13,17 @@ export class CodeActionsFeature implements vscode.Disposable {
         //
         // TODO: In the far future with LSP 3.19 the server can just set a URL
         // and this can go away. See https://github.com/microsoft/language-server-protocol/issues/1548
-        this.showDocumentationCommand =
+        this.command =
             vscode.commands.registerCommand("PowerShell.ShowCodeActionDocumentation", async (ruleName: string) => {
                 await this.showRuleDocumentation(ruleName);
             });
     }
 
     public dispose(): void {
-        this.showDocumentationCommand.dispose();
+        this.command.dispose();
     }
 
-    public async showRuleDocumentation(ruleId: string): Promise<void> {
+    private async showRuleDocumentation(ruleId: string): Promise<void> {
         const pssaDocBaseURL = "https://docs.microsoft.com/powershell/utility-modules/psscriptanalyzer/rules/";
 
         if (!ruleId) {

--- a/src/features/Console.ts
+++ b/src/features/Console.ts
@@ -200,8 +200,8 @@ export class ConsoleFeature extends LanguageClientConsumer {
                 } else {
                     selectionRange = editor.document.lineAt(editor.selection.start.line).range;
                 }
-
-                await this.languageClient?.sendRequest(EvaluateRequestType, {
+                const client = await LanguageClientConsumer.getLanguageClient();
+                await client.sendRequest(EvaluateRequestType, {
                     expression: editor.document.getText(selectionRange),
                 });
 
@@ -217,19 +217,19 @@ export class ConsoleFeature extends LanguageClientConsumer {
         for (const command of this.commands) {
             command.dispose();
         }
+
         for (const handler of this.handlers) {
             handler.dispose();
         }
     }
 
-    public override setLanguageClient(languageClient: LanguageClient): void {
-        this.languageClient = languageClient;
+    public override onLanguageClientSet(languageClient: LanguageClient): void {
         this.handlers = [
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 ShowChoicePromptRequestType,
                 (promptDetails) => showChoicePrompt(promptDetails)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 ShowInputPromptRequestType,
                 (promptDetails) => showInputPrompt(promptDetails)),
         ];

--- a/src/features/ExpandAlias.ts
+++ b/src/features/ExpandAlias.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 import vscode = require("vscode");
-import Window = vscode.window;
 import { RequestType } from "vscode-languageclient";
 import { LanguageClientConsumer } from "../languageClientConsumer";
+import type { LanguageClient } from "vscode-languageclient/node";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IExpandAliasRequestArguments {
@@ -23,7 +23,7 @@ export class ExpandAliasFeature extends LanguageClientConsumer {
     constructor() {
         super();
         this.command = vscode.commands.registerCommand("PowerShell.ExpandAlias", async () => {
-            const editor = Window.activeTextEditor;
+            const editor = vscode.window.activeTextEditor;
             if (editor === undefined) {
                 return;
             }
@@ -44,14 +44,16 @@ export class ExpandAliasFeature extends LanguageClientConsumer {
                 range = new vscode.Range(sls.line, sls.character, sle.line, sle.character);
             }
 
-            const result = await this.languageClient?.sendRequest(ExpandAliasRequestType, { text });
-            if (result !== undefined) {
-                await editor.edit((editBuilder) => {
-                    editBuilder.replace(range, result.text);
-                });
-            }
+            const client = await LanguageClientConsumer.getLanguageClient();
+            const result = await client.sendRequest(ExpandAliasRequestType, { text });
+            await editor.edit((editBuilder) => {
+                editBuilder.replace(range, result.text);
+            });
         });
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override onLanguageClientSet(_languageClient: LanguageClient): void {}
 
     public dispose(): void {
         this.command.dispose();

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -157,9 +157,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
         super();
         this.commands = [
             vscode.commands.registerCommand("PowerShell.ShowAdditionalCommands", async () => {
-                if (this.languageClient !== undefined) {
-                    await this.showExtensionCommands(this.languageClient);
-                }
+                await this.showExtensionCommands();
             }),
 
             vscode.commands.registerCommand("PowerShell.InvokeRegisteredEditorCommand",
@@ -168,7 +166,9 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
                         (x) => x.name === param.commandName);
 
                     if (commandToExecute) {
-                        await this.languageClient?.sendRequest(
+
+                        const client = await LanguageClientConsumer.getLanguageClient();
+                        await client.sendRequest(
                             InvokeExtensionCommandRequestType,
                             {
                                 name: commandToExecute.name,
@@ -193,63 +193,60 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
         ];
     }
 
-    public override setLanguageClient(languageClient: LanguageClient): void {
+    public override onLanguageClientSet(languageClient: LanguageClient): void {
         // Clear the current list of extension commands since they were
         // only relevant to the previous session
         this.extensionCommands = [];
-
-        this.languageClient = languageClient;
-
         this.handlers = [
-            this.languageClient.onNotification(
+            languageClient.onNotification(
                 ExtensionCommandAddedNotificationType,
                 (command) => { this.addExtensionCommand(command); }),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 GetEditorContextRequestType,
                 (_details) => this.getEditorContext()),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 InsertTextRequestType,
                 (details) => this.insertText(details)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 SetSelectionRequestType,
                 (details) => this.setSelection(details)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 NewFileRequestType,
                 (_content) => this.newFile(_content)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 OpenFileRequestType,
                 (filePath) => this.openFile(filePath)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 CloseFileRequestType,
                 (filePath) => this.closeFile(filePath)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 SaveFileRequestType,
                 (saveFileDetails) => this.saveFile(saveFileDetails)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 ShowInformationMessageRequestType,
                 (message) => this.showInformationMessage(message)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 ShowErrorMessageRequestType,
                 (message) => this.showErrorMessage(message)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 ShowWarningMessageRequestType,
                 (message) => this.showWarningMessage(message)),
 
-            this.languageClient.onRequest(
+            languageClient.onRequest(
                 SetStatusBarMessageRequestType,
                 (messageDetails) => this.setStatusBarMessage(messageDetails)),
 
-            this.languageClient.onNotification(
+            languageClient.onNotification(
                 ClearTerminalNotificationType,
                 () => {
                     // We check to see if they have TrueClear on. If not, no-op because the
@@ -284,7 +281,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
                 a.name.localeCompare(b.name));
     }
 
-    private async showExtensionCommands(client: LanguageClient): Promise<void> {
+    private async showExtensionCommands(): Promise<void> {
         // If no extension commands are available, show a message
         if (this.extensionCommands.length === 0) {
             void this.logger.writeAndShowInformation("No extension commands have been loaded into the current session.");
@@ -303,15 +300,14 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
         const selectedCommand = await vscode.window.showQuickPick(
             quickPickItems,
             { placeHolder: "Select a command..." });
-        return this.onCommandSelected(selectedCommand, client);
+
+        return this.onCommandSelected(selectedCommand);
     }
 
-    private async onCommandSelected(
-        chosenItem: IExtensionCommandQuickPickItem | undefined,
-        client: LanguageClient | undefined): Promise<void> {
-
+    private async onCommandSelected(chosenItem?: IExtensionCommandQuickPickItem): Promise<void> {
         if (chosenItem !== undefined) {
-            await client?.sendRequest(
+            const client = await LanguageClientConsumer.getLanguageClient();
+            await client.sendRequest(
                 InvokeExtensionCommandRequestType,
                 {
                     name: chosenItem.command.name,

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -3,7 +3,6 @@
 
 import * as vscode from "vscode";
 import { v4 as uuidv4 } from "uuid";
-import { LanguageClientConsumer } from "../languageClientConsumer";
 import { ILogger } from "../logging";
 import { SessionManager } from "../session";
 
@@ -33,14 +32,13 @@ NOTE: At some point, we should release a helper npm package that wraps the API a
 * Manages session id for you
 
 */
-export class ExternalApiFeature extends LanguageClientConsumer implements IPowerShellExtensionClient {
+export class ExternalApiFeature implements IPowerShellExtensionClient {
     private static readonly registeredExternalExtension: Map<string, IExternalExtension> = new Map<string, IExternalExtension>();
 
     constructor(
         private extensionContext: vscode.ExtensionContext,
         private sessionManager: SessionManager,
         private logger: ILogger) {
-        super();
     }
 
     /*

--- a/src/features/NewFileOrProject.ts
+++ b/src/features/NewFileOrProject.ts
@@ -11,50 +11,21 @@ export class NewFileOrProjectFeature extends LanguageClientConsumer {
 
     private readonly loadIcon = "  $(sync)  ";
     private command: vscode.Disposable;
-    private waitingForClientToken?: vscode.CancellationTokenSource;
 
     constructor(private logger: ILogger) {
         super();
         this.command =
-            vscode.commands.registerCommand("PowerShell.NewProjectFromTemplate", async () => {
-                if (!this.languageClient && !this.waitingForClientToken) {
-                    // If PowerShell isn't finished loading yet, show a loading message
-                    // until the LanguageClient is passed on to us
-                    this.waitingForClientToken = new vscode.CancellationTokenSource();
-                    const response = await vscode.window.showQuickPick(
-                        ["Cancel"],
-                        { placeHolder: "New Project: Please wait, starting PowerShell..." },
-                        this.waitingForClientToken.token);
-
-                    if (response === "Cancel") {
-                        this.clearWaitingToken();
-                    }
-
-                    // Cancel the loading prompt after 60 seconds
-                    setTimeout(() => {
-                        if (this.waitingForClientToken) {
-                            this.clearWaitingToken();
-                            void this.logger.writeAndShowError("New Project: PowerShell session took too long to start.");
-                        }
-                    }, 60000);
-                } else {
-                    await this.showProjectTemplates();
-                }
-            });
+            vscode.commands.registerCommand(
+                "PowerShell.NewProjectFromTemplate",
+                async () => { await this.showProjectTemplates(); });
     }
 
     public dispose(): void {
         this.command.dispose();
     }
 
-    public override setLanguageClient(languageClient: LanguageClient): void {
-        this.languageClient = languageClient;
-
-        if (this.waitingForClientToken) {
-            this.clearWaitingToken();
-            void this.showProjectTemplates();
-        }
-    }
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override onLanguageClientSet(_languageClient: LanguageClient): void {}
 
     private async showProjectTemplates(includeInstalledModules = false): Promise<void> {
         const template = await vscode.window.showQuickPick(
@@ -74,11 +45,8 @@ export class NewFileOrProjectFeature extends LanguageClientConsumer {
     }
 
     private async getProjectTemplates(includeInstalledModules: boolean): Promise<ITemplateQuickPickItem[]> {
-        if (this.languageClient === undefined) {
-            return Promise.reject<ITemplateQuickPickItem[]>("Language client not defined!");
-        }
-
-        const response = await this.languageClient.sendRequest(
+        const client = await LanguageClientConsumer.getLanguageClient();
+        const response = await client.sendRequest(
             GetProjectTemplatesRequestType,
             { includeInstalledModules });
 
@@ -86,37 +54,37 @@ export class NewFileOrProjectFeature extends LanguageClientConsumer {
             // TODO: Offer to install Plaster
             void this.logger.writeAndShowError("Plaster is not installed!");
             return Promise.reject<ITemplateQuickPickItem[]>("Plaster needs to be installed");
-        } else {
-            let templates = response.templates.map<ITemplateQuickPickItem>(
-                (template) => {
-                    return {
-                        label: template.title,
-                        description: `v${template.version} by ${template.author}, tags: ${template.tags}`,
-                        detail: template.description,
-                        template,
-                    };
-                });
-
-            if (!includeInstalledModules) {
-                templates =
-                    [({
-                        label: this.loadIcon,
-                        description: "Load additional templates from installed modules",
-                        template: undefined,
-                    } as ITemplateQuickPickItem)]
-                        .concat(templates);
-            } else {
-                templates =
-                    [({
-                        label: this.loadIcon,
-                        description: "Refresh template list",
-                        template: undefined,
-                    } as ITemplateQuickPickItem)]
-                        .concat(templates);
-            }
-
-            return templates;
         }
+
+        let templates = response.templates.map<ITemplateQuickPickItem>(
+            (template) => {
+                return {
+                    label: template.title,
+                    description: `v${template.version} by ${template.author}, tags: ${template.tags}`,
+                    detail: template.description,
+                    template,
+                };
+            });
+
+        if (!includeInstalledModules) {
+            templates =
+                [({
+                    label: this.loadIcon,
+                    description: "Load additional templates from installed modules",
+                    template: undefined,
+                } as ITemplateQuickPickItem)]
+                    .concat(templates);
+        } else {
+            templates =
+                [({
+                    label: this.loadIcon,
+                    description: "Refresh template list",
+                    template: undefined,
+                } as ITemplateQuickPickItem)]
+                    .concat(templates);
+        }
+
+        return templates;
     }
 
     private async createProjectFromTemplate(template: ITemplateDetails): Promise<void> {
@@ -129,10 +97,12 @@ export class NewFileOrProjectFeature extends LanguageClientConsumer {
         if (destinationPath !== undefined) {
             await vscode.commands.executeCommand("PowerShell.ShowSessionConsole");
 
-            const result = await this.languageClient?.sendRequest(
+            const client = await LanguageClientConsumer.getLanguageClient();
+            const result = await client.sendRequest(
                 NewProjectFromTemplateRequestType,
                 { templatePath: template.templatePath, destinationPath });
-            if (result?.creationSuccessful) {
+
+            if (result.creationSuccessful) {
                 await this.openWorkspacePath(destinationPath);
             } else {
                 void this.logger.writeAndShowError("Project creation failed, read the Output window for more details.");
@@ -160,11 +130,6 @@ export class NewFileOrProjectFeature extends LanguageClientConsumer {
             "vscode.openFolder",
             vscode.Uri.file(workspacePath),
             true);
-    }
-
-    private clearWaitingToken(): void {
-        this.waitingForClientToken?.dispose();
-        this.waitingForClientToken = undefined;
     }
 }
 

--- a/src/features/RemoteFiles.ts
+++ b/src/features/RemoteFiles.ts
@@ -6,6 +6,7 @@ import path = require("path");
 import vscode = require("vscode");
 import { NotificationType, TextDocumentIdentifier } from "vscode-languageclient";
 import { LanguageClientConsumer } from "../languageClientConsumer";
+import type { LanguageClient } from "vscode-languageclient/node";
 
 // NOTE: The following two DidSaveTextDocument* types will
 // be removed when #593 gets fixed.
@@ -37,8 +38,9 @@ export class RemoteFilesFeature extends LanguageClientConsumer {
         this.closeRemoteFiles();
 
         this.command = vscode.workspace.onDidSaveTextDocument(async (doc) => {
-            if (this.isDocumentRemote(doc) && this.languageClient) {
-                await this.languageClient.sendNotification(
+            if (this.isDocumentRemote(doc)) {
+                const client = await LanguageClientConsumer.getLanguageClient();
+                await client.sendNotification(
                     DidSaveTextDocumentNotificationType,
                     {
                         textDocument: TextDocumentIdentifier.create(doc.uri.toString()),
@@ -46,6 +48,9 @@ export class RemoteFilesFeature extends LanguageClientConsumer {
             }
         });
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override onLanguageClientSet(_languageClient: LanguageClient): void {}
 
     public dispose(): void {
         this.command.dispose();

--- a/src/features/ShowHelp.ts
+++ b/src/features/ShowHelp.ts
@@ -4,6 +4,7 @@
 import vscode = require("vscode");
 import { NotificationType } from "vscode-languageclient";
 import { LanguageClientConsumer } from "../languageClientConsumer";
+import type { LanguageClient } from "vscode-languageclient/node";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface IShowHelpNotificationArguments {
@@ -30,12 +31,17 @@ export class ShowHelpFeature extends LanguageClientConsumer {
                 const cwr = doc.getWordRangeAtPosition(selection.active);
                 const text = doc.getText(cwr);
 
-                await this.languageClient?.sendNotification(ShowHelpNotificationType, { text });
+                const client = await LanguageClientConsumer.getLanguageClient();
+                await client.sendNotification(ShowHelpNotificationType, { text });
             } else {
-                await this.languageClient?.sendNotification(ShowHelpNotificationType, { text: item.Name });
+                const client = await LanguageClientConsumer.getLanguageClient();
+                await client.sendNotification(ShowHelpNotificationType, { text: item.Name });
             }
         });
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    public override onLanguageClientSet(_languageClient: LanguageClient): void {}
 
     public dispose(): void {
         this.command.dispose();

--- a/src/languageClientConsumer.ts
+++ b/src/languageClientConsumer.ts
@@ -1,28 +1,66 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { window } from "vscode";
+import { ProgressLocation, window } from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 
 export abstract class LanguageClientConsumer {
+    private static languageClientPromise?: Promise<LanguageClient>;
+    private static getLanguageClientResolve?: (value: LanguageClient) => void;
 
-    private _languageClient: LanguageClient | undefined;
+    // Implementations of this class must override this method to register their
+    // handlers, as its called whenever the client is restarted / replaced.
+    public abstract onLanguageClientSet(languageClient: LanguageClient): void;
 
-    public setLanguageClient(languageClient: LanguageClient): void {
-        this.languageClient = languageClient;
+    // This is called in the session manager when the client is started (so we
+    // can wait for that). It's what actually resolves the promise.
+    public static onLanguageClientStarted(languageClient: LanguageClient): void {
+        // It should have been created earlier, but if not, create and resolve it.
+        this.languageClientPromise ??= Promise.resolve(languageClient);
+        this.getLanguageClientResolve?.(languageClient);
     }
 
-    abstract dispose(): void;
-
-    public get languageClient(): LanguageClient | undefined {
-        if (!this._languageClient) {
-            // TODO: Plumb through the logger.
-            void window.showInformationMessage("PowerShell extension has not finished starting up yet. Please try again in a few moments.");
-        }
-        return this._languageClient;
+    // This is called in the session manager when the client exits so we can
+    // make a new promise.
+    public static onLanguageClientExited(): void {
+        this.languageClientPromise = undefined;
+        this.getLanguageClientResolve = undefined;
     }
 
-    public set languageClient(value: LanguageClient | undefined) {
-        this._languageClient = value;
+    // We should have a promise as defined in resetLanguageClient, but if we
+    // don't, create it.
+    public static async getLanguageClient(): Promise<LanguageClient> {
+        // If it hasn't been created or was rejected, recreate it.
+        LanguageClientConsumer.languageClientPromise?.catch(() => {
+            LanguageClientConsumer.languageClientPromise = undefined;
+        });
+        LanguageClientConsumer.languageClientPromise ??= LanguageClientConsumer.createLanguageClientPromise();
+        return LanguageClientConsumer.languageClientPromise;
+    }
+
+    // This waits for the language client to start and shows a cancellable
+    // loading message. (It just wrap the static method below.)
+    private static async createLanguageClientPromise(): Promise<LanguageClient> {
+        return window.withProgress<LanguageClient>(
+            {
+                location: ProgressLocation.Notification,
+                title: "Please wait, starting PowerShell Extension Terminal...",
+                cancellable: true
+            },
+            (_progress, token) => {
+                token.onCancellationRequested(() => {
+                    void window.showErrorMessage("Cancelled PowerShell Extension Terminal start-up.");
+                });
+
+                // The real promise!
+                return new Promise<LanguageClient>(
+                    (resolve, reject) => {
+                        // Store the resolve function to be called in resetLanguageClient.
+                        LanguageClientConsumer.getLanguageClientResolve = resolve;
+                        // Reject the promise if the operation is cancelled.
+                        token.onCancellationRequested(() => { reject(); });
+                    }
+                );
+            });
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,6 @@ import { ISECompatibilityFeature } from "./features/ISECompatibility";
 import { NewFileOrProjectFeature } from "./features/NewFileOrProject";
 import { OpenInISEFeature } from "./features/OpenInISE";
 import { PesterTestsFeature } from "./features/PesterTests";
-import { PickPSHostProcessFeature, PickRunspaceFeature } from "./features/DebugSession";
 import { RemoteFilesFeature } from "./features/RemoteFiles";
 import { ShowHelpFeature } from "./features/ShowHelp";
 import { SpecifyScriptArgsFeature } from "./features/DebugSession";
@@ -147,16 +146,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
     languageClientConsumers = [
         new ConsoleFeature(logger),
         new ExpandAliasFeature(),
-        new GetCommandsFeature(logger),
+        new GetCommandsFeature(),
         new ShowHelpFeature(),
         new ExtensionCommandsFeature(logger),
         new NewFileOrProjectFeature(logger),
         new RemoteFilesFeature(),
         new DebugSessionFeature(context, sessionManager, logger),
-        new PickPSHostProcessFeature(logger),
         new HelpCompletionFeature(),
-        new PickRunspaceFeature(logger),
-        externalApi
     ];
 
     sessionManager.setLanguageClientConsumers(languageClientConsumers);
@@ -176,10 +172,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
 
 export async function deactivate(): Promise<void> {
     // Clean up all extension features
-    for (const languageClientConsumer of languageClientConsumers) {
-        languageClientConsumer.dispose();
-    }
-
     for (const commandRegistration of commandRegistrations) {
         commandRegistration.dispose();
     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -531,6 +531,8 @@ export class SessionManager implements Middleware {
 
         languageServerProcess.onExited(
             async () => {
+                LanguageClientConsumer.onLanguageClientExited();
+
                 if (this.sessionStatus === SessionStatus.Running
                     || this.sessionStatus === SessionStatus.Busy) {
                     this.setSessionStatus("Session Exited!", SessionStatus.Failed);
@@ -661,7 +663,7 @@ export class SessionManager implements Middleware {
         // so that they can register their message handlers
         // before the connection is established.
         for (const consumer of this.languageClientConsumers) {
-            consumer.setLanguageClient(languageClient);
+            consumer.onLanguageClientSet(languageClient);
         }
 
         this.registeredHandlers = [
@@ -684,6 +686,7 @@ export class SessionManager implements Middleware {
 
         try {
             await languageClient.start();
+            LanguageClientConsumer.onLanguageClientStarted(languageClient);
         } catch (err) {
             void this.setSessionFailedOpenBug("Language client failed to start: " + (err instanceof Error ? err.message : "unknown"));
         }

--- a/src/session.ts
+++ b/src/session.ts
@@ -303,6 +303,13 @@ export class SessionManager implements Middleware {
         return this.sessionDetails;
     }
 
+    public async getLanguageServerPid(): Promise<number | undefined> {
+        if (this.languageServerProcess === undefined) {
+            void this.logger.writeAndShowError("PowerShell Extension Terminal unavailable!");
+        }
+        return this.languageServerProcess?.getPid();
+    }
+
     public getPowerShellVersionDetails(): IPowerShellVersionDetails | undefined {
         return this.versionDetails;
     }


### PR DESCRIPTION
Wow this was a mess. Needs https://github.com/PowerShell/PowerShellEditorServices/pull/2130, and I'm a little worried about breaking changes _but_ supplying `"current"` to `processId` is special-cased to still work (well, throw an appropriate warning), since the launch configuration types only generate warnings.

Ok so we removed the notion of IDs (which are integers) being strings because that broke serialization with recent updates. But on inspection we realized the whole point was to be able to say "current" and have the attach configuration attach to the currently running Extension Terminal. Except that this was an unsupported, half-baked scenario (sure, it attached, but it couldn't actually be debugged properly). So now that throws warnings in both the client and server. The defaults for `processId` and `runspaceId` where changed to `null` (again, now they're just integers) which means to query for them. The supplied but half-baked configuration was removed.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4843