### PR TITLE
Fix tests on OneBranch

### DIFF
--- a/.pipelines/vscode-powershell-Official.yml
+++ b/.pipelines/vscode-powershell-Official.yml
@@ -109,8 +109,8 @@ extends:
                 displayName: PowerShellEditorServices version
               - pwsh: ./tools/installPSResources.ps1 -PSRepository CFS
                 displayName: Install PSResources
-              - pwsh: Invoke-Build Build -Configuration $(BuildConfiguration)
-                displayName: Build
+              - pwsh: Invoke-Build Test -Configuration $(BuildConfiguration)
+                displayName: Build and test
               - task: onebranch.pipeline.signing@1
                 displayName: Sign 1st-party example PowerShell files
                 inputs:
@@ -132,50 +132,6 @@ extends:
                   search_root: $(Build.SourcesDirectory)/out
                   files_to_sign: |
                     *.signature.p7s;
-          - job: test
-            displayName: Build and run tests
-            pool:
-              type: windows
-              isCustom: true
-              name: Azure Pipelines
-              vmImage: windows-latest
-            variables:
-              ob_outputDirectory: $(Build.SourcesDirectory)/out
-              skipComponentGovernanceDetection: true
-            steps:
-              - task: UseNode@1
-                displayName: Use Node 20.x
-                inputs:
-                  version: 20.x
-              - task: UseDotNet@2
-                displayName: Use .NET 8.x SDK
-                inputs:
-                  packageType: sdk
-                  version: 8.x
-              - task: DownloadPipelineArtifact@2
-                displayName: Download PowerShellEditorServices
-                inputs:
-                  source: specific
-                  project: PowerShellCore
-                  definition: 2905
-                  specificBuildWithTriggering: true
-                  allowPartiallySucceededBuilds: true
-                  buildVersionToDownload: latestFromBranch
-                  branchName: refs/heads/main
-                  artifact: drop_build_main
-              - task: ExtractFiles@1
-                displayName: Extract PowerShellEditorServices
-                inputs:
-                  archiveFilePatterns: $(Pipeline.Workspace)/PowerShellEditorServices.zip
-                  destinationFolder: $(Build.SourcesDirectory)/modules
-              - pwsh: |
-                  $manifest = Test-ModuleManifest $(Build.SourcesDirectory)/modules/PowerShellEditorServices/PowerShellEditorServices.psd1
-                  Write-Host Using PowerShellEditorServices v$($manifest.Version)
-                displayName: PowerShellEditorServices version
-              - pwsh: ./tools/installPSResources.ps1 -PSRepository CFS
-                displayName: Install PSResources
-              - pwsh: Invoke-Build Test -Configuration $(BuildConfiguration)
-                displayName: Run tests
       - stage: release
         dependsOn: build
         condition: eq(variables['Build.Reason'], 'Manual')

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,20 +1,20 @@
 import { defineConfig } from "@vscode/test-cli";
-import os from "os";
-import path from "path";
 
 export default defineConfig({
     files: "test/**/*.test.ts",
-    // The default user data directory had too many characters for the IPC connection on macOS in CI.
+    // It may break CI but we'll know sooner rather than later
+    version: "insiders",
     launchArgs: [
+        // Other extensions are unnecessary while testing
+        "--disable-extensions",
+        // Undocumented but valid option to use a temporary profile for testing
         "--profile-temp",
-        "--user-data-dir",
-        path.join(os.tmpdir(), "vscode-user-data"),
     ],
     workspaceFolder: "test/TestEnvironment.code-workspace",
     mocha: {
         ui: "bdd", // describe, it, etc.
         require: ["esbuild-register"], // transpile TypeScript on-the-fly
-        slow: 2000, // 2 seconds for slow test
-        timeout: 60 * 1000, // 10 minutes to allow for debugging
+        slow: 2 * 1000, // 2 seconds for slow test
+        timeout: 2 * 60 * 1000, // 2 minutes to allow for debugging
     },
 });

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from "@vscode/test-cli";
+import { existsSync } from "fs";
 
 export default defineConfig({
     files: "test/**/*.test.ts",
@@ -10,7 +11,7 @@ export default defineConfig({
         // Undocumented but valid option to use a temporary profile for testing
         "--profile-temp",
     ],
-    workspaceFolder: "test/TestEnvironment.code-workspace",
+    workspaceFolder: `test/${existsSync("C:\\powershell-7\\pwsh.exe") ? "OneBranch" : "TestEnvironment"}.code-workspace`,
     mocha: {
         ui: "bdd", // describe, it, etc.
         require: ["esbuild-register"], // transpile TypeScript on-the-fly

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { LanguageClientConsumer } from "./languageClientConsumer";
 import { Logger } from "./logging";
 import { SessionManager } from "./session";
 import { getSettings } from "./settings";
-import { PowerShellLanguageId } from "./utils";
+import { PowerShellLanguageId, sleep } from "./utils";
 // The 1DS telemetry key, which is just shared among all Microsoft extensions
 // (and isn't sensitive).
 const TELEMETRY_KEY =
@@ -257,7 +257,7 @@ function registerWaitForPsesActivationCommand(
                     return pidContent.toString();
                 } catch {
                     // File doesn't exist yet, wait and try again
-                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    await sleep(200);
                 }
             }
         },

--- a/src/process.ts
+++ b/src/process.ts
@@ -315,7 +315,7 @@ export class PowerShellProcess {
             }
 
             // Wait a bit and try again.
-            await utils.sleep(1000);
+            await utils.sleep(200);
         }
 
         this.logger.writeError("Timed out waiting for session file!");

--- a/src/session.ts
+++ b/src/session.ts
@@ -319,7 +319,7 @@ export class SessionManager implements Middleware {
         try {
             // If the stop fails, so will the dispose, I think this is a bug in
             // the client library.
-            await this.languageClient?.stop(3000);
+            await this.languageClient?.stop(2000);
             await this.languageClient?.dispose();
         } catch (err) {
             this.logger.writeError(
@@ -491,7 +491,7 @@ export class SessionManager implements Middleware {
 
     public async waitUntilStarted(): Promise<void> {
         while (this.sessionStatus !== SessionStatus.Running) {
-            await utils.sleep(300);
+            await utils.sleep(200);
         }
     }
 
@@ -1180,13 +1180,13 @@ Type 'help' to get help.
             ) {
                 return;
             }
-            await utils.sleep(300);
+            await utils.sleep(200);
         }
     }
 
     private async waitWhileStopping(): Promise<void> {
         while (this.sessionStatus === SessionStatus.Stopping) {
-            await utils.sleep(300);
+            await utils.sleep(200);
         }
     }
 

--- a/test/OneBranch.code-workspace
+++ b/test/OneBranch.code-workspace
@@ -1,0 +1,18 @@
+{
+  // A simple test environment that suppresses some first start warnings we don't care about.
+  "folders": [
+    {
+      "path": "mocks",
+    },
+  ],
+  "settings": {
+    "git.openRepositoryInParentFolders": "never",
+    "csharp.suppressDotnetRestoreNotification": true,
+    "extensions.ignoreRecommendations": true,
+    // The settings tests account for this fix
+    "powershell.powerShellAdditionalExePaths": {
+      "OneBranch": "C:\\powershell-7\\pwsh.exe",
+    },
+    "powershell.powerShellDefaultVersion": "OneBranch",
+  },
+}

--- a/test/core/settings.test.ts
+++ b/test/core/settings.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import * as assert from "assert";
+import { existsSync } from "fs";
 import * as os from "os";
 import path from "path";
 import * as vscode from "vscode";
@@ -38,6 +39,12 @@ describe("Settings E2E", function () {
 
         it("Loads the correct defaults", function () {
             const testSettings = new Settings();
+            if (existsSync("C:\\powershell-7\\pwsh.exe")) {
+                testSettings.powerShellAdditionalExePaths = {
+                    OneBranch: "C:\\powershell-7\\pwsh.exe",
+                };
+                testSettings.powerShellDefaultVersion = "OneBranch";
+            }
             const actualSettings = getSettings();
             assert.deepStrictEqual(actualSettings, testSettings);
         });

--- a/test/features/DebugSession.test.ts
+++ b/test/features/DebugSession.test.ts
@@ -656,8 +656,6 @@ describe("DebugSessionFeature", () => {
 });
 
 describe("DebugSessionFeature E2E", function () {
-    // E2E tests can take a while to run since the debugger has to start up and attach
-    this.slow(20000);
     before(async () => {
         // Registers and warms up the debug adapter and the PowerShell Extension Terminal
         await ensureEditorServicesIsConnected();

--- a/test/features/ISECompatibility.test.ts
+++ b/test/features/ISECompatibility.test.ts
@@ -94,8 +94,6 @@ describe("ISE compatibility feature", function () {
     });
 
     describe("Color theme interactions", function () {
-        // These tests are slow because they change the user's theme.
-        this.slow(3000);
         beforeEach(enableISEMode);
 
         function assertISESettings(): void {


### PR DESCRIPTION
This cleans up our sleeps and our unit test settings plus handles the edge case of OneBranch's non-default PowerShell installation, allowing us to cut an entire stage out of the build.