### PR TITLE
Fix server tracing setting to use `markdownDescription`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1009,7 +1009,7 @@
             "verbose"
           ],
           "default": "off",
-          "description": "Traces the communication between VS Code and the PowerShell Editor Services language server. **This setting is only meant for extension developers!**"
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services language server. **This setting is only meant for extension developers!**"
         }
       }
     },


### PR DESCRIPTION
## PR Summary

Changes the `powershell.trace.server` setting's `description` key to instead be `markdownDescription`; judging by the rest of the user settings in package.json, the usage of `description` seems unintentional.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
