### PR TITLE
Fix `PowerShellProcess.dipose()` to fire the `onExited` event idempotently

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -15,7 +15,7 @@ export class PowerShellProcess {
     private static warnUserThreshold = 30;
 
     public onExited: vscode.Event<void>;
-    private onExitedEmitter = new vscode.EventEmitter<void>();
+    private onExitedEmitter?: vscode.EventEmitter<void>;
 
     private consoleTerminal?: vscode.Terminal;
     private consoleCloseSubscription?: vscode.Disposable;
@@ -31,6 +31,7 @@ export class PowerShellProcess {
         private sessionFilePath: vscode.Uri,
         private sessionSettings: Settings) {
 
+        this.onExitedEmitter = new vscode.EventEmitter<void>();
         this.onExited = this.onExitedEmitter.event;
     }
 
@@ -149,6 +150,9 @@ export class PowerShellProcess {
 
         void this.deleteSessionFile(this.sessionFilePath);
 
+        this.onExitedEmitter?.fire();
+        this.onExitedEmitter = undefined;
+
         this.consoleTerminal?.dispose();
         this.consoleTerminal = undefined;
 
@@ -230,7 +234,6 @@ export class PowerShellProcess {
         }
 
         this.logger.writeWarning(`PowerShell process terminated or Extension Terminal was closed, PID: ${this.pid}`);
-        this.onExitedEmitter.fire();
         this.dispose();
     }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -530,13 +530,13 @@ export class SessionManager implements Middleware {
                 this.sessionSettings);
 
         languageServerProcess.onExited(
-            async () => {
+            () => {
                 LanguageClientConsumer.onLanguageClientExited();
 
                 if (this.sessionStatus === SessionStatus.Running
                     || this.sessionStatus === SessionStatus.Busy) {
                     this.setSessionStatus("Session Exited!", SessionStatus.Failed);
-                    await this.promptForRestart();
+                    void this.promptForRestart();
                 }
             });
 


### PR DESCRIPTION
It was only firing when the terminal was closed, not whenever the process exited (which didn't make sense given its name and how we were using it). Good find @JustinGrote.

Also had to be idempotent.