### PR TITLE
Improve warning when additional PowerShell isn't found

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -239,17 +239,17 @@ export class PowerShellExeFinder {
                 }
 
                 exePath = untildify(exePath);
-
-                // Always search for what the user gave us first
-                yield new PossiblePowerShellExe(exePath, versionName);
-
-                // Also search for `pwsh[.exe]` and `powershell[.exe]` if missing
                 const args: [string, undefined, boolean, boolean]
                     // Must be a tuple type and is suppressing the warning
                     = [versionName, undefined, true, true];
 
-                // Handle Windows where '.exe' and 'powershell' are things
+                // Always search for what the user gave us first, but with the warning
+                // suppressed so we can display it after all possibilities are exhausted
+                yield new PossiblePowerShellExe(exePath, ...args);
+
+                // Also search for `pwsh[.exe]` and `powershell[.exe]` if missing
                 if (this.platformDetails.operatingSystem === OperatingSystem.Windows) {
+                    // Handle Windows where '.exe' and 'powershell' are things
                     if (!exePath.endsWith("pwsh.exe") && !exePath.endsWith("powershell.exe")) {
                         if (exePath.endsWith("pwsh") || exePath.endsWith("powershell")) {
                             // Add extension if that was missing
@@ -260,9 +260,13 @@ export class PowerShellExeFinder {
                         yield new PossiblePowerShellExe(path.join(exePath, "pwsh.exe"), ...args);
                         yield new PossiblePowerShellExe(path.join(exePath, "powershell.exe"), ...args);
                     }
-                } else if (!exePath.endsWith("pwsh")) { // Always just 'pwsh' on non-Windows
+                } else if (!exePath.endsWith("pwsh")) {
+                    // Always just 'pwsh' on non-Windows
                     yield new PossiblePowerShellExe(path.join(exePath, "pwsh"), ...args);
                 }
+
+                // If we're still being iterated over, no permutation of the given path existed so yield an object with the warning unsuppressed
+                yield new PossiblePowerShellExe(exePath, versionName, false, undefined, false);
             }
         }
     }

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -468,10 +468,25 @@ if (process.platform === "win32") {
                 isProcess64Bit: true,
             },
             environmentVars: {},
+            // Note that for each given path, we expect:
+            // 1. The path as-is.
+            // 2. Any expected permutations of the path (for example, with a tilde or folder expanded, and/or '.exe' added).
+            // 3. The path as-is again (in order for a warning to be displayed at the correct time).
+            // An improvement here would be to check the suppressWarning field, but it's not currently exposed.
             expectedPowerShellSequence: [
                 {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
                     displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
+                    displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: path.join(os.homedir(), "pwsh", "pwsh.exe"),
+                    displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {
@@ -500,6 +515,11 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
+                    exePath: "C:\\Users\\test\\pwsh\\pwsh",
+                    displayName: "pwsh-no-exe",
+                    supportsProperArguments: true
+                },
+                {
                     exePath: "C:\\Users\\test\\pwsh\\",
                     displayName: "pwsh-folder",
                     supportsProperArguments: true
@@ -511,6 +531,11 @@ if (process.platform === "win32") {
                 },
                 {
                     exePath: "C:\\Users\\test\\pwsh\\powershell.exe",
+                    displayName: "pwsh-folder",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "C:\\Users\\test\\pwsh\\",
                     displayName: "pwsh-folder",
                     supportsProperArguments: true
                 },
@@ -535,8 +560,23 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
+                    exePath: "C:\\Users\\test\\pwsh",
+                    displayName: "pwsh-folder-no-slash",
+                    supportsProperArguments: true
+                },
+                {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
                     displayName: "pwsh-single-quotes",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
+                    displayName: "pwsh-single-quotes",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
+                    displayName: "pwsh-double-quotes",
                     supportsProperArguments: true
                 },
                 {
@@ -760,17 +800,32 @@ if (process.platform === "win32") {
 
     successAdditionalTestCases = [
         {   // Also sufficient for macOS as the behavior is the same
-            name: "Linux (Additional PowerShell Executables)",
+            name: "Linux/macOS (Additional PowerShell Executables)",
             platformDetails: {
                 operatingSystem: platform.OperatingSystem.Linux,
                 isOS64Bit: true,
                 isProcess64Bit: true,
             },
             environmentVars: {},
+            // Note that for each given path, we expect:
+            // 1. The path as-is.
+            // 2. Any expected permutations of the path (for example, with a tilde or folder expanded).
+            // 3. The path as-is again (in order for a warning to be displayed at the correct time).
+            // An improvement here would be to check the suppressWarning field, but it's not currently exposed.
             expectedPowerShellSequence: [
                 {
                     exePath: "/home/bin/pwsh",
                     displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/home/bin/pwsh",
+                    displayName: "pwsh",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: path.join(os.homedir(), "bin", "pwsh"),
+                    displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {
@@ -789,6 +844,11 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
+                    exePath: "/home/bin/",
+                    displayName: "pwsh-folder",
+                    supportsProperArguments: true
+                },
+                {
                     exePath: "/home/bin",
                     displayName: "pwsh-folder-no-slash",
                     supportsProperArguments: true
@@ -799,8 +859,23 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
+                    exePath: "/home/bin",
+                    displayName: "pwsh-folder-no-slash",
+                    supportsProperArguments: true
+                },
+                {
                     exePath: "/home/bin/pwsh",
                     displayName: "pwsh-single-quotes",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/home/bin/pwsh",
+                    displayName: "pwsh-single-quotes",
+                    supportsProperArguments: true
+                },
+                {
+                    exePath: "/home/bin/pwsh",
+                    displayName: "pwsh-double-quotes",
                     supportsProperArguments: true
                 },
                 {


### PR DESCRIPTION
Since we added logic which searches for possible intended permutations of the given additional PowerShell path, we needed to make the warning show only if none of the permutations were found. This was accomplished by suppressing it in the first iterator and then yielding it again after the permutations were exhausted with the warning unsuppressed.

@JustinGrote this bug just _really_ annoyed me...I'm surprised no one reported it yet.