### PR TITLE
Migrate to DeployBox for release stage

### DIFF
--- a/.pipelines/vscode-powershell-Official.yml
+++ b/.pipelines/vscode-powershell-Official.yml
@@ -58,6 +58,8 @@ extends:
       WindowsHostVersion:
         Version: 2022
         Network: KS3
+    release:
+      category: NonAzure
     stages:
     - stage: build
       jobs:
@@ -166,26 +168,30 @@ extends:
       dependsOn: build
       condition: eq(variables['Build.Reason'], 'Manual')
       variables:
+        ob_release_environment: PPE
         version: $[ stageDependencies.build.main.outputs['package.version'] ]
         vsixVersion: $[ stageDependencies.build.main.outputs['package.vsixVersion'] ]
         prerelease: $[ stageDependencies.build.main.outputs['package.prerelease'] ]
-        drop: $(Pipeline.Workspace)/drop_build_main
       jobs:
       - job: github
         displayName: Publish draft to GitHub
         pool:
-          type: windows
-        variables:
-          ob_outputDirectory: $(Build.SourcesDirectory)/out
+          type: release
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: drop_build_main
         steps:
-        - download: current
-          displayName: Download artifacts
         - task: GitHubRelease@1
           displayName: Create GitHub release
           inputs:
             gitHubConnection: GitHub
             repositoryName: PowerShell/vscode-powershell
-            assets: $(drop)/powershell-$(vsixVersion).vsix
+            target: main
+            assets: |
+              $(Pipeline.Workspace)/powershell-$(vsixVersion).vsix
+              $(Pipeline.Workspace)/powershell-$(vsixVersion).manifest
+              $(Pipeline.Workspace)/powershell-$(vsixVersion).signature.p7s
             tagSource: userSpecifiedTag
             tag: v$(version)
             isDraft: true
@@ -196,7 +202,7 @@ extends:
       - job: validation
         displayName: Manual validation
         pool:
-          type: agentless
+          type: server
         timeoutInMinutes: 1440
         steps:
         - task: ManualValidation@0
@@ -209,12 +215,12 @@ extends:
         dependsOn: validation
         displayName: Publish to VS Code Marketplace
         pool:
-          type: windows
-        variables:
-          ob_outputDirectory: $(Build.SourcesDirectory)/out
+          type: release
+        templateContext:
+          inputs:
+          - input: pipelineArtifact
+            artifactName: drop_build_main
         steps:
-        - download: current
-          displayName: Download artifacts
         - task: UseNode@1
           displayName: Use Node 20.x
           inputs:
@@ -231,11 +237,11 @@ extends:
               $publishArgs = @(
                 '--azure-credential'
                 '--packagePath'
-                '$(drop)/powershell-$(vsixVersion).vsix'
+                '$(Pipeline.Workspace)/powershell-$(vsixVersion).vsix'
                 '--manifestPath'
-                '$(drop)/powershell-$(vsixVersion).manifest'
+                '$(Pipeline.Workspace)/powershell-$(vsixVersion).manifest'
                 '--signaturePath'
-                '$(drop)/powershell-$(vsixVersion).signature.p7s'
+                '$(Pipeline.Workspace)/powershell-$(vsixVersion).signature.p7s'
                 if ([bool]::Parse('$(prerelease)')) { '--pre-release' }
               )
               npm run publish -- @publishArgs


### PR DESCRIPTION
TODO: Switch from PPE to Production. This requires OneBranch allow the AzureCLI task, used as [documented](https://devblogs.microsoft.com/devops/public-preview-of-workload-identity-federation-for-azure-pipelines/) for providing WIF credentials to the `vsce` tool when uploading to the marketplace.