### PR TITLE
Fix additional PowerShell warning (take two)

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -148,7 +148,7 @@ export class PowerShellExeFinder {
 
         // Also show any additionally configured PowerShells
         // These may be duplicates of the default installations, but given a different name.
-        for (const additionalPwsh of this.enumerateAdditionalPowerShellInstallations()) {
+        for await (const additionalPwsh of this.enumerateAdditionalPowerShellInstallations()) {
             if (await additionalPwsh.exists()) {
                 yield additionalPwsh;
             } else if (!additionalPwsh.suppressWarning) {
@@ -230,7 +230,7 @@ export class PowerShellExeFinder {
      * Iterates through the configured additional PowerShell executable locations,
      * without checking for their existence.
      */
-    private *enumerateAdditionalPowerShellInstallations(): Iterable<IPossiblePowerShellExe> {
+    private async *enumerateAdditionalPowerShellInstallations(): AsyncIterable<IPossiblePowerShellExe> {
         for (const versionName in this.additionalPowerShellExes) {
             if (Object.prototype.hasOwnProperty.call(this.additionalPowerShellExes, versionName)) {
                 let exePath: string | undefined = utils.stripQuotePair(this.additionalPowerShellExes[versionName]);
@@ -245,7 +245,11 @@ export class PowerShellExeFinder {
 
                 // Always search for what the user gave us first, but with the warning
                 // suppressed so we can display it after all possibilities are exhausted
-                yield new PossiblePowerShellExe(exePath, ...args);
+                let pwsh = new PossiblePowerShellExe(exePath, ...args);
+                if (await pwsh.exists()) {
+                    yield pwsh;
+                    continue;
+                }
 
                 // Also search for `pwsh[.exe]` and `powershell[.exe]` if missing
                 if (this.platformDetails.operatingSystem === OperatingSystem.Windows) {
@@ -253,16 +257,32 @@ export class PowerShellExeFinder {
                     if (!exePath.endsWith("pwsh.exe") && !exePath.endsWith("powershell.exe")) {
                         if (exePath.endsWith("pwsh") || exePath.endsWith("powershell")) {
                             // Add extension if that was missing
-                            yield new PossiblePowerShellExe(exePath + ".exe", ...args);
+                            pwsh = new PossiblePowerShellExe(exePath + ".exe", ...args);
+                            if (await pwsh.exists()) {
+                                yield pwsh;
+                                continue;
+                            }
                         }
                         // Also add full exe names (this isn't an else just in case
                         // the folder was named "pwsh" or "powershell")
-                        yield new PossiblePowerShellExe(path.join(exePath, "pwsh.exe"), ...args);
-                        yield new PossiblePowerShellExe(path.join(exePath, "powershell.exe"), ...args);
+                        pwsh = new PossiblePowerShellExe(path.join(exePath, "pwsh.exe"), ...args);
+                        if (await pwsh.exists()) {
+                            yield pwsh;
+                            continue;
+                        }
+                        pwsh = new PossiblePowerShellExe(path.join(exePath, "powershell.exe"), ...args);
+                        if (await pwsh.exists()) {
+                            yield pwsh;
+                            continue;
+                        }
                     }
                 } else if (!exePath.endsWith("pwsh")) {
                     // Always just 'pwsh' on non-Windows
-                    yield new PossiblePowerShellExe(path.join(exePath, "pwsh"), ...args);
+                    pwsh = new PossiblePowerShellExe(path.join(exePath, "pwsh"), ...args);
+                    if (await pwsh.exists()) {
+                        yield pwsh;
+                        continue;
+                    }
                 }
 
                 // If we're still being iterated over, no permutation of the given path existed so yield an object with the warning unsuppressed

--- a/test/core/platform.test.ts
+++ b/test/core/platform.test.ts
@@ -18,10 +18,20 @@ import { stripQuotePair } from "../../src/utils";
 const platformMock = rewire("../../src/platform");
 
 // eslint-disable-next-line @typescript-eslint/require-await
-async function fakeCheckIfFileOrDirectoryExists(targetPath: string | vscode.Uri): Promise<boolean> {
+async function fakeCheckIfFileExists(targetPath: string | vscode.Uri): Promise<boolean> {
     try {
-        fs.lstatSync(targetPath instanceof vscode.Uri ? targetPath.fsPath : targetPath);
-        return true;
+        const stat = fs.lstatSync(targetPath instanceof vscode.Uri ? targetPath.fsPath : targetPath);
+        return stat.isFile();
+    } catch {
+        return false;
+    }
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+async function fakeCheckIfDirectoryExists(targetPath: string | vscode.Uri): Promise<boolean> {
+    try {
+        const stat = fs.lstatSync(targetPath instanceof vscode.Uri ? targetPath.fsPath : targetPath);
+        return stat.isDirectory();
     } catch {
         return false;
     }
@@ -33,8 +43,8 @@ async function fakeReadDirectory(targetPath: string | vscode.Uri): Promise<strin
 }
 
 const utilsMock = {
-    checkIfFileExists: fakeCheckIfFileOrDirectoryExists,
-    checkIfDirectoryExists: fakeCheckIfFileOrDirectoryExists,
+    checkIfFileExists: fakeCheckIfFileExists,
+    checkIfDirectoryExists: fakeCheckIfDirectoryExists,
     readDirectory: fakeReadDirectory,
     stripQuotePair: stripQuotePair
 };
@@ -467,12 +477,10 @@ if (process.platform === "win32") {
                 isOS64Bit: true,
                 isProcess64Bit: true,
             },
-            environmentVars: {},
-            // Note that for each given path, we expect:
-            // 1. The path as-is.
-            // 2. Any expected permutations of the path (for example, with a tilde or folder expanded, and/or '.exe' added).
-            // 3. The path as-is again (in order for a warning to be displayed at the correct time).
-            // An improvement here would be to check the suppressWarning field, but it's not currently exposed.
+            environmentVars: {
+                "USERNAME": "test",
+                "USERPROFILE": "C:\\Users\\test",
+            },
             expectedPowerShellSequence: [
                 {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
@@ -480,48 +488,13 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
-                    displayName: "pwsh",
-                    supportsProperArguments: true
-                },
-                {
                     exePath: path.join(os.homedir(), "pwsh", "pwsh.exe"),
                     displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: path.join(os.homedir(), "pwsh", "pwsh.exe"),
-                    displayName: "pwsh-tilde",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh",
-                    displayName: "pwsh-no-exe",
-                    supportsProperArguments: true
-                },
-                {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
                     displayName: "pwsh-no-exe",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh\\pwsh.exe",
-                    displayName: "pwsh-no-exe",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh\\powershell.exe",
-                    displayName: "pwsh-no-exe",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh",
-                    displayName: "pwsh-no-exe",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\",
-                    displayName: "pwsh-folder",
                     supportsProperArguments: true
                 },
                 {
@@ -530,53 +503,13 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "C:\\Users\\test\\pwsh\\powershell.exe",
-                    displayName: "pwsh-folder",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\",
-                    displayName: "pwsh-folder",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh.exe",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\powershell.exe",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh",
                     displayName: "pwsh-folder-no-slash",
                     supportsProperArguments: true
                 },
                 {
                     exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
                     displayName: "pwsh-single-quotes",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
-                    displayName: "pwsh-single-quotes",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "C:\\Users\\test\\pwsh\\pwsh.exe",
-                    displayName: "pwsh-double-quotes",
                     supportsProperArguments: true
                 },
                 {
@@ -585,7 +518,14 @@ if (process.platform === "win32") {
                     supportsProperArguments: true
                 },
             ],
-            filesystem: {},
+            filesystem: {
+                "C:\\Users\\test\\pwsh": {
+                    "pwsh.exe": "",
+                },
+                [path.join(os.homedir(), "pwsh")]: {
+                    "pwsh.exe": "",
+                }
+            },
         }
     ];
 } else {
@@ -693,7 +633,7 @@ if (process.platform === "win32") {
             ],
             filesystem: {
                 "/usr/bin": {
-                    pwsh: "",
+                    "pwsh": "",
                 },
             },
         },
@@ -714,7 +654,7 @@ if (process.platform === "win32") {
             ],
             filesystem: {
                 "/snap/bin": {
-                    pwsh: "",
+                    "pwsh": "",
                 },
             },
         },
@@ -735,7 +675,7 @@ if (process.platform === "win32") {
             ],
             filesystem: {
                 "/usr/local/bin": {
-                    pwsh: "",
+                    "pwsh": "",
                 },
             },
         },
@@ -759,7 +699,7 @@ if (process.platform === "win32") {
             ],
             filesystem: {
                 "/Users/test/.dotnet/tools": {
-                    pwsh: "",
+                    "pwsh": "",
                 },
             },
         },
@@ -783,108 +723,74 @@ if (process.platform === "win32") {
             ],
             filesystem: {
                 "/home/test/.dotnet/tools": {
-                    pwsh: "",
+                    "pwsh": "",
                 },
             },
         },
     ];
 
     additionalPowerShellExes = {
-        "pwsh": "/home/bin/pwsh",
+        "pwsh": "/home/test/bin/pwsh",
         "pwsh-tilde": "~/bin/pwsh",
-        "pwsh-folder": "/home/bin/",
-        "pwsh-folder-no-slash": "/home/bin",
-        "pwsh-single-quotes": "'/home/bin/pwsh'",
-        "pwsh-double-quotes": "\"/home/bin/pwsh\"",
+        "pwsh-folder": "/home/test/bin/",
+        "pwsh-folder-no-slash": "/home/test/bin",
+        "pwsh-single-quotes": "'/home/test/bin/pwsh'",
+        "pwsh-double-quotes": "\"/home/test/bin/pwsh\"",
     };
 
     successAdditionalTestCases = [
-        {   // Also sufficient for macOS as the behavior is the same
+        {
             name: "Linux/macOS (Additional PowerShell Executables)",
             platformDetails: {
                 operatingSystem: platform.OperatingSystem.Linux,
                 isOS64Bit: true,
                 isProcess64Bit: true,
             },
-            environmentVars: {},
-            // Note that for each given path, we expect:
-            // 1. The path as-is.
-            // 2. Any expected permutations of the path (for example, with a tilde or folder expanded).
-            // 3. The path as-is again (in order for a warning to be displayed at the correct time).
-            // An improvement here would be to check the suppressWarning field, but it's not currently exposed.
+            environmentVars: {
+                "USER": "test",
+                "HOME": "/home/test",
+            },
             expectedPowerShellSequence: [
                 {
-                    exePath: "/home/bin/pwsh",
+                    exePath: "/home/test/bin/pwsh",
                     displayName: "pwsh",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "/home/bin/pwsh",
-                    displayName: "pwsh",
-                    supportsProperArguments: true
-                },
-                {
+                    // untildify ignores the HOME mock so this is platform-dependent
                     exePath: path.join(os.homedir(), "bin", "pwsh"),
                     displayName: "pwsh-tilde",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: path.join(os.homedir(), "bin", "pwsh"),
-                    displayName: "pwsh-tilde",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin/",
+                    exePath: "/home/test/bin/pwsh",
                     displayName: "pwsh-folder",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "/home/bin/pwsh",
-                    displayName: "pwsh-folder",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin/",
-                    displayName: "pwsh-folder",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin",
+                    exePath: "/home/test/bin/pwsh",
                     displayName: "pwsh-folder-no-slash",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "/home/bin/pwsh",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin",
-                    displayName: "pwsh-folder-no-slash",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin/pwsh",
+                    exePath: "/home/test/bin/pwsh",
                     displayName: "pwsh-single-quotes",
                     supportsProperArguments: true
                 },
                 {
-                    exePath: "/home/bin/pwsh",
-                    displayName: "pwsh-single-quotes",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin/pwsh",
-                    displayName: "pwsh-double-quotes",
-                    supportsProperArguments: true
-                },
-                {
-                    exePath: "/home/bin/pwsh",
+                    exePath: "/home/test/bin/pwsh",
                     displayName: "pwsh-double-quotes",
                     supportsProperArguments: true
                 },
             ],
-            filesystem: {},
+            filesystem: {
+                "/home/test/bin": {
+                    "pwsh": "",
+                },
+                [path.join(os.homedir(), "bin")]: {
+                    "pwsh": "",
+                }
+            },
         }
     ];
 }
@@ -1099,13 +1005,13 @@ describe("Platform module", function () {
         });
 
         for (const testPlatform of successAdditionalTestCases) {
-            it(`Guesses for ${testPlatform.name}`, function () {
+            it(`Guesses for ${testPlatform.name}`, async function () {
                 setupTestEnvironment(testPlatform);
 
                 const powerShellExeFinder = new platformMock.PowerShellExeFinder(testPlatform.platformDetails, additionalPowerShellExes);
 
                 let i = 0;
-                for (const additionalPwsh of powerShellExeFinder.enumerateAdditionalPowerShellInstallations()) {
+                for await (const additionalPwsh of powerShellExeFinder.enumerateAdditionalPowerShellInstallations()) {
                     const expectedPowerShell = testPlatform.expectedPowerShellSequence[i];
                     i++;
 


### PR DESCRIPTION
Since Show Session Menu always fully enumerates the iterator we needed to move the existence check into the generator. Fortunately the 'exists' method was already idempotent. I'd like this to be cleaner, but at least the tests now make sense (and required a stub fix).

This is a follow up to #5099 after further testing.

@JustinGrote can you think of a way to simplify this logic?