### PR TITLE
Reorganize build and packages to allow for omitting dev tools

### DIFF
--- a/.pipelines/vscode-powershell-Official.yml
+++ b/.pipelines/vscode-powershell-Official.yml
@@ -27,7 +27,7 @@ parameters:
 variables:
   system.debug: ${{ parameters.debug }}
   BuildConfiguration: Release
-  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+  WindowsContainerImage: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
 
 resources:
   repositories:
@@ -41,6 +41,8 @@ resources:
     trigger:
       branches:
       - main
+      stages:
+      - release
 
 extends:
   # https://aka.ms/obpipelines/templates
@@ -50,6 +52,10 @@ extends:
       asyncSdl:
         enabled: true
         forStages: [build]
+    featureFlags:
+      WindowsHostVersion:
+        Version: 2022
+        Network: Netlock
     stages:
     - stage: build
       jobs:
@@ -75,15 +81,6 @@ extends:
             inputs:
               system: Custom
               customVersion: $(package.version)
-          - task: UseNode@1
-            displayName: Use Node 18.x
-            inputs:
-              version: 18.x
-          - task: PowerShell@2
-            displayName: Install PSResources
-            inputs:
-              pwsh: true
-              filePath: tools/installPSResources.ps1
           - task: DownloadPipelineArtifact@2
             displayName: Download PowerShellEditorServices
             inputs:
@@ -91,14 +88,14 @@ extends:
               project: PowerShellCore
               definition: 2905
               specificBuildWithTriggering: true
-              artifact: drop_release_github
-              itemPattern: PowerShellEditorServices.zip
-          - task: ExtractFiles@1
-            displayName: Extract PowerShellEditorServices module
-            inputs:
-              archiveFilePatterns: $(Pipeline.Workspace)/PowerShellEditorServices.zip
-              destinationFolder: $(Build.SourcesDirectory)/modules
-          - pwsh: Invoke-Build Build -Configuration $(BuildConfiguration)
+              branchName: refs/heads/main
+              artifact: drop_build_main
+              targetPath: $(Build.SourcesDirectory)/modules
+          - pwsh: |
+              Register-PSRepository -Name CFS -SourceLocation "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v2" -InstallationPolicy Trusted
+              Install-Module -Name InvokeBuild -Repository CFS -RequiredVersion 5.11.3 -Verbose
+              Invoke-Build Build -Configuration $(BuildConfiguration)
+            # TODO: When the OneBuild container updates to 7.4, update to PSResourceGet
             displayName: Build
           - task: onebranch.pipeline.signing@1
             displayName: Sign 1st-party example PowerShell files
@@ -141,13 +138,9 @@ extends:
               project: PowerShellCore
               definition: 2905
               specificBuildWithTriggering: true
-              artifact: drop_release_github
-              itemPattern: PowerShellEditorServices.zip
-          - task: ExtractFiles@1
-            displayName: Extract PowerShellEditorServices module
-            inputs:
-              archiveFilePatterns: $(Pipeline.Workspace)/PowerShellEditorServices.zip
-              destinationFolder: $(Build.SourcesDirectory)/modules
+              branchName: refs/heads/main
+              artifact: drop_build_main
+              targetPath: $(Build.SourcesDirectory)/modules
           - pwsh: Invoke-Build Test -Configuration $(BuildConfiguration)
             displayName: Run tests
     - stage: release

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,13 @@
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
+        "@vscode/vsce": "^2.30.0",
+        "esbuild": "^0.21.5"
+      },
+      "engines": {
+        "vscode": "^1.82.0"
+      },
+      "optionalDependencies": {
         "@types/mocha": "^10.0.7",
         "@types/mock-fs": "^4.13.4",
         "@types/node": "~18.15.0",
@@ -33,8 +40,6 @@
         "@ungap/structured-clone": "^1.2.0",
         "@vscode/debugprotocol": "^1.66.0",
         "@vscode/test-electron": "^2.4.1",
-        "@vscode/vsce": "^2.30.0",
-        "esbuild": "^0.21.5",
         "eslint": "^8.57.0",
         "eslint-plugin-header": "^3.1.1",
         "glob": "^10.4.5",
@@ -46,9 +51,6 @@
         "sinon": "^18.0.0",
         "source-map-support": "^0.5.21",
         "typescript": "^5.5.3"
-      },
-      "engines": {
-        "vscode": "^1.82.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -600,7 +602,7 @@
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
       "integrity": "sha1-ojUU6Pua8SadX3eIqlVnmNYca1k=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.3.0"
       },
@@ -614,7 +616,7 @@
     "node_modules/@eslint-community/regexpp": {
       "version": "4.11.0",
       "integrity": "sha1-sP/QMStKP9LW93I35ySKWtOmgK4=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -622,7 +624,7 @@
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
       "integrity": "sha1-OIomnw8lwbatwxe1osVXFIlMcK0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -644,7 +646,7 @@
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -653,7 +655,7 @@
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.2",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -664,7 +666,7 @@
     "node_modules/@eslint/js": {
       "version": "8.57.0",
       "integrity": "sha1-pUF66EJ4c/HdCLcLNXS0U+Z7X38=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
@@ -672,7 +674,7 @@
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "integrity": "sha1-145IGgOfdWbsyWYLTqf+ax/sRCs=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.2",
         "debug": "^4.3.1",
@@ -685,7 +687,7 @@
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -694,7 +696,7 @@
     "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
       "version": "3.1.2",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -705,7 +707,7 @@
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "integrity": "sha1-r1smkaIrRL6EewyoFkHF+2rQFyw=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12.22"
       },
@@ -717,12 +719,12 @@
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
       "integrity": "sha1-Siho111taWPkI7z5C3/RvjQ0CdM=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -738,7 +740,7 @@
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.0.1",
       "integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -749,7 +751,7 @@
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
       "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -867,7 +869,7 @@
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "integrity": "sha1-dhnC6yGyVIP20WdUi0z9WnSIw9U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -879,7 +881,7 @@
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
       "integrity": "sha1-W9Jir5Tp0lvR5xsF3u1Eh2oiLos=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -887,7 +889,7 @@
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
       "integrity": "sha1-6Vc36LtnRt3t9pxVaVNJTxlv5po=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -899,7 +901,6 @@
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "integrity": "sha1-p36nQvqyV3UUVDTrHSMoz1ATrDM=",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -908,7 +909,7 @@
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "integrity": "sha1-ECk1fkTKkBphVYX20nc428iQhM0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -916,7 +917,7 @@
     "node_modules/@sinonjs/fake-timers": {
       "version": "11.2.2",
       "integrity": "sha1-UAY8w1dPSie9hFMYCgQXHIXMlpk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
@@ -924,7 +925,7 @@
     "node_modules/@sinonjs/samsam": {
       "version": "8.0.0",
       "integrity": "sha1-DUiMke+z+hRC4mq+qBdZ38i1rGA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0",
         "lodash.get": "^4.4.2",
@@ -934,7 +935,7 @@
     "node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
       "version": "2.0.0",
       "integrity": "sha1-/UylsGNVQwfoMntFZL1W07c5JKM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -942,17 +943,17 @@
     "node_modules/@sinonjs/text-encoding": {
       "version": "0.7.2",
       "integrity": "sha1-WYGo2xi1a6OO8O+32ZWxKqe1GRg=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/mocha": {
       "version": "10.0.7",
       "integrity": "sha1-TGIAkPKMp/kFqUtwb3TcW1e0Ty8=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.4",
       "integrity": "sha1-5z7bS0iJ1E0j8eoC1u6+UKowsJo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -960,12 +961,12 @@
     "node_modules/@types/node": {
       "version": "18.15.13",
       "integrity": "sha1-9kJ3w0EVDJeeQrAOSsKJKQyd9Gk=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
       "integrity": "sha1-mzm3hmXa4OgqCPAvSWfWLGb5XSQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -974,17 +975,17 @@
     "node_modules/@types/rewire": {
       "version": "2.5.30",
       "integrity": "sha1-da8QbSlOyIriEij+/jqlee/sJ24=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
       "integrity": "sha1-gmioxXo+Sr0lwWXs02I323lIpV4=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/sinon": {
       "version": "17.0.3",
       "integrity": "sha1-mqfmLwoyO56tF37SOjbqdXFBpfo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
       }
@@ -992,27 +993,27 @@
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
       "integrity": "sha1-X9NZL/EMHpaV03cCDAMxFswoifI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/ungap__structured-clone": {
       "version": "1.2.0",
       "integrity": "sha1-Ern9SrPmqCKS1gBISSsF63W0pI8=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "integrity": "sha1-dUW6T8PAA9bHVvZR878WPY8PKbo=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/vscode": {
       "version": "1.82.0",
       "integrity": "sha1-ibCyEXnc9ejO4WZKmgXF9sYNONA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.16.0",
       "integrity": "sha1-s1Y5JzQeyhUSShjG+UIV93n1wCo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "7.16.0",
@@ -1044,7 +1045,7 @@
     "node_modules/@typescript-eslint/parser": {
       "version": "7.16.0",
       "integrity": "sha1-U/roES+MkSAkrqe0mc9zdEh69tg=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.16.0",
         "@typescript-eslint/types": "7.16.0",
@@ -1071,7 +1072,7 @@
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "7.16.0",
       "integrity": "sha1-6wdXr1cgycU8gBDXoDVa4n4Xt+U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "7.16.0",
         "@typescript-eslint/visitor-keys": "7.16.0"
@@ -1087,7 +1088,7 @@
     "node_modules/@typescript-eslint/type-utils": {
       "version": "7.16.0",
       "integrity": "sha1-7FKxkyuPtEoVo+ICCOC9SdC2vQA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/typescript-estree": "7.16.0",
         "@typescript-eslint/utils": "7.16.0",
@@ -1113,7 +1114,7 @@
     "node_modules/@typescript-eslint/types": {
       "version": "7.16.0",
       "integrity": "sha1-YKGdfnprHKosBvrIYIKdFioDbtI=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "^18.18.0 || >=20.0.0"
       },
@@ -1125,7 +1126,7 @@
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "7.16.0",
       "integrity": "sha1-mKx3nVJvqyp4HlYZySUPPjOGfAk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "7.16.0",
         "@typescript-eslint/visitor-keys": "7.16.0",
@@ -1152,7 +1153,7 @@
     "node_modules/@typescript-eslint/utils": {
       "version": "7.16.0",
       "integrity": "sha1-s43Azhd46BguInyY2R00GESaoX8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@typescript-eslint/scope-manager": "7.16.0",
@@ -1173,7 +1174,7 @@
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "7.16.0",
       "integrity": "sha1-odmfp6N4eWLW4O/UNlde+EDiOwY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/types": "7.16.0",
         "eslint-visitor-keys": "^3.4.3"
@@ -1189,12 +1190,12 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "integrity": "sha1-dWZBrbWHhRtcyz4JXa8nrlgchAY=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@vscode/debugprotocol": {
       "version": "1.66.0",
       "integrity": "sha1-4xHudpYFPn17DTDhOElojCI58qg=",
-      "dev": true
+      "optional": true
     },
     "node_modules/@vscode/extension-telemetry": {
       "version": "0.9.6",
@@ -1211,7 +1212,7 @@
     "node_modules/@vscode/test-electron": {
       "version": "2.4.1",
       "integrity": "sha1-XCdgZAv2ku+9qhi6/NNftRloiUE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.5",
@@ -1430,7 +1431,7 @@
     "node_modules/acorn": {
       "version": "8.12.1",
       "integrity": "sha1-cWFr3MviXielRDngBG6JynbfIkg=",
-      "dev": true,
+      "optional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1441,7 +1442,7 @@
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "integrity": "sha1-ftW7VZCLOy8bxVxq8WU7rafweTc=",
-      "dev": true,
+      "optional": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -1449,7 +1450,7 @@
     "node_modules/agent-base": {
       "version": "7.1.1",
       "integrity": "sha1-vb3tffsJa3UaKgh+7rlmRyWy4xc=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -1460,7 +1461,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1475,7 +1476,7 @@
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "integrity": "sha1-N2ETQOsiQ+cMxgTK011jJw1IeBs=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1483,7 +1484,7 @@
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1502,7 +1503,7 @@
     "node_modules/anymatch": {
       "version": "3.1.3",
       "integrity": "sha1-eQxYsZuhcgqEIFtXxhjVrYUklz4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -1514,12 +1515,12 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
       "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1527,7 +1528,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/azure-devops-node-api": {
       "version": "12.5.0",
@@ -1545,7 +1546,6 @@
     "node_modules/base64-js": {
       "version": "1.5.1",
       "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1559,12 +1559,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "integrity": "sha1-9uFKl4WNMnJSIAJC1Mz+UixEVSI=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -1575,7 +1576,7 @@
     "node_modules/bl": {
       "version": "5.1.0",
       "integrity": "sha1-GDcV9njHGI7O+f5HXZAglABiQnM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -1585,7 +1586,7 @@
     "node_modules/bl/node_modules/readable-stream": {
       "version": "3.6.2",
       "integrity": "sha1-VqmzbqllwAxak+8x6xEaDxEFaWc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1610,7 +1611,7 @@
     "node_modules/braces": {
       "version": "3.0.3",
       "integrity": "sha1-SQMy9AkZRSJy1VqEgK3AxEE1h4k=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -1621,12 +1622,11 @@
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/buffer": {
       "version": "6.0.3",
       "integrity": "sha1-Ks5XhFnMj74qcKqo9S7mO2p0xsY=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1641,6 +1641,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -1662,7 +1663,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
-      "dev": true
+      "optional": true
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -1685,7 +1686,7 @@
     "node_modules/callsites": {
       "version": "3.1.0",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1693,7 +1694,7 @@
     "node_modules/camelcase": {
       "version": "6.3.0",
       "integrity": "sha1-VoW5XrIJrJwMF3Rnd4ychN9Yupo=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1753,7 +1754,7 @@
     "node_modules/chokidar": {
       "version": "3.6.0",
       "integrity": "sha1-GXxsxmnvKo3F57TZfuTgksPrDVs=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1776,7 +1777,7 @@
     "node_modules/chokidar/node_modules/glob-parent": {
       "version": "5.1.2",
       "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1793,7 +1794,7 @@
     "node_modules/cli-cursor": {
       "version": "4.0.0",
       "integrity": "sha1-POz+NzS/T+Aqg2HL3A9v4oxqV+o=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -1807,7 +1808,7 @@
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "integrity": "sha1-F3Oo9LnE1qwxVj31Oz/B15Ri/kE=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       },
@@ -1818,7 +1819,7 @@
     "node_modules/cliui": {
       "version": "7.0.4",
       "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1828,7 +1829,7 @@
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "4.3.0",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1842,7 +1843,7 @@
     "node_modules/cliui/node_modules/color-convert": {
       "version": "2.0.1",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1853,17 +1854,17 @@
     "node_modules/cliui/node_modules/color-name": {
       "version": "1.1.4",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1876,7 +1877,7 @@
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1913,7 +1914,7 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1932,17 +1933,17 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
-      "dev": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1981,7 +1982,7 @@
     "node_modules/debug": {
       "version": "4.3.5",
       "integrity": "sha1-6DRE7Ouf7dSh2lbWca4kRqAabh4=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1997,7 +1998,7 @@
     "node_modules/decamelize": {
       "version": "4.0.0",
       "integrity": "sha1-qkcte/Zg6xXzSU79UxyrfypwmDc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -2032,7 +2033,7 @@
     "node_modules/deep-is": {
       "version": "0.1.4",
       "integrity": "sha1-pvLc5hL63S7x9Rm3NVHxfoUZmDE=",
-      "dev": true
+      "optional": true
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -2061,7 +2062,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2078,7 +2079,7 @@
     "node_modules/diff": {
       "version": "5.2.0",
       "integrity": "sha1-Jt7QR80RebeLlTfV73JVA84a5TE=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -2086,7 +2087,7 @@
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -2097,7 +2098,7 @@
     "node_modules/doctrine": {
       "version": "3.0.0",
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -2159,7 +2160,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
-      "dev": true
+      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -2172,7 +2173,7 @@
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2253,7 +2254,7 @@
     "node_modules/escalade": {
       "version": "3.1.2",
       "integrity": "sha1-VAdumrKepb89jx7WKs/7uIJy3yc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -2269,7 +2270,7 @@
     "node_modules/eslint": {
       "version": "8.57.0",
       "integrity": "sha1-x4am/Q4LaJQar2JFlvuYcIkZVmg=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2323,7 +2324,7 @@
     "node_modules/eslint-plugin-header": {
       "version": "3.1.1",
       "integrity": "sha1-bOUSQy1XZ1Jl+sRykrUNHv8RrNY=",
-      "dev": true,
+      "optional": true,
       "peerDependencies": {
         "eslint": ">=7.7.0"
       }
@@ -2331,7 +2332,7 @@
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "integrity": "sha1-3rT5JWM5DzIAaJSvYqItuhxGQj8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -2346,7 +2347,7 @@
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "integrity": "sha1-DNcv6FUOPC6uFWqWpN3c0cisWAA=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2357,7 +2358,7 @@
     "node_modules/eslint/node_modules/ansi-styles": {
       "version": "4.3.0",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2371,7 +2372,7 @@
     "node_modules/eslint/node_modules/brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2380,7 +2381,7 @@
     "node_modules/eslint/node_modules/chalk": {
       "version": "4.1.2",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2395,7 +2396,7 @@
     "node_modules/eslint/node_modules/color-convert": {
       "version": "2.0.1",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2406,12 +2407,12 @@
     "node_modules/eslint/node_modules/color-name": {
       "version": "1.1.4",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -2422,7 +2423,7 @@
     "node_modules/eslint/node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2430,7 +2431,7 @@
     "node_modules/eslint/node_modules/minimatch": {
       "version": "3.1.2",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2441,7 +2442,7 @@
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2452,7 +2453,7 @@
     "node_modules/espree": {
       "version": "9.6.1",
       "integrity": "sha1-oqF7jkNGkKVDLy+AGM5x0zGkjG8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -2468,7 +2469,7 @@
     "node_modules/esquery": {
       "version": "1.6.0",
       "integrity": "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -2479,7 +2480,7 @@
     "node_modules/esrecurse": {
       "version": "4.3.0",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -2490,7 +2491,7 @@
     "node_modules/estraverse": {
       "version": "5.3.0",
       "integrity": "sha1-LupSkHAvJquP5TcDcP+GyWXSESM=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2498,7 +2499,7 @@
     "node_modules/esutils": {
       "version": "2.0.3",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2523,12 +2524,12 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
-      "dev": true
+      "optional": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "integrity": "sha1-qQRQHlfP3S/83tRemaVP71XkYSk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2543,7 +2544,7 @@
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
       "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2554,17 +2555,17 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
-      "dev": true
+      "optional": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/fastq": {
       "version": "1.17.1",
       "integrity": "sha1-KlI/B6TnsegaQrkbi/IlQQd1O0c=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2580,7 +2581,7 @@
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "integrity": "sha1-IRst2WWcsDlLBz5zI6w8kz1SICc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -2591,7 +2592,7 @@
     "node_modules/fill-range": {
       "version": "7.1.1",
       "integrity": "sha1-RCZdPKwH4+p9wkdRY4BkN1SgUpI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2602,7 +2603,7 @@
     "node_modules/find-up": {
       "version": "5.0.0",
       "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2617,7 +2618,7 @@
     "node_modules/flat": {
       "version": "5.0.2",
       "integrity": "sha1-jKb+MyBp/6nTJMMnGYxZglnOskE=",
-      "dev": true,
+      "optional": true,
       "bin": {
         "flat": "cli.js"
       }
@@ -2625,7 +2626,7 @@
     "node_modules/flat-cache": {
       "version": "3.2.0",
       "integrity": "sha1-LAwtUEDJmxYydxqdEFclwBFTY+4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -2638,12 +2639,12 @@
     "node_modules/flatted": {
       "version": "3.3.1",
       "integrity": "sha1-IdtHBymmc01JlwAvQ5yzCJh/Vno=",
-      "dev": true
+      "optional": true
     },
     "node_modules/foreground-child": {
       "version": "3.2.1",
       "integrity": "sha1-dnAEzPOlsw3zm+2QcYurQ/4KWfc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -2658,7 +2659,7 @@
     "node_modules/form-data": {
       "version": "4.0.0",
       "integrity": "sha1-k5Gdrq82HuUpWEubMWZNwSyfpFI=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2677,12 +2678,11 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "integrity": "sha1-ysZAd4XQNnWipeGlMFxpezR9kNY=",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2703,7 +2703,7 @@
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -2735,7 +2735,7 @@
     "node_modules/glob": {
       "version": "10.4.5",
       "integrity": "sha1-9NnwuQ/9urCcnXf18ptCYlF7CVY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -2754,7 +2754,7 @@
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "integrity": "sha1-bSN9mQg5UMeSkPJMdkKj3poo+eM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -2765,7 +2765,7 @@
     "node_modules/globals": {
       "version": "13.24.0",
       "integrity": "sha1-hDKhnXjODB6DOUnDats0VAC7EXE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2779,7 +2779,7 @@
     "node_modules/globby": {
       "version": "11.1.0",
       "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -2809,7 +2809,7 @@
     "node_modules/graphemer": {
       "version": "1.4.0",
       "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
-      "dev": true
+      "optional": true
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -2866,7 +2866,7 @@
     "node_modules/he": {
       "version": "1.2.0",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
-      "dev": true,
+      "optional": true,
       "bin": {
         "he": "bin/he"
       }
@@ -2903,7 +2903,7 @@
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -2915,7 +2915,7 @@
     "node_modules/https-proxy-agent": {
       "version": "7.0.5",
       "integrity": "sha1-notQE4cymeEfq2/VSEBdotbGArI=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -2927,7 +2927,6 @@
     "node_modules/ieee754": {
       "version": "1.2.1",
       "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2941,12 +2940,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.1",
       "integrity": "sha1-UHPlVM1CxbM7OUN19Ti4WT401O8=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2954,12 +2954,12 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "optional": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "integrity": "sha1-NxYsJfy566oublPVtNiM4X2eDCs=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2974,7 +2974,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -2982,7 +2982,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2991,7 +2991,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -3002,7 +3002,7 @@
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -3027,7 +3027,7 @@
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3035,7 +3035,7 @@
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3043,7 +3043,7 @@
     "node_modules/is-glob": {
       "version": "4.0.3",
       "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3054,7 +3054,7 @@
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "integrity": "sha1-QMV2FFk4JtoRAK3mBZd41ZfxbpA=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -3065,7 +3065,7 @@
     "node_modules/is-number": {
       "version": "7.0.0",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3073,7 +3073,7 @@
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "integrity": "sha1-0jE2LlOgf/Kw4Op/7QSRYf/RYoM=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3081,7 +3081,7 @@
     "node_modules/is-plain-obj": {
       "version": "2.1.0",
       "integrity": "sha1-ReQuN/zPH0Dajl927iFRWEDAkoc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3089,7 +3089,7 @@
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "integrity": "sha1-PybHaoCVk7Ur+i7LVxDtJ3m1Iqc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -3111,17 +3111,17 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "optional": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "integrity": "sha1-iDOp2Jq0rN5hiJQr0cU7Y5DtWoo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -3135,7 +3135,7 @@
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3146,17 +3146,17 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "integrity": "sha1-kziAKjDTtmBfvgYT4JQAjKjAWhM=",
-      "dev": true
+      "optional": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
+      "optional": true
     },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
@@ -3206,7 +3206,7 @@
     "node_modules/jszip": {
       "version": "3.10.1",
       "integrity": "sha1-NK7nDrGOofrsL1iSCKFX0f6wkcI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -3217,7 +3217,7 @@
     "node_modules/just-extend": {
       "version": "6.2.0",
       "integrity": "sha1-uBar+z1n7oYEgudAFWRnJVgWOUc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/jwa": {
       "version": "2.0.0",
@@ -3252,7 +3252,7 @@
     "node_modules/keyv": {
       "version": "4.5.4",
       "integrity": "sha1-qHmpnilFL5QkOfKkBeOvizHU3pM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3268,7 +3268,7 @@
     "node_modules/levn": {
       "version": "0.4.1",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3280,7 +3280,7 @@
     "node_modules/lie": {
       "version": "3.3.0",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -3296,7 +3296,7 @@
     "node_modules/locate-path": {
       "version": "6.0.0",
       "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -3310,12 +3310,12 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-      "dev": true
+      "optional": true
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "optional": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -3350,7 +3350,7 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "integrity": "sha1-VYqlO0O2YeGSWgr9+japoQhf5Xo=",
-      "dev": true
+      "optional": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -3360,7 +3360,7 @@
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "integrity": "sha1-P727lbRoOsn8eFER55LlWNSr1QM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "is-unicode-supported": "^0.1.0"
@@ -3375,7 +3375,7 @@
     "node_modules/log-symbols/node_modules/ansi-styles": {
       "version": "4.3.0",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3389,7 +3389,7 @@
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
       "integrity": "sha1-qsTit3NKdAhnrrFr8CqtVWoeegE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3404,7 +3404,7 @@
     "node_modules/log-symbols/node_modules/color-convert": {
       "version": "2.0.1",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3415,12 +3415,12 @@
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3428,7 +3428,7 @@
     "node_modules/log-symbols/node_modules/supports-color": {
       "version": "7.2.0",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3478,7 +3478,7 @@
     "node_modules/merge2": {
       "version": "1.4.1",
       "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3486,7 +3486,7 @@
     "node_modules/micromatch": {
       "version": "4.0.7",
       "integrity": "sha1-M+gZDZ/kdKmJVSX1YY7uE21GwuU=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -3509,7 +3509,7 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3517,7 +3517,7 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3528,7 +3528,7 @@
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -3548,7 +3548,7 @@
     "node_modules/minimatch": {
       "version": "9.0.5",
       "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3571,7 +3571,7 @@
     "node_modules/minipass": {
       "version": "7.1.2",
       "integrity": "sha1-k6libOXl5mvU24aEnnUV6SNApwc=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3585,7 +3585,7 @@
     "node_modules/mocha": {
       "version": "10.6.0",
       "integrity": "sha1-Rl/GbFJhMIjhABiYmjuY1eEZVLk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
@@ -3619,7 +3619,7 @@
     "node_modules/mocha-explorer-launcher-scripts": {
       "version": "0.4.0",
       "integrity": "sha1-kVauKTxShWU3XHnD+5O2tbEIgSY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "vscode-test-adapter-remoting-util": "^0.13.0"
       }
@@ -3627,7 +3627,7 @@
     "node_modules/mocha-multi-reporters": {
       "version": "1.5.1",
       "integrity": "sha1-xzSGvtVRnh1Zyc45rHqXkmAOVnY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "lodash": "^4.17.15"
@@ -3642,7 +3642,7 @@
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -3653,7 +3653,7 @@
     "node_modules/mocha/node_modules/glob": {
       "version": "8.1.0",
       "integrity": "sha1-04j2Vlk+9wjuPjRkD9+5mp/Rwz4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3671,7 +3671,7 @@
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3679,7 +3679,7 @@
     "node_modules/mocha/node_modules/minimatch": {
       "version": "5.1.6",
       "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3690,12 +3690,12 @@
     "node_modules/mocha/node_modules/ms": {
       "version": "2.1.3",
       "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/mocha/node_modules/supports-color": {
       "version": "8.1.1",
       "integrity": "sha1-zW/BfihQDP9WwbhsCn/UpUpzAFw=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3709,7 +3709,7 @@
     "node_modules/mock-fs": {
       "version": "5.2.0",
       "integrity": "sha1-NQKpSZyEwKEhjuS/kq5b8uqbK14=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3717,7 +3717,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -3733,12 +3733,12 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/nise": {
       "version": "6.0.0",
       "integrity": "sha1-rlb8y12RIDc2PDs/Keu/oovei0g=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.0",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -3786,7 +3786,7 @@
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3816,7 +3816,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3824,7 +3824,7 @@
     "node_modules/onetime": {
       "version": "5.1.2",
       "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -3854,7 +3854,7 @@
     "node_modules/optionator": {
       "version": "0.9.4",
       "integrity": "sha1-fqHBpdkddk+yghOciP4R4YKjpzQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -3870,7 +3870,7 @@
     "node_modules/ora": {
       "version": "7.0.1",
       "integrity": "sha1-zdUw7Nhl/jnkUaDnaXhlZpyxGTA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^4.0.0",
@@ -3892,7 +3892,7 @@
     "node_modules/ora/node_modules/ansi-regex": {
       "version": "6.0.1",
       "integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -3903,7 +3903,7 @@
     "node_modules/ora/node_modules/chalk": {
       "version": "5.3.0",
       "integrity": "sha1-Z8IKfr73Dn85cKAfkPohDLaGA4U=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3914,12 +3914,12 @@
     "node_modules/ora/node_modules/emoji-regex": {
       "version": "10.3.0",
       "integrity": "sha1-dpmLkmhAnrPa496YklTUVucM/iM=",
-      "dev": true
+      "optional": true
     },
     "node_modules/ora/node_modules/is-unicode-supported": {
       "version": "1.3.0",
       "integrity": "sha1-2CSYS2FsKSouGYIH1KYJmDhC9xQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -3930,7 +3930,7 @@
     "node_modules/ora/node_modules/log-symbols": {
       "version": "5.1.0",
       "integrity": "sha1-og47ml9T+sauuOK7IsB88sjxbZM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -3945,7 +3945,7 @@
     "node_modules/ora/node_modules/string-width": {
       "version": "6.1.0",
       "integrity": "sha1-lkiNbtI/mtXYLRNSKvnkxMP9dRg=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^10.2.1",
@@ -3961,7 +3961,7 @@
     "node_modules/ora/node_modules/strip-ansi": {
       "version": "7.1.0",
       "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -3975,7 +3975,7 @@
     "node_modules/p-limit": {
       "version": "3.1.0",
       "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3989,7 +3989,7 @@
     "node_modules/p-locate": {
       "version": "5.0.0",
       "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4003,17 +4003,17 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.0",
       "integrity": "sha1-5QHNMJSyeEletCWNTJ9tWsMBnwA=",
-      "dev": true
+      "optional": true
     },
     "node_modules/pako": {
       "version": "1.0.11",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
-      "dev": true
+      "optional": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4063,7 +4063,7 @@
     "node_modules/path-exists": {
       "version": "4.0.0",
       "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4071,7 +4071,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4079,7 +4079,7 @@
     "node_modules/path-key": {
       "version": "3.1.1",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4087,7 +4087,7 @@
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "integrity": "sha1-eWCmaIiFlKByCxKpEdGnQqufEdI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -4102,17 +4102,17 @@
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
       "integrity": "sha1-QQ/IoXtw5ZgBPfJXwkRrfzOD8Rk=",
-      "dev": true
+      "optional": true
     },
     "node_modules/path-to-regexp": {
       "version": "6.2.2",
       "integrity": "sha1-MkN3qD5QScvsrcVVTWpjqaSGazY=",
-      "dev": true
+      "optional": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
       "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4125,7 +4125,7 @@
     "node_modules/picomatch": {
       "version": "2.3.1",
       "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4162,7 +4162,7 @@
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4170,7 +4170,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "dev": true
+      "optional": true
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -4185,7 +4185,7 @@
     "node_modules/punycode": {
       "version": "2.3.1",
       "integrity": "sha1-AnQi4vrsCyXhVJw+G9gwm5EztuU=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -4207,7 +4207,6 @@
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "integrity": "sha1-SSkii7xyTfrEPg77BYyve2z7YkM=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4221,12 +4220,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -4269,7 +4269,7 @@
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "integrity": "sha1-kRJegEK7obmIf0k0X2J3Anzovps=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -4283,12 +4283,12 @@
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
+      "optional": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -4299,7 +4299,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4307,7 +4307,7 @@
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -4315,7 +4315,7 @@
     "node_modules/restore-cursor": {
       "version": "4.0.0",
       "integrity": "sha1-UZVgpDGJdQlt725gnUQQDtqkzLk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -4330,12 +4330,12 @@
     "node_modules/restore-cursor/node_modules/signal-exit": {
       "version": "3.0.7",
       "integrity": "sha1-qaF2f4r4QVURTqq9c/mSc8j1mtk=",
-      "dev": true
+      "optional": true
     },
     "node_modules/reusify": {
       "version": "1.0.4",
       "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4344,7 +4344,7 @@
     "node_modules/rewire": {
       "version": "7.0.0",
       "integrity": "sha1-QdtUgjcMiHWP/Jpxn3ySp2H6j78=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "eslint": "^8.47.0"
       }
@@ -4352,7 +4352,7 @@
     "node_modules/rimraf": {
       "version": "3.0.2",
       "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4366,7 +4366,7 @@
     "node_modules/rimraf/node_modules/brace-expansion": {
       "version": "1.1.11",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -4375,7 +4375,7 @@
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4394,7 +4394,7 @@
     "node_modules/rimraf/node_modules/minimatch": {
       "version": "3.1.2",
       "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4405,7 +4405,6 @@
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "integrity": "sha1-ZtE2jae9+SHrnZW9GpIp5/IaQ+4=",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4420,6 +4419,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
@@ -4427,7 +4427,7 @@
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4461,7 +4461,7 @@
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "integrity": "sha1-3voeBVyDv21Z6oBdjahiJU62psI=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -4485,12 +4485,12 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "optional": true
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4501,7 +4501,7 @@
     "node_modules/shebang-regex": {
       "version": "3.0.0",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4526,7 +4526,7 @@
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=14"
       },
@@ -4582,7 +4582,7 @@
     "node_modules/sinon": {
       "version": "18.0.0",
       "integrity": "sha1-acopPbw+glkKiw1GyX9j68Hl/AE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@sinonjs/commons": "^3.0.1",
         "@sinonjs/fake-timers": "^11.2.2",
@@ -4599,7 +4599,7 @@
     "node_modules/sinon/node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4607,7 +4607,7 @@
     "node_modules/sinon/node_modules/supports-color": {
       "version": "7.2.0",
       "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4618,7 +4618,7 @@
     "node_modules/slash": {
       "version": "3.0.0",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4626,7 +4626,7 @@
     "node_modules/source-map": {
       "version": "0.6.1",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4634,7 +4634,7 @@
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "integrity": "sha1-BP58f54e0tZiIzwoyys1ufY/bk8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -4643,7 +4643,7 @@
     "node_modules/split": {
       "version": "1.0.1",
       "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "through": "2"
       },
@@ -4654,7 +4654,7 @@
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "integrity": "sha1-IrPkADk6jijr9T+ZWPOIBiLv3iE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "bl": "^5.0.0"
       },
@@ -4677,7 +4677,7 @@
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -4685,12 +4685,12 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
+      "optional": true
     },
     "node_modules/string-width": {
       "version": "5.1.2",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -4707,7 +4707,7 @@
       "name": "string-width",
       "version": "4.2.3",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4720,12 +4720,12 @@
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.0.1",
       "integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -4736,7 +4736,7 @@
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.1.0",
       "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -4750,7 +4750,7 @@
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4762,7 +4762,7 @@
       "name": "strip-ansi",
       "version": "6.0.1",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4773,7 +4773,7 @@
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -4872,12 +4872,12 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
+      "optional": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "optional": true
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -4890,7 +4890,7 @@
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4905,7 +4905,7 @@
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "integrity": "sha1-S0kOJxKfHo5oa0XMSrY3FNxg7qE=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=16"
       },
@@ -4940,7 +4940,7 @@
     "node_modules/type-check": {
       "version": "0.4.0",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -4951,7 +4951,7 @@
     "node_modules/type-detect": {
       "version": "4.0.8",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -4959,7 +4959,7 @@
     "node_modules/type-fest": {
       "version": "0.20.2",
       "integrity": "sha1-G/IH9LKPkVg2ZstfvTJ4hzAc1fQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -4980,7 +4980,7 @@
     "node_modules/typescript": {
       "version": "5.5.3",
       "integrity": "sha1-4bCjw5QZCDigsWjncbCtVqCvD6o=",
-      "dev": true,
+      "optional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5009,7 +5009,7 @@
     "node_modules/uri-js": {
       "version": "4.4.1",
       "integrity": "sha1-mxpSWVIlhZ5V9mnZKPiMbFfyp34=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5022,7 +5022,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "optional": true
     },
     "node_modules/uuid": {
       "version": "9.0.1",
@@ -5079,7 +5079,7 @@
     "node_modules/vscode-test-adapter-api": {
       "version": "1.9.0",
       "integrity": "sha1-D9Ff7Z8mFZZwmWyz349WGJAKAHk=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "vscode": "^1.23.0"
       }
@@ -5087,7 +5087,7 @@
     "node_modules/vscode-test-adapter-remoting-util": {
       "version": "0.13.0",
       "integrity": "sha1-5BNv1y0pK1dul6ZvRLdPkB9PJj8=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "split": "^1.0.1",
         "tslib": "^2.0.0",
@@ -5109,7 +5109,7 @@
     "node_modules/which": {
       "version": "2.0.2",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5123,7 +5123,7 @@
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "integrity": "sha1-0sRcbdT7zmIaZvE2y+Mor9BBCzQ=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5131,12 +5131,12 @@
     "node_modules/workerpool": {
       "version": "6.5.1",
       "integrity": "sha1-Bg9zs50Mr5fG22TaAEzQG0wJlUQ=",
-      "dev": true
+      "optional": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -5153,7 +5153,7 @@
       "name": "wrap-ansi",
       "version": "7.0.0",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5169,7 +5169,7 @@
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -5183,7 +5183,7 @@
     "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
       "version": "2.0.1",
       "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -5194,17 +5194,17 @@
     "node_modules/wrap-ansi-cjs/node_modules/color-name": {
       "version": "1.1.4",
       "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-      "dev": true
+      "optional": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5217,7 +5217,7 @@
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.0.1",
       "integrity": "sha1-MYPjj66aZdfLXlOUXNWJfQJgoGo=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -5228,7 +5228,7 @@
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
       "integrity": "sha1-DmIyDPmcIa//OzASGSVGqsv7BcU=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -5239,7 +5239,7 @@
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
       "integrity": "sha1-1bZWjKaJ2FYTcLBwdoXSJDT6/0U=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -5253,7 +5253,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
@@ -5278,7 +5278,7 @@
     "node_modules/y18n": {
       "version": "5.0.8",
       "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -5291,7 +5291,7 @@
     "node_modules/yargs": {
       "version": "16.2.0",
       "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -5308,7 +5308,7 @@
     "node_modules/yargs-parser": {
       "version": "20.2.9",
       "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -5316,7 +5316,7 @@
     "node_modules/yargs-unparser": {
       "version": "2.0.0",
       "integrity": "sha1-8TH5ImkRrl2a04xDL+gJNmwjJes=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
@@ -5330,12 +5330,12 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "dev": true
+      "optional": true
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5365,7 +5365,7 @@
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
-      "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },

--- a/package.json
+++ b/package.json
@@ -82,6 +82,10 @@
     "vscode-languageserver-protocol": "^3.17.5"
   },
   "devDependencies": {
+    "@vscode/vsce": "^2.30.0",
+    "esbuild": "^0.21.5"
+  },
+  "optionalDependencies": {
     "@types/mocha": "^10.0.7",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "~18.15.0",
@@ -97,8 +101,6 @@
     "@ungap/structured-clone": "^1.2.0",
     "@vscode/debugprotocol": "^1.66.0",
     "@vscode/test-electron": "^2.4.1",
-    "@vscode/vsce": "^2.30.0",
-    "esbuild": "^0.21.5",
     "eslint": "^8.57.0",
     "eslint-plugin-header": "^3.1.1",
     "glob": "^10.4.5",

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Set-PSRepository -Name PSGallery -InstallationPolicy Trusted | Out-Null
-if ($PSVersionTable.PSVersion.Major -lt 6) {
-    throw "The build script requires PowerShell 7!"
+if ($PSVersionTable.PSVersion -lt [Version]"7.4") {
+    throw "The build script requires PowerShell 7.4 or higher!"
 }
 
-# TODO: Switch to Install-PSResource when CI uses PowerShell 7.4
-Install-Module -Name InvokeBuild -Scope CurrentUser
-Install-Module -Name platyPS -Scope CurrentUser
+Register-PSResourceRepository -PSGallery -Trusted -Force
+
+Install-PSResource -Name InvokeBuild -Scope CurrentUser
+Install-PSResource -Name platyPS -Scope CurrentUser

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -17,20 +17,19 @@ function Get-EditorServicesPath {
     }
     # NOTE: The ErrorActionPreference for both Invoke-Build and Azure DevOps
     # scripts is Stop, but we want to continue and return false here.
-    return Resolve-Path "$psesRepoPath/PowerShellEditorServices.build.ps1" -ErrorAction Continue
+    return Resolve-Path "$psesRepoPath/PowerShellEditorServices.build.ps1" -ErrorAction SilentlyContinue
 }
 
 #region Setup tasks
 
-task RestoreNodeModules -If { !(Test-Path ./node_modules) } {
-    Write-Host "`n### Restoring vscode-powershell dependencies`n" -ForegroundColor Green
-    # When in a CI build use the --loglevel=error parameter so that
-    # package install warnings don't cause PowerShell to throw up
-    if ($env:CI -or $env:TF_BUILD) {
-        Invoke-BuildExec { & npm ci --loglevel=error }
-    } else {
-        Invoke-BuildExec { & npm install }
-    }
+task RestoreNode -If { !(Test-Path ./node_modules/esbuild) } {
+    Write-Build DarkGreen "Restoring build dependencies"
+    Invoke-BuildExec { & npm ci --omit=optional }
+}
+
+task RestoreNodeOptional -If { !(Test-Path ./node_modules/eslint) } {
+    Write-Build DarkMagenta "Restoring build, test, and lint dependencies"
+    Invoke-BuildExec { & npm ci --include=optional }
 }
 
 task RestoreEditorServices -If (Get-EditorServicesPath) {
@@ -39,60 +38,59 @@ task RestoreEditorServices -If (Get-EditorServicesPath) {
             # When debugging, we always rebuild PSES and ensure its symlinked so
             # that developers always have the latest local bits.
             if ((Get-Item ./modules -ErrorAction SilentlyContinue).LinkType -ne "SymbolicLink") {
-                Write-Host "`n### Creating symbolic link to PSES" -ForegroundColor Green
+                Write-Build DarkMagenta "Creating symbolic link to PSES"
                 Remove-BuildItem ./modules
                 New-Item -ItemType SymbolicLink -Path ./modules -Target "$(Split-Path (Get-EditorServicesPath))/module"
             }
 
-            Write-Host "`n### Building PSES`n" -ForegroundColor Green
+            Write-Build DarkGreen "Building PSES"
             Invoke-Build Build (Get-EditorServicesPath) -Configuration $Configuration
         }
         "Release" {
             # When releasing, we ensure the bits are not symlinked but copied,
             # and only if they don't already exist.
             if ((Get-Item ./modules -ErrorAction SilentlyContinue).LinkType -eq "SymbolicLink") {
-                Write-Host "`n### Deleting PSES symbolic link" -ForegroundColor Green
+                Write-Build DarkRed "Deleting PSES symbolic link"
                 Remove-BuildItem ./modules
             }
 
             if (!(Test-Path ./modules)) {
                 # We only build if it hasn't been built at all.
                 if (!(Test-Path "$(Split-Path (Get-EditorServicesPath))/module/PowerShellEditorServices/bin")) {
-                    Write-Host "`n### Building PSES`n" -ForegroundColor Green
+                    Write-Build DarkGreen "Building PSES"
                     Invoke-Build Build (Get-EditorServicesPath) -Configuration $Configuration
                 }
 
-                Write-Host "`n### Copying PSES`n" -ForegroundColor Green
+                Write-Build DarkGreen "Copying PSES"
                 Copy-Item -Recurse -Force "$(Split-Path (Get-EditorServicesPath))/module" ./modules
             }
         }
     }
 }
 
-task Restore RestoreEditorServices, RestoreNodeModules
-
 #endregion
 #region Clean tasks
 
 task Clean {
-    Write-Host "`n### Cleaning vscode-powershell`n" -ForegroundColor Green
+    Write-Build DarkMagenta "Cleaning vscode-powershell"
     Remove-BuildItem *.js, *.js.map, ./dist, ./modules, ./node_modules, ./out
 }
 
 task CleanEditorServices -If (Get-EditorServicesPath) {
-    Write-Host "`n### Cleaning PowerShellEditorServices`n" -ForegroundColor Green
+    Write-Build DarkMagenta "Cleaning PowerShellEditorServices"
     Invoke-Build Clean (Get-EditorServicesPath)
 }
 
 #endregion
 #region Build tasks
-
-task Build Restore, {
-    Write-Host "`n### Building vscode-powershell`n" -ForegroundColor Green
-    Assert-Build (Test-Path ./modules/PowerShellEditorServices/bin) "Extension requires PSES"
-
-    Write-Host "`n### Linting TypeScript`n" -ForegroundColor Green
+task Lint RestoreNodeOptional, {
+    Write-Build DarkMagenta "Linting TypeScript"
     Invoke-BuildExec { & npm run lint }
+}
+
+task Build RestoreEditorServices, RestoreNode, {
+    Write-Build DarkGreen "Building vscode-powershell"
+    Assert-Build (Test-Path ./modules/PowerShellEditorServices/bin) "Extension requires PSES"
 
     # TODO: When supported we should use `esbuild` for the tests too. Although
     # we now use `esbuild` to transpile, bundle, and minify the extension, we
@@ -109,15 +107,15 @@ task Build Restore, {
 #endregion
 #region Test tasks
 
-task Test Build, {
-    Write-Host "`n### Running extension tests" -ForegroundColor Green
+task Test Lint, Build, {
+    Write-Build DarkMagenta "Running extension tests"
     Invoke-BuildExec { & npm run test }
     # Reset the state of files modified by tests
     Invoke-BuildExec { git checkout package.json test/TestEnvironment.code-workspace }
 }
 
 task TestEditorServices -If (Get-EditorServicesPath) {
-    Write-Host "`n### Testing PowerShellEditorServices`n" -ForegroundColor Green
+    Write-Build DarkMagenta "Testing PowerShellEditorServices"
     Invoke-Build Test (Get-EditorServicesPath)
 }
 
@@ -126,7 +124,7 @@ task TestEditorServices -If (Get-EditorServicesPath) {
 
 task Package {
     [semver]$version = $((Get-Content -Raw -Path package.json | ConvertFrom-Json).version)
-    Write-Host "`n### Packaging powershell-$version.vsix`n" -ForegroundColor Green
+    Write-Build DarkGreen "Packaging powershell-$version.vsix"
     Remove-BuildItem ./out
     New-Item -ItemType Directory -Force out | Out-Null
 
@@ -136,13 +134,13 @@ task Package {
     # we might have built in Debug configuration, not Release, and still want to
     # package it. So delete the symlink and copy what we just built.
     if ((Get-Item ./modules -ErrorAction SilentlyContinue).LinkType -eq "SymbolicLink") {
-        Write-Host "`n### PSES is a symbolic link, replacing with copy!" -ForegroundColor Green
+        Write-Build DarkRed "PSES is a symbolic link, replacing with copy!"
         Remove-BuildItem ./modules
         Copy-Item -Recurse -Force "$(Split-Path (Get-EditorServicesPath))/module" ./modules
     }
 
     if ($version.Minor % 2 -ne 0) {
-        Write-Host "`n### This is a pre-release!`n" -ForegroundColor Green
+        Write-Build DarkRed "This is a pre-release!"
         Invoke-BuildExec { & npm run package -- --pre-release }
     } else {
         Invoke-BuildExec { & npm run package }
@@ -151,4 +149,4 @@ task Package {
 
 #endregion
 
-task . Build, Test, Package
+task . Test, Package


### PR DESCRIPTION
New requirements in our release pipeline require us to omit the installation of quite a few of our (optional) dev tools, as their post-install tasks reach out to the public NPM registry and so are blocked. By moving everything except `esbuild` and `vsce` to `optionalDependencies` (and reorganzing the build script) we can run the linter and tests outside of the secure container.