### PR TITLE
Fix ghost terminals after using "Developer: Restart Extension Host"

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -14,6 +14,8 @@ export class PowerShellProcess {
     // This is used to warn the user that the extension is taking longer than expected to startup.
     private static warnUserThreshold = 30;
 
+    private static title = "PowerShell Extension";
+
     public onExited: vscode.Event<void>;
     private onExitedEmitter?: vscode.EventEmitter<void>;
 
@@ -25,7 +27,7 @@ export class PowerShellProcess {
     constructor(
         public exePath: string,
         private bundledModulesPath: string,
-        private title: string,
+        private isTemp: boolean,
         private logger: ILogger,
         private startPsesArgs: string,
         private sessionFilePath: vscode.Uri,
@@ -99,7 +101,7 @@ export class PowerShellProcess {
 
         // Launch PowerShell in the integrated terminal
         const terminalOptions: vscode.TerminalOptions = {
-            name: this.title,
+            name: this.isTemp ? `${PowerShellProcess.title} (TEMP)` : PowerShellProcess.title,
             shellPath: this.exePath,
             shellArgs: powerShellArgs,
             cwd: await validateCwdSetting(this.logger),
@@ -125,6 +127,17 @@ export class PowerShellProcess {
         }
 
         return await this.waitForSessionFile(cancellationToken);
+    }
+
+    // This function is used to clean-up stale PowerShell Extension terminals,
+    // which can happen with `restartExtensionHost` is called because we are
+    // unable to finish diposing before we're gone.
+    public static cleanUpTerminals(): void {
+        for (const terminal of vscode.window.terminals) {
+            if (terminal.name.startsWith(PowerShellProcess.title)) {
+                terminal.dispose();
+            }
+        }
     }
 
     // This function should only be used after a failure has occurred because it is slow!

--- a/src/session.ts
+++ b/src/session.ts
@@ -350,7 +350,7 @@ export class SessionManager implements Middleware {
             new PowerShellProcess(
                 this.PowerShellExeDetails.exePath,
                 bundledModulesPath,
-                "[TEMP] PowerShell Extension",
+                true,
                 this.logger,
                 this.getEditorServicesArgs(bundledModulesPath, this.PowerShellExeDetails) + "-DebugServiceOnly ",
                 this.getNewSessionFilePath(),
@@ -528,11 +528,14 @@ export class SessionManager implements Middleware {
         cancellationToken: vscode.CancellationToken): Promise<PowerShellProcess> {
 
         const bundledModulesPath = await this.getBundledModulesPath();
+
+        // Dispose any stale terminals from previous killed sessions.
+        PowerShellProcess.cleanUpTerminals();
         const languageServerProcess =
             new PowerShellProcess(
                 powerShellExeDetails.exePath,
                 bundledModulesPath,
-                "PowerShell Extension",
+                false,
                 this.logger,
                 this.getEditorServicesArgs(bundledModulesPath, powerShellExeDetails),
                 this.getNewSessionFilePath(),


### PR DESCRIPTION
When this features restarts us, we're unable to clean up our terminals because we're gone before we can finish disposing. Therefore we must search for stale terminals and dispose them.

Fixes #4986.

@Tyriar can you confirm there isn't a better way to handle this? For reference: https://github.com/PowerShell/vscode-powershell/issues/4986#issuecomment-2135031563