### PR TITLE
Implement LogOutputWindow for Logging

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -253,11 +253,11 @@ Logs provide context for what was happening when the issue occurred. **You shoul
 your logs for any sensitive information you would not like to share online!**
 
 * Before sending through logs, try and reproduce the issue with **log level set to
-  Diagnostic**. You can set this in the [VS Code Settings][]
+  Trace**. You can set this in the [VS Code Settings][]
   (<kbd>Ctrl</kbd>+<kbd>,</kbd>) with:
 
   ```json
-  "powershell.developer.editorServicesLogLevel": "Diagnostic"
+  "powershell.developer.editorServicesLogLevel": "Trace"
   ```
 
 * After you have captured the issue with the log level turned up, you may want to return

--- a/package.json
+++ b/package.json
@@ -916,20 +916,20 @@
         },
         "powershell.developer.editorServicesLogLevel": {
           "type": "string",
-          "default": "Normal",
+          "default": "Warning",
           "enum": [
-            "Diagnostic",
-            "Verbose",
-            "Normal",
+            "Trace",
+            "Debug",
+            "Information",
             "Warning",
             "Error",
             "None"
           ],
           "markdownEnumDescriptions": [
             "Enables all logging possible, please use this setting when submitting logs for bug reports!",
-            "Enables more logging than normal.",
-            "The default logging level.",
-            "Only log warnings and errors.",
+            "Enables more detailed logging of the extension",
+            "Logs high-level information about what the extension is doing.",
+            "Only log warnings and errors. This is the default setting",
             "Only log errors.",
             "Disable all logging possible. No log files will be written!"
           ],

--- a/package.json
+++ b/package.json
@@ -953,6 +953,27 @@
           "default": [],
           "markdownDescription": "An array of strings that enable experimental features in the PowerShell extension. **No flags are currently available!**"
         },
+        "powershell.developer.traceLsp": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Traces the LSP communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**"
+        },
+        "powershell.developer.traceDap": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Traces the DAP communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**"
+        },
+        "powershell.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**",
+          "markdownDeprecationMessage": "Please use the `powershell.developer.traceLsp` setting instead and control verbosity via the Output Window settings."
+        },
         "powershell.developer.waitForSessionFileTimeoutSeconds": {
           "type": "number",
           "default": 240,
@@ -1002,21 +1023,6 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Show buttons in the editor's title bar for moving the terminals pane (with the PowerShell Extension Terminal) around."
-        },
-        "powershell.trace.server": {
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). **Only for extension developers and issue troubleshooting!**"
-        },
-        "powershell.trace.dap": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **Only meant for extension developers and issue troubleshooting!**"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -933,7 +933,7 @@
             "Only log errors.",
             "Disable all logging possible. No log files will be written!"
           ],
-          "markdownDescription": "Sets the log verbosity for both the extension and its LSP server, PowerShell Editor Services. **Please set to `Diagnostic` when recording logs for a bug report!**"
+          "markdownDescription": "Sets the log verbosity for both the extension and its LSP server, PowerShell Editor Services. **Please set to `Trace` when recording logs for a bug report!**"
         },
         "powershell.developer.editorServicesWaitForDebugger": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1011,12 +1011,12 @@
             "verbose"
           ],
           "default": "off",
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). **only for extension developers and issue troubleshooting!**"
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). **Only for extension developers and issue troubleshooting!**"
         },
         "powershell.trace.dap": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **This setting is only meant for extension developers and issue troubleshooting!**"
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [DAP Server](https://microsoft.github.io/debug-adapter-protocol/). **Only meant for extension developers and issue troubleshooting!**"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -953,11 +953,6 @@
           "default": [],
           "markdownDescription": "An array of strings that enable experimental features in the PowerShell extension. **No flags are currently available!**"
         },
-        "powershell.developer.traceLsp": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Traces the LSP communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**"
-        },
         "powershell.developer.traceDap": {
           "type": "boolean",
           "default": false,
@@ -971,8 +966,7 @@
             "verbose"
           ],
           "default": "off",
-          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**",
-          "markdownDeprecationMessage": "Please use the `powershell.developer.traceLsp` setting instead and control verbosity via the Output Window settings."
+          "markdownDescription": "Traces the communication between VS Code and the PowerShell Editor Services [LSP Server](https://microsoft.github.io/language-server-protocol/). The output will be logged and also visible in the Output pane, where the verbosity is configurable. **For extension developers and issue troubleshooting only!**"
         },
         "powershell.developer.waitForSessionFileTimeoutSeconds": {
           "type": "number",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import { ShowHelpFeature } from "./features/ShowHelp";
 import { SpecifyScriptArgsFeature } from "./features/DebugSession";
 import { Logger } from "./logging";
 import { SessionManager } from "./session";
-import { LogLevel, getSettings } from "./settings";
+import { getSettings } from "./settings";
 import { PowerShellLanguageId } from "./utils";
 import { LanguageClientConsumer } from "./languageClientConsumer";
 
@@ -43,9 +43,8 @@ const documentSelector: DocumentSelector = [
 ];
 
 export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
-    const logLevel = vscode.workspace.getConfiguration(`${PowerShellLanguageId}.developer`)
-        .get<string>("editorServicesLogLevel", LogLevel.Normal);
-    logger = new Logger(logLevel, context.globalStorageUri);
+    // This is the output channel for the PowerShell extension
+    logger = new Logger(context.globalStorageUri);
 
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);
 
     const settings = getSettings();
-    logger.writeVerbose(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
+    logger.writeDebug(`Loaded settings:\n${JSON.stringify(settings, undefined, 2)}`);
 
     languageConfigurationDisposable = vscode.languages.setLanguageConfiguration(
         PowerShellLanguageId,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,6 +167,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         getPowerShellVersionDetails: uuid => externalApi.getPowerShellVersionDetails(uuid),
         waitUntilStarted: uuid => externalApi.waitUntilStarted(uuid),
         getStorageUri: () => externalApi.getStorageUri(),
+        getLogUri: () => externalApi.getLogUri(),
     };
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ const documentSelector: DocumentSelector = [
 ];
 
 export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
-    logger = new Logger(context.globalStorageUri);
+    logger = new Logger(context.logUri);
 
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -139,6 +139,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<IPower
         new PesterTestsFeature(sessionManager, logger),
         new CodeActionsFeature(logger),
         new SpecifyScriptArgsFeature(context),
+
+        vscode.commands.registerCommand(
+            "PowerShell.OpenLogFolder",
+            async () => {await vscode.commands.executeCommand(
+                "vscode.openFolder",
+                context.logUri,
+                { forceNewWindow: true }
+            );}
+        ),
+        vscode.commands.registerCommand(
+            "PowerShell.ShowLogs",
+            () => {logger.showLogPanel();}
+        )
     ];
 
     const externalApi = new ExternalApiFeature(context, sessionManager, logger);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,6 @@ const documentSelector: DocumentSelector = [
 ];
 
 export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
-    // This is the output channel for the PowerShell extension
     logger = new Logger(context.globalStorageUri);
 
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ const documentSelector: DocumentSelector = [
 ];
 
 export async function activate(context: vscode.ExtensionContext): Promise<IPowerShellExtensionClient> {
-    logger = new Logger(context.logUri);
+    logger = new Logger();
 
     telemetryReporter = new TelemetryReporter(TELEMETRY_KEY);
 

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -335,8 +335,8 @@ export class DebugSessionFeature extends LanguageClientConsumer
         // Create or show the debug terminal (either temporary or session).
         this.sessionManager.showDebugTerminal(true);
 
-        this.logger.writeVerbose(`Connecting to pipe: ${sessionDetails.debugServicePipeName}`);
-        this.logger.writeVerbose(`Debug configuration: ${JSON.stringify(session.configuration, undefined, 2)}`);
+        this.logger.writeDebug(`Connecting to pipe: ${sessionDetails.debugServicePipeName}`);
+        this.logger.writeDebug(`Debug configuration: ${JSON.stringify(session.configuration, undefined, 2)}`);
 
         return new DebugAdapterNamedPipeServer(sessionDetails.debugServicePipeName);
     }
@@ -424,7 +424,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
                 // The dispose shorthand demonry for making an event one-time courtesy of: https://github.com/OmniSharp/omnisharp-vscode/blob/b8b07bb12557b4400198895f82a94895cb90c461/test/integrationTests/launchConfiguration.integration.test.ts#L41-L45
                 startDebugEvent.dispose();
 
-                this.logger.writeVerbose(`Debugger session detected: ${dotnetAttachSession.name} (${dotnetAttachSession.id})`);
+                this.logger.writeDebug(`Debugger session detected: ${dotnetAttachSession.name} (${dotnetAttachSession.id})`);
 
                 tempConsoleDotnetAttachSession = dotnetAttachSession;
 
@@ -434,7 +434,7 @@ export class DebugSessionFeature extends LanguageClientConsumer
                     // Makes the event one-time
                     stopDebugEvent.dispose();
 
-                    this.logger.writeVerbose(`Debugger session terminated: ${tempConsoleSession.name} (${tempConsoleSession.id})`);
+                    this.logger.writeDebug(`Debugger session terminated: ${tempConsoleSession.name} (${tempConsoleSession.id})`);
 
                     // HACK: As of 2023-08-17, there is no vscode debug API to request the C# debugger to detach, so we send it a custom DAP request instead.
                     const disconnectRequest: DebugProtocol.DisconnectRequest = {
@@ -462,8 +462,8 @@ export class DebugSessionFeature extends LanguageClientConsumer
             // Start a child debug session to attach the dotnet debugger
             // TODO: Accommodate multi-folder workspaces if the C# code is in a different workspace folder
             await debug.startDebugging(undefined, dotnetAttachConfig, session);
-            this.logger.writeVerbose(`Dotnet attach debug configuration: ${JSON.stringify(dotnetAttachConfig, undefined, 2)}`);
-            this.logger.writeVerbose(`Attached dotnet debugger to process: ${pid}`);
+            this.logger.writeDebug(`Dotnet attach debug configuration: ${JSON.stringify(dotnetAttachConfig, undefined, 2)}`);
+            this.logger.writeDebug(`Attached dotnet debugger to process: ${pid}`);
         }
 
         return this.tempSessionDetails;

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -626,6 +626,7 @@ class PowerShellDebugAdapterTrackerFactory implements DebugAdapterTrackerFactory
         return this._log;
     }
 
+    // This tracker effectively implements the logging for the debug adapter to a LogOutputChannel
     createDebugAdapterTracker(session: DebugSession): DebugAdapterTracker {
         const sessionInfo = `${this.adapterName} Debug Session: ${session.name} [${session.id}]`;
         return {

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -19,6 +19,7 @@ export interface IPowerShellExtensionClient {
     getPowerShellVersionDetails(uuid: string): Promise<IExternalPowerShellDetails>;
     waitUntilStarted(uuid: string): Promise<void>;
     getStorageUri(): vscode.Uri;
+    getLogUri(): vscode.Uri;
 }
 
 /*
@@ -169,6 +170,10 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
         // We have to override the scheme because it defaults to
         // 'vscode-userdata' which breaks UNC paths.
         return this.extensionContext.globalStorageUri.with({ scheme: "file"});
+    }
+
+    public getLogUri(): vscode.Uri {
+        return this.getLogUri().with({ scheme: "file"});
     }
 
     public dispose(): void {

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -173,7 +173,7 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
     }
 
     public getLogUri(): vscode.Uri {
-        return this.getLogUri().with({ scheme: "file"});
+        return this.extensionContext.logUri.with({ scheme: "file"});
     }
 
     public dispose(): void {

--- a/src/features/ExternalApi.ts
+++ b/src/features/ExternalApi.ts
@@ -56,7 +56,7 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
         string session uuid
     */
     public registerExternalExtension(id: string, apiVersion = "v1"): string {
-        this.logger.writeVerbose(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
+        this.logger.writeDebug(`Registering extension '${id}' for use with API version '${apiVersion}'.`);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const [_name, externalExtension] of ExternalApiFeature.registeredExternalExtension) {
@@ -97,7 +97,7 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
         true if it worked, otherwise throws an error.
     */
     public unregisterExternalExtension(uuid = ""): boolean {
-        this.logger.writeVerbose(`Unregistering extension with session UUID: ${uuid}`);
+        this.logger.writeDebug(`Unregistering extension with session UUID: ${uuid}`);
         if (!ExternalApiFeature.registeredExternalExtension.delete(uuid)) {
             throw new Error(`No extension registered with session UUID: ${uuid}`);
         }
@@ -134,7 +134,7 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
     */
     public async getPowerShellVersionDetails(uuid = ""): Promise<IExternalPowerShellDetails> {
         const extension = this.getRegisteredExtension(uuid);
-        this.logger.writeVerbose(`Extension '${extension.id}' called 'getPowerShellVersionDetails'.`);
+        this.logger.writeDebug(`Extension '${extension.id}' called 'getPowerShellVersionDetails'.`);
 
         await this.sessionManager.waitUntilStarted();
         const versionDetails = this.sessionManager.getPowerShellVersionDetails();
@@ -162,7 +162,7 @@ export class ExternalApiFeature implements IPowerShellExtensionClient {
     */
     public async waitUntilStarted(uuid = ""): Promise<void> {
         const extension = this.getRegisteredExtension(uuid);
-        this.logger.writeVerbose(`Extension '${extension.id}' called 'waitUntilStarted'.`);
+        this.logger.writeDebug(`Extension '${extension.id}' called 'waitUntilStarted'.`);
         await this.sessionManager.waitUntilStarted();
     }
 

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -51,20 +51,20 @@ export class UpdatePowerShell {
     private shouldCheckForUpdate(): boolean {
         // Respect user setting.
         if (!this.sessionSettings.promptToUpdatePowerShell) {
-            this.logger.writeVerbose("Setting 'promptToUpdatePowerShell' was false.");
+            this.logger.writeDebug("Setting 'promptToUpdatePowerShell' was false.");
             return false;
         }
 
         // Respect environment configuration.
         if (process.env.POWERSHELL_UPDATECHECK?.toLowerCase() === "off") {
-            this.logger.writeVerbose("Environment variable 'POWERSHELL_UPDATECHECK' was 'Off'.");
+            this.logger.writeDebug("Environment variable 'POWERSHELL_UPDATECHECK' was 'Off'.");
             return false;
         }
 
         // Skip prompting when using Windows PowerShell for now.
         if (this.localVersion.compare("6.0.0") === -1) {
             // TODO: Maybe we should announce PowerShell Core?
-            this.logger.writeVerbose("Not prompting to update Windows PowerShell.");
+            this.logger.writeDebug("Not prompting to update Windows PowerShell.");
             return false;
         }
 
@@ -78,13 +78,13 @@ export class UpdatePowerShell {
 
             // Skip if PowerShell is self-built, that is, this contains a commit hash.
             if (commit.length >= 40) {
-                this.logger.writeVerbose("Not prompting to update development build.");
+                this.logger.writeDebug("Not prompting to update development build.");
                 return false;
             }
 
             // Skip if preview is a daily build.
             if (daily.toLowerCase().startsWith("daily")) {
-                this.logger.writeVerbose("Not prompting to update daily build.");
+                this.logger.writeDebug("Not prompting to update daily build.");
                 return false;
             }
         }
@@ -106,7 +106,7 @@ export class UpdatePowerShell {
         //     "ReleaseTag": "v7.2.7"
         // }
         const data = await response.json();
-        this.logger.writeVerbose(`Received from '${url}':\n${JSON.stringify(data, undefined, 2)}`);
+        this.logger.writeDebug(`Received from '${url}':\n${JSON.stringify(data, undefined, 2)}`);
         return data.ReleaseTag;
     }
 
@@ -115,18 +115,18 @@ export class UpdatePowerShell {
             return undefined;
         }
 
-        this.logger.writeVerbose("Checking for PowerShell update...");
+        this.logger.writeDebug("Checking for PowerShell update...");
         const tags: string[] = [];
         if (process.env.POWERSHELL_UPDATECHECK?.toLowerCase() === "lts") {
             // Only check for update to LTS.
-            this.logger.writeVerbose("Checking for LTS update...");
+            this.logger.writeDebug("Checking for LTS update...");
             const tag = await this.getRemoteVersion(UpdatePowerShell.LTSBuildInfoURL);
             if (tag != undefined) {
                 tags.push(tag);
             }
         } else {
             // Check for update to stable.
-            this.logger.writeVerbose("Checking for stable update...");
+            this.logger.writeDebug("Checking for stable update...");
             const tag = await this.getRemoteVersion(UpdatePowerShell.StableBuildInfoURL);
             if (tag != undefined) {
                 tags.push(tag);
@@ -134,7 +134,7 @@ export class UpdatePowerShell {
 
             // Also check for a preview update.
             if (this.localVersion.prerelease.length > 0) {
-                this.logger.writeVerbose("Checking for preview update...");
+                this.logger.writeDebug("Checking for preview update...");
                 const tag = await this.getRemoteVersion(UpdatePowerShell.PreviewBuildInfoURL);
                 if (tag != undefined) {
                     tags.push(tag);
@@ -181,11 +181,11 @@ export class UpdatePowerShell {
 
         // If the user cancels the notification.
         if (!result) {
-            this.logger.writeVerbose("User canceled PowerShell update prompt.");
+            this.logger.writeDebug("User canceled PowerShell update prompt.");
             return;
         }
 
-        this.logger.writeVerbose(`User said '${UpdatePowerShell.promptOptions[result.id].title}'.`);
+        this.logger.writeDebug(`User said '${UpdatePowerShell.promptOptions[result.id].title}'.`);
 
         switch (result.id) {
         // Yes

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -9,8 +9,8 @@ import { LogOutputChannel, LogLevel, window, Event } from "vscode";
 export interface ILogger {
     write(message: string, ...additionalMessages: string[]): void;
     writeAndShowInformation(message: string, ...additionalMessages: string[]): Promise<void>;
-    writeDiagnostic(message: string, ...additionalMessages: string[]): void;
-    writeVerbose(message: string, ...additionalMessages: string[]): void;
+    writeTrace(message: string, ...additionalMessages: string[]): void;
+    writeDebug(message: string, ...additionalMessages: string[]): void;
     writeWarning(message: string, ...additionalMessages: string[]): void;
     writeAndShowWarning(message: string, ...additionalMessages: string[]): Promise<void>;
     writeError(message: string, ...additionalMessages: string[]): void;
@@ -56,11 +56,11 @@ export class Logger implements ILogger {
         }
     }
 
-    public writeDiagnostic(message: string, ...additionalMessages: string[]): void {
+    public writeTrace(message: string, ...additionalMessages: string[]): void {
         this.writeAtLevel(LogLevel.Trace, message, ...additionalMessages);
     }
 
-    public writeVerbose(message: string, ...additionalMessages: string[]): void {
+    public writeDebug(message: string, ...additionalMessages: string[]): void {
         this.writeAtLevel(LogLevel.Debug, message, ...additionalMessages);
     }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -255,6 +255,20 @@ export class LanguageClientOutputChannelAdapter implements LogOutputChannel {
     // #endregion
 }
 
+/** Appends additional  */
+export class PsesMergedOutputChannel extends LanguageClientOutputChannelAdapter {
+    public override appendLine(message: string): void {
+        this.append(message);
+    }
+
+    public override append(message: string): void {
+        const [parsedMessage, level] = this.parse(message);
+
+        // Append PSES prefix to log messages to differentiate them from Client messages
+        this.sendLogMessage("[PSES] " + parsedMessage, level);
+    }
+}
+
 /** Overrides the severity of some LSP traces to be more logical */
 export class LanguageClientTraceFormatter extends LanguageClientOutputChannelAdapter {
     public override appendLine(message: string): void {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -153,8 +153,10 @@ export class LanguageClientOutputChannelAdapter implements LogOutputChannel {
         this.sendLogMessage(parsedMessage, level);
     }
 
+    // We include the log level inline from PSES for VSCode because our LanguageClient doesn't support middleware for logMessages yet.
+    // BUG:
     protected parse(message: string): [string, LogLevel] {
-        const logLevelMatch = /^\[(?<level>Trace|Debug|Info|Warn|Error) +- \d+:\d+:\d+ [AP]M\] (?<message>.+)/.exec(message);
+        const logLevelMatch = /^<(?<level>Trace|Debug|Info|Warning|Error)>(?<message>.+)/.exec(message);
         if (logLevelMatch) {
             const { level, message } = logLevelMatch.groups!;
             let logLevel: LogLevel;
@@ -168,7 +170,7 @@ export class LanguageClientOutputChannelAdapter implements LogOutputChannel {
             case "Info":
                 logLevel = LogLevel.Info;
                 break;
-            case "Warn":
+            case "Warning":
                 logLevel = LogLevel.Warning;
                 break;
             case "Error":

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -274,7 +274,7 @@ export function LspTraceParser(message: string): [string, LogLevel] {
         level = LogLevel.Trace;
     }
 
-    // These are PSES messages we don't really need to see so we drop these to trace
+    // These are PSES messages that get logged to the output channel anyways so we drop these to trace for easy noise filtering
     if (parsedMessage.startsWith("⬅️ notification 'window/logMessage'")) {
         level = LogLevel.Trace;
     }

--- a/src/process.ts
+++ b/src/process.ts
@@ -90,13 +90,13 @@ export class PowerShellProcess {
                 startEditorServices);
         } else {
             // Otherwise use -EncodedCommand for better quote support.
-            this.logger.writeVerbose("Using Base64 -EncodedCommand but logging as -Command equivalent.");
+            this.logger.writeDebug("Using Base64 -EncodedCommand but logging as -Command equivalent.");
             powerShellArgs.push(
                 "-EncodedCommand",
                 Buffer.from(startEditorServices, "utf16le").toString("base64"));
         }
 
-        this.logger.writeVerbose(`Starting process: ${this.exePath} ${powerShellArgs.slice(0, -2).join(" ")} -Command ${startEditorServices}`);
+        this.logger.writeDebug(`Starting process: ${this.exePath} ${powerShellArgs.slice(0, -2).join(" ")} -Command ${startEditorServices}`);
 
         // Make sure no old session file exists
         await this.deleteSessionFile(this.sessionFilePath);
@@ -174,7 +174,7 @@ export class PowerShellProcess {
     }
 
     public dispose(): void {
-        this.logger.writeVerbose(`Disposing PowerShell process with PID: ${this.pid}`);
+        this.logger.writeDebug(`Disposing PowerShell process with PID: ${this.pid}`);
 
         void this.deleteSessionFile(this.sessionFilePath);
 
@@ -227,7 +227,7 @@ export class PowerShellProcess {
         const warnAt = numOfTries - PowerShellProcess.warnUserThreshold;
 
         // Check every second.
-        this.logger.writeVerbose(`Waiting for session file: ${this.sessionFilePath}`);
+        this.logger.writeDebug(`Waiting for session file: ${this.sessionFilePath}`);
         for (let i = numOfTries; i > 0; i--) {
             if (cancellationToken.isCancellationRequested) {
                 this.logger.writeWarning("Canceled while waiting for session file.");
@@ -240,7 +240,7 @@ export class PowerShellProcess {
             }
 
             if (await utils.checkIfFileExists(this.sessionFilePath)) {
-                this.logger.writeVerbose("Session file found.");
+                this.logger.writeDebug("Session file found.");
                 return await this.readSessionFile(this.sessionFilePath);
             }
 

--- a/src/process.ts
+++ b/src/process.ts
@@ -30,6 +30,7 @@ export class PowerShellProcess {
         private isTemp: boolean,
         private shellIntegrationEnabled: boolean,
         private logger: ILogger,
+        private logDirectoryPath: vscode.Uri,
         private startPsesArgs: string,
         private sessionFilePath: vscode.Uri,
         private sessionSettings: Settings) {
@@ -51,7 +52,7 @@ export class PowerShellProcess {
                 : "";
 
         this.startPsesArgs +=
-            `-LogPath '${utils.escapeSingleQuotes(this.logger.logDirectoryPath.fsPath)}' ` +
+            `-LogPath '${utils.escapeSingleQuotes(this.logDirectoryPath.fsPath)}' ` +
             `-SessionDetailsPath '${utils.escapeSingleQuotes(this.sessionFilePath.fsPath)}' ` +
             `-FeatureFlags @(${featureFlags}) `;
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements } from "@vscode/extension-telemetry";
 import { Message, Trace } from "vscode-jsonrpc";
-import { ILogger, LanguageClientOutputChannelAdapter, LanguageClientTraceFormatter } from "./logging";
+import { ILogger, LanguageClientOutputChannelAdapter, LanguageClientTraceFormatter, PsesMergedOutputChannel } from "./logging";
 import { PowerShellProcess } from "./process";
 import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
 import utils = require("./utils");
@@ -690,7 +690,7 @@ export class SessionManager implements Middleware {
             middleware: this,
             traceOutputChannel: new LanguageClientTraceFormatter("PowerShell: Trace LSP"),
             // This is named the same as the Client log to merge the logs, but will be handled and disposed separately.
-            outputChannel: new LanguageClientOutputChannelAdapter("PowerShell"),
+            outputChannel: new PsesMergedOutputChannel("PowerShell"),
             revealOutputChannelOn: RevealOutputChannelOn.Never
         };
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -5,7 +5,7 @@ import net = require("net");
 import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements } from "@vscode/extension-telemetry";
-import { Message, Trace } from "vscode-jsonrpc";
+import { Message } from "vscode-jsonrpc";
 import { ILogger, LanguageClientOutputChannelAdapter, LspTraceParser, PsesParser } from "./logging";
 import { PowerShellProcess } from "./process";
 import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,7 +14,7 @@ import utils = require("./utils");
 import {
     CloseAction, CloseHandlerResult, DocumentSelector, ErrorAction, ErrorHandlerResult,
     LanguageClientOptions, Middleware, NotificationType,
-    RequestType0, ResolveCodeLensSignature, RevealOutputChannelOn
+    RequestType0, ResolveCodeLensSignature
 } from "vscode-languageclient";
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 
@@ -454,7 +454,6 @@ export class SessionManager implements Middleware {
     private async onConfigurationUpdated(): Promise<void> {
         const settings = getSettings();
         const shellIntegrationEnabled = vscode.workspace.getConfiguration("terminal.integrated.shellIntegration").get<boolean>("enabled");
-        this.logger.updateLogLevel(settings.developer.editorServicesLogLevel);
 
         // Detect any setting changes that would affect the session.
         if (!this.suppressRestartPrompt
@@ -656,9 +655,9 @@ export class SessionManager implements Middleware {
                     };
                 },
             },
-            revealOutputChannelOn: RevealOutputChannelOn.Never,
             middleware: this,
             traceOutputChannel: vscode.window.createOutputChannel("PowerShell Trace - LSP", {log: true}),
+            outputChannel: vscode.window.createOutputChannel("PowerShell Editor Services", {log: true}),
         };
 
         const languageClient = new LanguageClient("powershell", "PowerShell Editor Services Client", connectFunc, clientOptions);

--- a/src/session.ts
+++ b/src/session.ts
@@ -689,7 +689,8 @@ export class SessionManager implements Middleware {
             },
             middleware: this,
             traceOutputChannel: new LanguageClientTraceFormatter("PowerShell: Trace LSP"),
-            outputChannel: new LanguageClientOutputChannelAdapter("PowerShell: Editor Services"),
+            // This is named the same as the Client log to merge the logs, but will be handled and disposed separately.
+            outputChannel: new LanguageClientOutputChannelAdapter("PowerShell"),
             revealOutputChannelOn: RevealOutputChannelOn.Never
         };
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -744,19 +744,6 @@ export class SessionManager implements Middleware {
         return languageClient;
     }
 
-    /** Synchronizes a vscode LogOutputChannel log level to the LSP trace setting to minimize traffic */
-    private async setLspTrace(languageClient: LanguageClient, level: vscode.LogLevel): Promise<void> {
-        this.logger.writeVerbose("LSP Trace level changed to: " + level.toString());
-        if (level == vscode.LogLevel.Trace) {
-            return languageClient.setTrace(Trace.Verbose);
-        } else if (level == vscode.LogLevel.Debug) {
-            return languageClient.setTrace(Trace.Messages);
-        } else {
-            return languageClient.setTrace(Trace.Off);
-        }
-    }
-
-
     private async getBundledModulesPath(): Promise<string> {
         // Because the extension is always at `<root>/out/main.js`
         let bundledModulesPath = path.resolve(__dirname, "../modules");

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements } from "@vscode/extension-telemetry";
 import { Message, Trace } from "vscode-jsonrpc";
-import { ILogger, LanguageClientOutputChannelAdapter, LanguageClientTraceFormatter, PsesMergedOutputChannel } from "./logging";
+import { ILogger, LanguageClientTraceFormatter, PsesMergedOutputChannel } from "./logging";
 import { PowerShellProcess } from "./process";
 import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
 import utils = require("./utils");

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements } from "@vscode/extension-telemetry";
 import { Message, Trace } from "vscode-jsonrpc";
-import { ILogger, LanguageClientTraceFormatter, PsesMergedOutputChannel } from "./logging";
+import { ILogger, LanguageClientOutputChannelAdapter, LspTraceParser, PsesParser } from "./logging";
 import { PowerShellProcess } from "./process";
 import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
 import utils = require("./utils");
@@ -688,9 +688,9 @@ export class SessionManager implements Middleware {
                 },
             },
             middleware: this,
-            traceOutputChannel: new LanguageClientTraceFormatter("PowerShell: Trace LSP"),
+            traceOutputChannel: new LanguageClientOutputChannelAdapter("PowerShell: Trace LSP", LspTraceParser),
             // This is named the same as the Client log to merge the logs, but will be handled and disposed separately.
-            outputChannel: new PsesMergedOutputChannel("PowerShell"),
+            outputChannel: new LanguageClientOutputChannelAdapter("PowerShell", PsesParser),
             revealOutputChannelOn: RevealOutputChannelOn.Never
         };
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import vscode = require("vscode");
 import TelemetryReporter, { TelemetryEventProperties, TelemetryEventMeasurements } from "@vscode/extension-telemetry";
 import { Message, Trace } from "vscode-jsonrpc";
-import { ILogger } from "./logging";
+import { ILogger, LanguageClientOutputChannelAdapter, LanguageClientTraceFormatter } from "./logging";
 import { PowerShellProcess } from "./process";
 import { Settings, changeSetting, getSettings, getEffectiveConfigurationTarget, validateCwdSetting } from "./settings";
 import utils = require("./utils");
@@ -338,7 +338,6 @@ export class SessionManager implements Middleware {
         // handler when the process is disposed).
         this.debugSessionProcess?.dispose();
         this.debugEventHandler?.dispose();
-
         if (this.PowerShellExeDetails === undefined) {
             return Promise.reject(new Error("Required PowerShellExeDetails undefined!"));
         }
@@ -689,8 +688,8 @@ export class SessionManager implements Middleware {
                 },
             },
             middleware: this,
-            // traceOutputChannel: traceOutputChannel,
-            // outputChannel: outputChannel,
+            traceOutputChannel: new LanguageClientTraceFormatter("PowerShell: Trace LSP"),
+            outputChannel: new LanguageClientOutputChannelAdapter("PowerShell: Editor Services"),
             revealOutputChannelOn: RevealOutputChannelOn.Never
         };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -56,15 +56,6 @@ export enum PipelineIndentationStyle {
     None = "None",
 }
 
-export enum LogLevel {
-    Diagnostic = "Diagnostic",
-    Verbose = "Verbose",
-    Normal = "Normal",
-    Warning = "Warning",
-    Error = "Error",
-    None = "None",
-}
-
 export enum CommentType {
     Disabled = "Disabled",
     BlockComment = "BlockComment",
@@ -120,7 +111,6 @@ class DeveloperSettings extends PartialSettings {
     // From `<root>/out/main.js` we go to the directory before <root> and
     // then into the other repo.
     bundledModulesPath = "../../PowerShellEditorServices/module";
-    editorServicesLogLevel = LogLevel.Normal;
     editorServicesWaitForDebugger = false;
     setExecutionPolicy = true;
     waitForSessionFileTimeoutSeconds = 240;
@@ -209,7 +199,7 @@ export async function changeSetting(
     configurationTarget: vscode.ConfigurationTarget | boolean | undefined,
     logger: ILogger | undefined): Promise<void> {
 
-    logger?.writeVerbose(`Changing '${settingName}' at scope '${configurationTarget}' to '${newValue}'.`);
+    logger?.writeDebug(`Changing '${settingName}' at scope '${configurationTarget}' to '${newValue}'.`);
 
     try {
         const configuration = vscode.workspace.getConfiguration(utils.PowerShellLanguageId);
@@ -242,7 +232,7 @@ export async function getChosenWorkspace(logger: ILogger | undefined): Promise<v
 
         chosenWorkspace = await vscode.window.showWorkspaceFolderPick(options);
 
-        logger?.writeVerbose(`User selected workspace: '${chosenWorkspace?.name}'`);
+        logger?.writeDebug(`User selected workspace: '${chosenWorkspace?.name}'`);
         if (chosenWorkspace === undefined) {
             chosenWorkspace = vscode.workspace.workspaceFolders[0];
         } else {
@@ -296,7 +286,7 @@ export async function validateCwdSetting(logger: ILogger | undefined): Promise<s
     // Otherwise get a cwd from the workspace, if possible.
     const workspace = await getChosenWorkspace(logger);
     if (workspace === undefined) {
-        logger?.writeVerbose("Workspace was undefined, using homedir!");
+        logger?.writeDebug("Workspace was undefined, using homedir!");
         return os.homedir();
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,57 +86,6 @@ export function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-/**
- * Invokes the specified action when a setting changes
- * @param setting a string representation of the setting you wish to evaluate, e.g. `trace.server`
- * @param action the action to take when the setting changes
- * @param section the section of the vscode settings to evaluate. Defaults to `powershell`
- * @param scope the scope in which the vscode setting should be evaluated.
- * @param workspace
- * @param onDidChangeConfiguration
- * @example onPowerShellSettingChange("settingName", (newValue) => console.log(newValue));
- * @returns a Disposable object that can be used to stop listening for changes
- */
-
-// Because we actually do use the constraint in the callback
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export function onSettingChange<T>(
-    section: string,
-    setting: string,
-    action: (newValue: T | undefined) => void,
-    scope?: vscode.ConfigurationScope,
-): vscode.Disposable {
-    const settingPath = `${section}.${setting}`;
-    return vscode.workspace.onDidChangeConfiguration(e => {
-        if (!e.affectsConfiguration(settingPath, scope)) { return; }
-        const value = vscode.workspace.getConfiguration(section, scope).get<T>(setting);
-        action(value);
-    });
-}
-
-/**
- * Invokes the specified action when a PowerShell setting changes. Convenience function for `onSettingChange`
- * @param setting a string representation of the setting you wish to evaluate, e.g. `trace.server`
- * @param action the action to take when the setting changes
- * @param section the section of the vscode settings to evaluate. Defaults to `powershell`
- * @param scope the scope in which the vscode setting should be evaluated.
- * @param workspace
- * @param onDidChangeConfiguration
- * @example onPowerShellSettingChange("settingName", (newValue) => console.log(newValue));
- * @returns a Disposable object that can be used to stop listening for changes
- */
-
-// Because we actually do use the constraint in the callback
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export function onPowerShellSettingChange<T>(
-    setting: string,
-    action: (newValue: T | undefined) => void,
-    scope?: vscode.ConfigurationScope,
-): vscode.Disposable {
-    const section = "powershell";
-    return onSettingChange(section, setting, action, scope);
-}
-
 export const isMacOS: boolean = process.platform === "darwin";
 export const isWindows: boolean = process.platform === "win32";
 export const isLinux: boolean = !isMacOS && !isWindows;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,10 +87,39 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Invokes the specified action when a PowerShell setting changes
- * @param setting a string representation of the setting you wish to evaluate
+ * Invokes the specified action when a setting changes
+ * @param setting a string representation of the setting you wish to evaluate, e.g. `trace.server`
  * @param action the action to take when the setting changes
- * @param scope the scope in which the vscode setting should be evaluated. Defaults to
+ * @param section the section of the vscode settings to evaluate. Defaults to `powershell`
+ * @param scope the scope in which the vscode setting should be evaluated.
+ * @param workspace
+ * @param onDidChangeConfiguration
+ * @example onPowerShellSettingChange("settingName", (newValue) => console.log(newValue));
+ * @returns a Disposable object that can be used to stop listening for changes
+ */
+
+// Because we actually do use the constraint in the callback
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function onSettingChange<T>(
+    section: string,
+    setting: string,
+    action: (newValue: T | undefined) => void,
+    scope?: vscode.ConfigurationScope,
+): vscode.Disposable {
+    const settingPath = `${section}.${setting}`;
+    return vscode.workspace.onDidChangeConfiguration(e => {
+        if (!e.affectsConfiguration(settingPath, scope)) { return; }
+        const value = vscode.workspace.getConfiguration(section, scope).get<T>(setting);
+        action(value);
+    });
+}
+
+/**
+ * Invokes the specified action when a PowerShell setting changes. Convenience function for `onSettingChange`
+ * @param setting a string representation of the setting you wish to evaluate, e.g. `trace.server`
+ * @param action the action to take when the setting changes
+ * @param section the section of the vscode settings to evaluate. Defaults to `powershell`
+ * @param scope the scope in which the vscode setting should be evaluated.
  * @param workspace
  * @param onDidChangeConfiguration
  * @example onPowerShellSettingChange("settingName", (newValue) => console.log(newValue));
@@ -101,15 +130,11 @@ export function sleep(ms: number): Promise<void> {
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
 export function onPowerShellSettingChange<T>(
     setting: string,
-    listener: (newValue: T | undefined) => void,
-    section: "powershell",
+    action: (newValue: T | undefined) => void,
     scope?: vscode.ConfigurationScope,
 ): vscode.Disposable {
-    return vscode.workspace.onDidChangeConfiguration(e => {
-        if (!e.affectsConfiguration(section, scope)) { return; }
-        const value = vscode.workspace.getConfiguration(section, scope).get<T>(setting);
-        listener(value);
-    });
+    const section = "powershell";
+    return onSettingChange(section, setting, action, scope);
 }
 
 export const isMacOS: boolean = process.platform === "darwin";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,32 @@ export function sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+/**
+ * Invokes the specified action when a PowerShell setting changes
+ * @param setting a string representation of the setting you wish to evaluate
+ * @param action the action to take when the setting changes
+ * @param scope the scope in which the vscode setting should be evaluated. Defaults to
+ * @param workspace
+ * @param onDidChangeConfiguration
+ * @example onPowerShellSettingChange("settingName", (newValue) => console.log(newValue));
+ * @returns a Disposable object that can be used to stop listening for changes
+ */
+
+// Because we actually do use the constraint in the callback
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+export function onPowerShellSettingChange<T>(
+    setting: string,
+    listener: (newValue: T | undefined) => void,
+    section: "powershell",
+    scope?: vscode.ConfigurationScope,
+): vscode.Disposable {
+    return vscode.workspace.onDidChangeConfiguration(e => {
+        if (!e.affectsConfiguration(section, scope)) { return; }
+        const value = vscode.workspace.getConfiguration(section, scope).get<T>(setting);
+        listener(value);
+    });
+}
+
 export const isMacOS: boolean = process.platform === "darwin";
 export const isWindows: boolean = process.platform === "win32";
 export const isLinux: boolean = !isMacOS && !isWindows;

--- a/test/core/paths.test.ts
+++ b/test/core/paths.test.ts
@@ -9,9 +9,11 @@ import { checkIfDirectoryExists, checkIfFileExists, ShellIntegrationScript } fro
 
 describe("Path assumptions", function () {
     let globalStorageUri: vscode.Uri;
+    let logUri: vscode.Uri;
     before(async () => {
         const extension: IPowerShellExtensionClient = await utils.ensureEditorServicesIsConnected();
         globalStorageUri = extension.getStorageUri();
+        logUri = extension.getLogUri();
     });
 
     it("Creates the session folder at the correct path", async function () {
@@ -19,7 +21,7 @@ describe("Path assumptions", function () {
     });
 
     it("Creates the log folder at the correct path", async function () {
-        assert(await checkIfDirectoryExists(vscode.Uri.joinPath(globalStorageUri, "logs")));
+        assert(await checkIfDirectoryExists(logUri));
     });
 
     it("Finds the Terminal Shell Integration Script", async function () {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -25,10 +25,10 @@ export class TestLogger implements ILogger {
     writeAndShowInformation(_message: string, ..._additionalMessages: string[]): Promise<void> {
         return Promise.resolve();
     }
-    writeDiagnostic(_message: string, ..._additionalMessages: string[]): void {
+    writeTrace(_message: string, ..._additionalMessages: string[]): void {
         return;
     }
-    writeVerbose(_message: string, ..._additionalMessages: string[]): void {
+    writeDebug(_message: string, ..._additionalMessages: string[]): void {
         return;
     }
     writeWarning(_message: string, ..._additionalMessages: string[]): void {


### PR DESCRIPTION
Implements the `LogOutputWindow` vscode API for PowerShell extension and PSES logs received via LSP.

https://github.com/user-attachments/assets/6c0210ca-a641-430c-8d01-47f5ca8b0b38

There will now be 3 separate log output panels:
`PowerShell` Messages logged for the PowerShell client and messages sent via the LSP adapter (prepended with [PSES])
`PowerShell: Trace LSP` Traces the LSP messages back and forth. Omnisharp messages will show up as traces here
`PowerShell: Trace DAP` Traces the DAP messages back and forth (already implemented)

This has several benefits:
1. Output to file is handled by vscode, we don't need our own custom handler anymore
1. Log levels and switching log levels handled by vscode, our code related to this (settings etc.) can be removed
1. Logs can be tailed and opened in separate editors within vscode, providing a very nice experience. Logs are visible using the log syntax highlighting which can be enhanced by my [ Crisp Logs Highlighter](https://marketplace.visualstudio.com/items?itemName=justin-grote.crisp-logs)
1. Centralizes to vscode extension log folder that will be used with `Issue Reporter`, there's a contribution API for issue reporter where we can gather additional data as well (PR forthcoming)

Log windows do not appear unless enabled.

Right now the Log Verbosity with "Set Log Level" only controls the client-side logging level, but I hope in a future PR to be able to update the logging level of PSES dynamically. Has a minor LSP performance benefit but difficult to implement due to MEL not having dynamic log level change support natively, but I think I found a way with IOptionsMonitor to do it.

Should be merged with https://github.com/PowerShell/PowerShellEditorServices/pull/2200

Fixes https://github.com/PowerShell/vscode-powershell/issues/5079