### PR TITLE
Don't make the Command Explorer visible by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -611,7 +611,7 @@
       "properties": {
         "powershell.sideBar.CommandExplorerVisibility": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "markdownDescription": "Specifies the visibility of the Command Explorer in the side bar."
         },
         "powershell.sideBar.CommandExplorerExcludeFilter": {

--- a/src/features/ISECompatibility.ts
+++ b/src/features/ISECompatibility.ts
@@ -22,7 +22,8 @@ export class ISECompatibilityFeature implements vscode.Disposable {
         { path: "workbench", name: "colorTheme", value: "PowerShell ISE" },
         { path: "editor", name: "wordSeparators", value: "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?" },
         { path: "powershell.buttons", name: "showPanelMovementButtons", value: true },
-        { path: "powershell.codeFolding", name: "showLastLine", value: false }
+        { path: "powershell.codeFolding", name: "showLastLine", value: false },
+        { path: "powershell.sideBar", name: "CommandExplorerVisibility", value: true }
     ];
 
     private commands: vscode.Disposable[] = [];

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -140,7 +140,7 @@ class IntegratedConsoleSettings extends PartialSettings {
 }
 
 class SideBarSettings extends PartialSettings {
-    CommandExplorerVisibility = true;
+    CommandExplorerVisibility = false;
     CommandExplorerExcludeFilter: string[] = [];
 }
 


### PR DESCRIPTION
But turn it on in ISE mode.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4932.