### PR TITLE
v2025.0.0: New Year Update!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # PowerShell Extension Release History
 
+## v2025.0.0
+### Tuesday, January 21, 2025
+
+With PowerShell Editor Services [v4.2.0](https://github.com/PowerShell/PowerShellEditorServices/releases/tag/v4.2.0)!
+
+New Year Update!
+
+PowerShell 7.4+ and Windows PowerShell 5.1 (on a best-effort basis)
+are now solely supported as 7.3 LTS and 7.2 are past end-of-support.
+
+A major bug due to a Global Assembly Cache conflict with Serilog
+when using Windows PowerShell has been resolved by removing the
+troublesome dependency. This also came with a wonderful logging
+overhaul for both the server and client. Thanks Justin!
+
+Dependencies and VS Code engine have been updated. Snippets fixed.
+Extension settings are now categorized. Additional PowerShell
+executable path verification fixed.
+
+See more details at the GitHub Release for [v2025.0.0](https://github.com/PowerShell/vscode-powershell/releases/tag/v2025.0.0).
+
 ## v2025.1.0-preview
 ### Thursday, January 16, 2025
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "powershell",
   "displayName": "PowerShell",
-  "version": "2025.1.0",
+  "version": "2025.0.0",
   "preview": false,
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",


### PR DESCRIPTION
PowerShell 7.4+ and Windows PowerShell 5.1 (on a best-effort basis) are now soley supported as 7.3 LTS and 7.2 are past end-of-support.

A major bug due to a Global Assembly Cache conflict with Serilog when using Windows PowerShell has been resolved by removing the troublesome dependency. This also came with a wonderful logging overhaul for both the server and client. Thanks Justin!

Dependencies and VS Code engine have been updated. Snippets fixed. Extension settings are now categorized. Additional PowerShell executable path verification fixed.