### PR TITLE
Limit GitHub Actions to 10 minutes

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,6 +20,7 @@ jobs:
       DOTNET_NOLOGO: true
       DOTNET_GENERATE_ASPNET_CERTIFICATE: false
       DISPLAY: ':99.0'
+    timeout-minutes: 10
     steps:
       - name: Checkout PowerShellEditorServices
         uses: actions/checkout@v4


### PR DESCRIPTION
Currently jobs run for 360 minutes if something gets stuck. This lowers that limit to something more reasonable.

