### PR TITLE
Fix for "Suppress PSScriptAnalyzer Rule" snippets

### DIFF
--- a/snippets/PowerShell.json
+++ b/snippets/PowerShell.json
@@ -268,8 +268,9 @@
     "description": "Suppress a PSScriptAnalyzer rule for a function. More: https://docs.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#suppressing-rules",
     "body": [
       "[Diagnostics.CodeAnalysis.SuppressMessageAttribute(",
-      "\t<#Category#>'${1:PSProvideDefaultParameterValue}', <#CheckId>\\$null, Scope='Function',",
-      "\tJustification = '${0:${TM_SELECTED_TEXT:Reason for suppressing}}'",
+      "\t<#Category#>'${1:PSProvideDefaultParameterValue}', <#CheckId#>\\$null,",
+      "\tScope='Function',",
+      "\tJustification='${0:${TM_SELECTED_TEXT:Reason for suppressing}}'",
       ")]"
     ]
   },
@@ -522,9 +523,10 @@
     ],
     "description": "Suppress a PSScriptAnalyzer rule on a parameter. More: https://docs.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#suppressing-rules",
     "body": [
-      "[Diagnostics.CodeAnalysis.SuppressMessageAttribute(<#Category#>'${1:PSUseDeclaredVarsMoreThanAssignments}',",
-      "\t<#ParameterName#>'${0:${TM_SELECTED_TEXT:ParamName}}',",
-      "\tJustification = '${0:${TM_SELECTED_TEXT:Reason for suppressing}}'",
+      "[Diagnostics.CodeAnalysis.SuppressMessageAttribute(",
+      "\t<#Category#>'${1:PSUseDeclaredVarsMoreThanAssignments}',",
+      "\t<#ParameterName#>'${2:${TM_SELECTED_TEXT:ParamName}}',",
+      "\tJustification='${0:Reason for suppressing}'",
       ")]"
     ]
   },
@@ -566,13 +568,17 @@
     ]
   },
   "Scope: Suppress PSScriptAnalyzer Rule": {
-    "prefix": "suppress-message-rule-scope",
+    "prefix": [
+      "suppress-message-rule-scope",
+      "[SuppressMessageAttribute]"
+    ],
     "description": "Suppress a PSScriptAnalyzer rule based on a function/parameter/class/variable/object's name by setting the SuppressMessageAttribute's Target property to a regular expression or a glob pattern. More: https://docs.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/overview?view=ps-modules#suppressing-rules",
     "body": [
       "[Diagnostics.CodeAnalysis.SuppressMessageAttribute(",
-      "\t<#Category#>'${1:PSUseDeclaredVarsMoreThanAssignments}', <#CheckId#>\\$null, Scope='Function',",
-      "\tTarget='${1:${TM_SELECTED_TEXT:RegexOrGlobPatternToMatchName}}'",
-      "\tJustification = '${0:Reason for suppressing}}'",
+      "\t<#Category#>'${1:PSUseDeclaredVarsMoreThanAssignments}', <#CheckId#>\\$null,",
+      "\tScope='${2|Function,Parameter,Class,Variable,Object|}',",
+      "\tTarget='${3:${TM_SELECTED_TEXT:RegexOrGlobPatternToMatchName}}',",
+      "\tJustification='${0:Reason for suppressing}'",
       ")]"
     ]
   },


### PR DESCRIPTION
Fixes #5108. Also my first PR, so hopefully everything checks out!

## PR Summary

- Corrects a missing close comment in the Function rule snippet
- Corrects the tab stop numbering in the Parameter rule snippet as well as duplicate use of `$TM_SELECTED_TEXT`
- Adds a missing comma in The Scope rule snippet
- Minor formatting

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- `NA` PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
