### PR TITLE
Pass the path to `shellIntegration.ps1` directly to the server

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -610,6 +610,11 @@ export class SessionManager implements Middleware {
                 });
         };
 
+        // When Terminal Shell Integration is enabled, we pass the path to the script that the server should execute.
+        // Passing an empty string implies integration is disabled.
+        const shellIntegrationEnabled = vscode.workspace.getConfiguration("terminal.integrated.shellIntegration").get<boolean>("enabled");
+        const shellIntegrationScript = path.join(vscode.env.appRoot, "out", "vs", "workbench", "contrib", "terminal", "browser", "media", "shellIntegration.ps1");
+
         const clientOptions: LanguageClientOptions = {
             documentSelector: this.documentSelector,
             synchronize: {
@@ -622,7 +627,7 @@ export class SessionManager implements Middleware {
             initializationOptions: {
                 enableProfileLoading: this.sessionSettings.enableProfileLoading,
                 initialWorkingDirectory: await validateCwdSetting(this.logger),
-                shellIntegrationEnabled: vscode.workspace.getConfiguration("terminal.integrated.shellIntegration").get<boolean>("enabled"),
+                shellIntegrationScript: shellIntegrationEnabled ? shellIntegrationScript : "",
             },
             errorHandler: {
                 // Override the default error handler to prevent it from


### PR DESCRIPTION
The server can't use `code --locate-shell-integration-path pwsh` because it doesn't know if it's `code` or `code-insiders` etc. Even when given the direct path to the client's host process, it can't reliably use that API either. Mostly this is due to Windows using `Code.cmd` in the background (which is not `Code.exe`, the host process) but it's also slower anyway as it requires another launch of Node.js.

We'll have to rely on the path to the script not changing relative to `vscode.env.appRoot`, but at least that part is a public API.

Required by https://github.com/PowerShell/PowerShellEditorServices/pull/2156.