### PR TITLE
Enable LanguageClient Tracing Option

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,25 +287,22 @@ your logs for any sensitive information you would not like to share online!**
 
 #### Provide Language Server Protocol payload logs
 
-The extension works mostly from exchanging messages with [PowerShell Editor Services][].
+A lot of the features of the PowerShell extension actually come from Visual Studio Code directly interacting with the [PowerShell Editor Services](https://github.com/PowerShell/PowerShellEditorServices) process via a [Language Server Protocol client](https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server).
 In some cases, getting to the bottom of a bug will require looking at the payloads of
-these messages. To do this:
+these messages. To enable viewing these messages:
 
 * Add the following setting to your settings file:
 
   ```json
-  "powershell editor services.trace.server":"verbose"
+  "powershell.trace.server":"verbose"
   ```
-
-> While VS Code will not recognize and highlight it, it is a valid option and enables
-> tracer logs on the server.
 
 * Restart VS Code and reproduce the issue.
 
 * Go into the "Output" panel (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd> or
   <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>U</kbd>).
 
-* In the drop down on the right, select "PowerShell Editor Services".
+* In the drop down on the right, select "PowerShell Editor Services Client".
 
 * Copy the entire contents of the Output panel and paste it into the GitHub issue in the
   browser. At this point, you may delete the setting if you want.

--- a/package.json
+++ b/package.json
@@ -1006,6 +1006,16 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Show buttons in the editor's title bar for moving the terminals pane (with the PowerShell Extension Terminal) around."
+        },
+        "powershell.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the PowerShell Editor Services language server. **This setting is only meant for extension developers!**"
         }
       }
     },

--- a/src/session.ts
+++ b/src/session.ts
@@ -644,7 +644,7 @@ export class SessionManager implements Middleware {
             middleware: this,
         };
 
-        const languageClient = new LanguageClient("PowerShell Editor Services", connectFunc, clientOptions);
+        const languageClient = new LanguageClient("powershell", "PowerShell Editor Services Client", connectFunc, clientOptions);
 
         // This enables handling Semantic Highlighting messages in PowerShell Editor Services
         // TODO: We should only turn this on in preview.


### PR DESCRIPTION
## PR Summary

Enables the native vscode-languageclient tracing option that allows all LSP activity to be viewed from the client in an output window.

Reference: https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#logging-support-for-language-server

![image](https://github.com/PowerShell/vscode-powershell/assets/15258962/55bc22cb-73f5-4bd7-89c3-7f23459a78e0)




## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
