### PR TITLE
Check if the Terminal Shell Integration setting is changed

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,8 @@ import vscode = require("vscode");
 
 export const PowerShellLanguageId = "powershell";
 
+export const ShellIntegrationScript = path.join(vscode.env.appRoot, "out", "vs", "workbench", "contrib", "terminal", "browser", "media", "shellIntegration.ps1");
+
 export function escapeSingleQuotes(p: string): string {
     return p.replace(new RegExp("'", "g"), "''");
 }

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -5,7 +5,7 @@ import assert from "assert";
 import * as vscode from "vscode";
 import { IPowerShellExtensionClient } from "../../src/features/ExternalApi";
 import utils = require("../utils");
-import { checkIfDirectoryExists } from "../../src/utils";
+import { checkIfDirectoryExists, checkIfFileExists, ShellIntegrationScript } from "../../src/utils";
 
 describe("Path assumptions", function () {
     let globalStorageUri: vscode.Uri;
@@ -20,5 +20,10 @@ describe("Path assumptions", function () {
 
     it("Creates the log folder at the correct path", async function () {
         assert(await checkIfDirectoryExists(vscode.Uri.joinPath(globalStorageUri, "logs")));
+    });
+
+    it("Finds the Terminal Shell Integration Script", async function () {
+        // If VS Code changes the location of the script, we need to know ASAP (as it's not a public API).
+        assert(await checkIfFileExists(ShellIntegrationScript));
     });
 });


### PR DESCRIPTION
Because if it is, we'll need to restart the Extension Terminal (unless it was hidden at startup).
Also add a test to ensure we can find VS Code's script (in case its location changes upstream).