### PR TITLE
Bump the types group with 1 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/semver": "7.5.7",
         "@types/sinon": "17.0.3",
         "@types/ungap__structured-clone": "1.2.0",
-        "@types/uuid": "9.0.7",
+        "@types/uuid": "9.0.8",
         "@types/vscode": "1.82.0",
         "@typescript-eslint/eslint-plugin": "7.0.1",
         "@typescript-eslint/parser": "7.0.1",
@@ -941,10 +941,11 @@
       "dev": true
     },
     "node_modules/@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
-      "dev": true
+      "version": "9.0.8",
+      "resolved": "https://pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha1-dUW6T8PAA9bHVvZR878WPY8PKbo=",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/vscode": {
       "version": "1.82.0",
@@ -5470,9 +5471,9 @@
       "dev": true
     },
     "@types/uuid": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
-      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "version": "9.0.8",
+      "resolved": "https://pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha1-dUW6T8PAA9bHVvZR878WPY8PKbo=",
       "dev": true
     },
     "@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@types/semver": "7.5.7",
     "@types/sinon": "17.0.3",
     "@types/ungap__structured-clone": "1.2.0",
-    "@types/uuid": "9.0.7",
+    "@types/uuid": "9.0.8",
     "@types/vscode": "1.82.0",
     "@typescript-eslint/eslint-plugin": "7.0.1",
     "@typescript-eslint/parser": "7.0.1",


### PR DESCRIPTION
Bumps the types group with 1 update: [@types/uuid](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/HEAD/types/uuid).


Updates `@types/uuid` from 9.0.7 to 9.0.8
- [Release notes](https://github.com/DefinitelyTyped/DefinitelyTyped/releases)
- [Commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/uuid)

---
updated-dependencies:
- dependency-name: "@types/uuid" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: types ...

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
- [ ] Summarized changes
- [ ] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
