### PR TITLE
Fix how we pass the log directory to Editor Services

### DIFF
--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -122,8 +122,6 @@ export const DebugConfigurations: Record<DebugConfig, DebugConfiguration> = {
 
 export class DebugSessionFeature extends LanguageClientConsumer
     implements DebugConfigurationProvider, DebugAdapterDescriptorFactory {
-
-    private sessionCount = 1;
     private tempDebugProcess: PowerShellProcess | undefined;
     private tempSessionDetails: IEditorServicesSessionDetails | undefined;
     private commands: Disposable[] = [];
@@ -392,8 +390,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
         this.tempDebugProcess = await this.sessionManager.createDebugSessionProcess(settings);
         // TODO: Maybe set a timeout on the cancellation token?
         const cancellationTokenSource = new CancellationTokenSource();
-        this.tempSessionDetails = await this.tempDebugProcess.start(
-            `DebugSession-${this.sessionCount++}`, cancellationTokenSource.token);
+        this.tempSessionDetails = await this.tempDebugProcess.start(cancellationTokenSource.token);
 
         // NOTE: Dotnet attach debugging is only currently supported if a temporary debug terminal is used, otherwise we get lots of lock conflicts from loading the assemblies.
         if (session.configuration.attachDotnetDebugger) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -19,7 +19,7 @@ export enum LogLevel {
  *  This will allow for easy mocking of the logger during unit tests.
  */
 export interface ILogger {
-    getLogFilePath(baseName: string): vscode.Uri;
+    logDirectoryPath: vscode.Uri;
     updateLogLevel(logLevelName: string): void;
     write(message: string, ...additionalMessages: string[]): void;
     writeAndShowInformation(message: string, ...additionalMessages: string[]): Promise<void>;
@@ -35,12 +35,11 @@ export interface ILogger {
 }
 
 export class Logger implements ILogger {
-    public logDirectoryPath: vscode.Uri;
-
+    public logDirectoryPath: vscode.Uri; // The folder for all the logs
     private logLevel: LogLevel;
     private commands: vscode.Disposable[];
     private logChannel: vscode.OutputChannel;
-    private logFilePath: vscode.Uri;
+    private logFilePath: vscode.Uri; // The client's logs
     private logDirectoryCreated = false;
     private writingLog = false;
 
@@ -53,7 +52,7 @@ export class Logger implements ILogger {
             globalStorageUri.with({ scheme: "file" }),
             "logs",
             `${Math.floor(Date.now() / 1000)}-${vscode.env.sessionId}`);
-        this.logFilePath = this.getLogFilePath("vscode-powershell");
+        this.logFilePath = vscode.Uri.joinPath(this.logDirectoryPath, "vscode-powershell.log");
 
         // Early logging of the log paths for debugging.
         if (LogLevel.Diagnostic >= this.logLevel) {
@@ -77,10 +76,6 @@ export class Logger implements ILogger {
         for (const command of this.commands) {
             command.dispose();
         }
-    }
-
-    public getLogFilePath(baseName: string): vscode.Uri {
-        return vscode.Uri.joinPath(this.logDirectoryPath, `${baseName}.log`);
     }
 
     private writeAtLevel(logLevel: LogLevel, message: string, ...additionalMessages: string[]): void {

--- a/src/process.ts
+++ b/src/process.ts
@@ -35,9 +35,7 @@ export class PowerShellProcess {
         this.onExited = this.onExitedEmitter.event;
     }
 
-    public async start(logFileName: string, cancellationToken: vscode.CancellationToken): Promise<IEditorServicesSessionDetails | undefined> {
-        const editorServicesLogPath = this.logger.getLogFilePath(logFileName);
-
+    public async start(cancellationToken: vscode.CancellationToken): Promise<IEditorServicesSessionDetails | undefined> {
         const psesModulePath =
             path.resolve(
                 __dirname,
@@ -50,7 +48,7 @@ export class PowerShellProcess {
                 : "";
 
         this.startPsesArgs +=
-            `-LogPath '${utils.escapeSingleQuotes(editorServicesLogPath.fsPath)}' ` +
+            `-LogPath '${utils.escapeSingleQuotes(this.logger.logDirectoryPath.fsPath)}' ` +
             `-SessionDetailsPath '${utils.escapeSingleQuotes(this.sessionFilePath.fsPath)}' ` +
             `-FeatureFlags @(${featureFlags}) `;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -540,7 +540,7 @@ export class SessionManager implements Middleware {
                 }
             });
 
-        this.sessionDetails = await languageServerProcess.start("EditorServices", cancellationToken);
+        this.sessionDetails = await languageServerProcess.start(cancellationToken);
 
         return languageServerProcess;
     }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -15,9 +15,7 @@ const packageJSON: any = require(path.resolve(rootPath, "package.json"));
 export const extensionId = `${packageJSON.publisher}.${packageJSON.name}`;
 
 export class TestLogger implements ILogger {
-    getLogFilePath(_baseName: string): vscode.Uri {
-        return vscode.Uri.file("");
-    }
+    logDirectoryPath: vscode.Uri = vscode.Uri.file("");
     updateLogLevel(_logLevelName: string): void {
         return;
     }


### PR DESCRIPTION
Requires the related changes to Editor Services, and now our log files make sense, hooray!

Requires https://github.com/PowerShell/PowerShellEditorServices/pull/2129.