### PR TITLE
Enable ability to trace DAP messages at client side

### DIFF
--- a/package.json
+++ b/package.json
@@ -1016,7 +1016,7 @@
         "powershell.trace.dap": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **only for extension developers and issue troubleshooting!**"
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **This setting is only meant for extension developers and issue troubleshooting!**"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1011,7 +1011,12 @@
             "verbose"
           ],
           "default": "off",
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services language server. **This setting is only meant for extension developers!**"
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). **only for extension developers and issue troubleshooting!**"
+        },
+        "powershell.trace.dap": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **only for extension developers and issue troubleshooting!**"
         }
       }
     },

--- a/src/session.ts
+++ b/src/session.ts
@@ -623,8 +623,6 @@ export class SessionManager implements Middleware {
                         });
                 });
         };
-
-
         const clientOptions: LanguageClientOptions = {
             documentSelector: this.documentSelector,
             synchronize: {
@@ -660,6 +658,7 @@ export class SessionManager implements Middleware {
             },
             revealOutputChannelOn: RevealOutputChannelOn.Never,
             middleware: this,
+            traceOutputChannel: vscode.window.createOutputChannel("PowerShell Trace - LSP", {log: true}),
         };
 
         const languageClient = new LanguageClient("powershell", "PowerShell Editor Services Client", connectFunc, clientOptions);

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -69,7 +69,7 @@ describe("DebugSessionFeature", () => {
             createDebugSessionFeatureStub({context: context});
             assert.ok(registerFactoryStub.calledOnce, "Debug adapter factory method called");
             assert.ok(registerProviderStub.calledTwice, "Debug config provider registered for both Initial and Dynamic");
-            assert.equal(context.subscriptions.length, 3, "DebugSessionFeature disposables populated");
+            assert.equal(context.subscriptions.length, 4, "DebugSessionFeature disposables populated");
             // TODO: Validate the registration content, such as the language name
         });
     });


### PR DESCRIPTION
## PR Summary
This PR adds a setting to enable tracing of DAP requests via the output pane to simplify issue troubleshooting and enable better user reporting.

By enabling the `powershell.trace.dap` option, a new DAP output pane will appear upon debug invocation. When set to "debug" log level, it will show summary of messages back and forth, similar to LSP "messages" setting. When set to "trace" log level, it will also show content similar to LSP "verbose" setting. The panel will not disappear once debug stops and will be resused for subsequent DAP connections.

This PR also segregates the LSP messages into their own output pane so they don't cross-pollute with PSES messages.

https://github.com/user-attachments/assets/9e163ef9-2e07-4bc7-9511-09b4abd0e68b

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests -> Developer tooling, tests not necessary
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready


