### PR TITLE
Update Azure NPM secret names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ registries:
     type: npm-registry
     url: https://pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/
     username: powershell-rel
-    password: ${{ secrets.AZURE_NPM_TOKEN }}
+    password: ${{ secrets.AZURE_NPM_PASSWORD }}
 updates:
 - package-ecosystem: npm
   directory: "/"

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -66,7 +66,7 @@ jobs:
         shell: pwsh
         run: Invoke-Build
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.AZURE_NPM_TOKEN }}
+          NPM_PASSWORD: ${{ secrets.AZURE_NPM_PASSWORD_BASE64}}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/npmrc
+++ b/.github/workflows/npmrc
@@ -1,12 +1,12 @@
-; This requires NPM_AUTH_TOKEN to be available as a base64 encoded secret, since
+; This requires NPM_PASSWORD to be available as a base64 encoded secret, since
 ; Azure DevOps does not support actual auth tokens.
 
 ; begin auth token
 //pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/:username=powershell-rel
-//pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/:_password=${NPM_AUTH_TOKEN}
+//pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/:_password=${NPM_PASSWORD}
 //pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/:email=powershell-rel
 //pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/:username=powershell-rel
-//pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/:_password=${NPM_AUTH_TOKEN}
+//pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/:_password=${NPM_PASSWORD}
 //pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/:email=powershell-rel
 ; end auth token
 registry=https://pkgs.dev.azure.com/powershell-rel/PowerShellEditorServices/_packaging/PSESFeed/npm/registry/


### PR DESCRIPTION
Turns out Dependabot-triggered Actions use Dependabot secrets, not Actions secrets. In the Action, the password must be base64 encoded, but in the Dependabot configuration it must not, so we need three secrets:

* GitHub Action secret: base64 encoded password
* Dependabot secret: base64 encoded password
* Dependabot secret: plain text password

There's no reasonable way to base64 encode the secret on-the-fly.

See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions