### PR TITLE
Fix "Suppress a PSScriptAnalyzer rule on a parameter" snippet

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -505,7 +505,7 @@
     "description": "Suppress a PSScriptAnalyzer rule on a parameter. More: https://docs.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#suppressing-rules",
     "body": [
       "[Diagnostics.CodeAnalysis.SuppressMessageAttribute(<#Category#>'${1:PSUseDeclaredVarsMoreThanAssignments}',",
-      "\t<#ParameterName#>'${0:${TM_SELECTED_TEXT:ParamName}}",
+      "\t<#ParameterName#>'${0:${TM_SELECTED_TEXT:ParamName}}',",
       "\tJustification = '${0:${TM_SELECTED_TEXT:Reason for suppressing}}'",
       ")]"
     ]


### PR DESCRIPTION
fix suppress-message-rule-parameter snippet

## PR Summary

Fix Parameter: Suppress PSScriptAnalyzer Rule, adding the missing closing quote and comma

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
