### PR TITLE
Add setting to use either `.` or `&` when launching script

### DIFF
--- a/package.json
+++ b/package.json
@@ -462,7 +462,7 @@
               "name": "PowerShell Launch Script",
               "type": "PowerShell",
               "request": "launch",
-              "script": "^\"enter path or command to execute e.g.: \\${workspaceFolder}/src/foo.ps1 or Invoke-Pester\"",
+              "script": "^\"Enter path or command to execute, for example, \\${workspaceFolder}/src/foo.ps1 or Invoke-Pester\"",
               "cwd": "^\"\\${cwd}\""
             }
           },
@@ -908,6 +908,20 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Creates a temporary PowerShell Extension Terminal for each debugging session. This is useful for debugging PowerShell classes and binary modules."
+        },
+        "powershell.debugging.executeMode": {
+          "type": "string",
+          "enum": [
+            "DotSource",
+            "Call"
+          ],
+          "default": "DotSource",
+          "markdownEnumDescriptions": [
+            "Use the Dot-Source operator `.` to launch the script, for example, `. 'C:\\Data\\MyScript.ps1'`",
+            "Use the Call operator `&` to launch the script, for example, `& 'C:\\Data\\MyScript.ps1'`"
+          ],
+          "markdownDescription": "Sets the operator used to launch scripts."
+
         },
         "powershell.developer.bundledModulesPath": {
           "type": "string",

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -290,6 +290,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
 
         const settings = getSettings();
         config.createTemporaryIntegratedConsole ??= settings.debugging.createTemporaryIntegratedConsole;
+        config.executeMode ??= settings.debugging.executeMode;
         if (config.request === "attach") {
             resolvedConfig = await this.resolveAttachDebugConfiguration(config);
         } else if (config.request === "launch") {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -76,6 +76,11 @@ export enum StartLocation {
     Panel = "Panel"
 }
 
+export enum ExecuteMode{
+    Call = "Call",
+    DotSource = "DotSource"
+}
+
 export type PowerShellAdditionalExePathSettings = Record<string, string>;
 
 class CodeFormattingSettings extends PartialSettings {
@@ -107,6 +112,7 @@ class ScriptAnalysisSettings extends PartialSettings {
 
 class DebuggingSettings extends PartialSettings {
     createTemporaryIntegratedConsole = false;
+    executeMode = ExecuteMode.DotSource;
 }
 
 class DeveloperSettings extends PartialSettings {


### PR DESCRIPTION
Replaces #5036, thanks @LucasArona. I was trying just to edit your PR and accidentally closed it.