### PR TITLE
Bump to Node 22.15.1 and remove `node-fetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.9",
-        "node-fetch": "^2.7.0",
         "semver": "^7.7.2",
         "untildify": "^4.0.0",
         "uuid": "^9.0.1",
@@ -22,18 +21,17 @@
         "esbuild": "^0.25.6"
       },
       "engines": {
-        "vscode": "^1.96.0"
+        "vscode": "^1.101.0"
       },
       "optionalDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/mock-fs": "^4.13.4",
-        "@types/node": "^20.19.6",
-        "@types/node-fetch": "^2.6.12",
+        "@types/node": "^22.15.1",
         "@types/semver": "^7.7.0",
         "@types/sinon": "^17.0.4",
         "@types/ungap__structured-clone": "^1.2.0",
         "@types/uuid": "^9.0.8",
-        "@types/vscode": "~1.96.0",
+        "@types/vscode": "~1.101.0",
         "@ungap/structured-clone": "^1.3.0",
         "@vscode/debugprotocol": "^1.68.0",
         "@vscode/test-cli": "^0.0.10",
@@ -1518,22 +1516,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.6",
-      "integrity": "sha1-zwu3F3a7Bh5wC23mjg5TG1Vw9q4=",
+      "version": "22.16.5",
+      "integrity": "sha1-zEasOZTNlXAA0MEQlaCx2uLqI2g=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "integrity": "sha1-irXD74Mw8TEAp0eeLNVtM4aDCgM=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -1582,8 +1570,8 @@
       "optional": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.96.0",
-      "integrity": "sha1-MYEAS/JdcWd65KrN12BaP9ft8I4=",
+      "version": "1.101.0",
+      "integrity": "sha1-BiLKJuoVqvvlcNxNJZF8dcr+V4o=",
       "license": "MIT",
       "optional": true
     },
@@ -2297,7 +2285,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/azure-devops-node-api": {
@@ -2511,7 +2499,7 @@
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "integrity": "sha1-S1QowiK+mF15w9gmV0edvgtZstY=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2768,7 +2756,7 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2950,7 +2938,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -3033,7 +3021,7 @@
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "integrity": "sha1-165mfh3INIL4tw/Q9u78UNow9Yo=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3143,7 +3131,7 @@
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "integrity": "sha1-mD6y+aZyTpMD9hrd8BHHLgngsPo=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3152,7 +3140,7 @@
     "node_modules/es-errors": {
       "version": "1.3.0",
       "integrity": "sha1-BfdaJdq5jk+x3NXhRywFRtUFfI8=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3161,7 +3149,7 @@
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "integrity": "sha1-HE8sSDcydZfOadLKGQp/3RcjOME=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3173,7 +3161,7 @@
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "integrity": "sha1-8x274MGDsAptJutjJcgQwP0YvU0=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3653,9 +3641,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "integrity": "sha1-YIsbPz4ovg/M9ZAfyF+zZB5c8K4=",
-      "devOptional": true,
+      "version": "4.0.4",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -3711,7 +3699,7 @@
     "node_modules/function-bind": {
       "version": "1.1.2",
       "integrity": "sha1-LALYZNl/PqbIgwxGTL0Rq26rehw=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3741,7 +3729,7 @@
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "integrity": "sha1-dD8OO2lkqTpUke0b/6rgVNf5jQE=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3765,7 +3753,7 @@
     "node_modules/get-proto": {
       "version": "1.0.1",
       "integrity": "sha1-FQs/J0OGnvPoUewMSdFbHRTQDuE=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3858,7 +3846,7 @@
     "node_modules/gopd": {
       "version": "1.2.0",
       "integrity": "sha1-ifVrghe9vIgCvSmd9tfxCB1+UaE=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3891,7 +3879,7 @@
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "integrity": "sha1-/JxqeDoISVHQuXH+EBjegTcHozg=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3903,7 +3891,7 @@
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "integrity": "sha1-LNxC1AvvLltO6rfAGnPFTOerWrw=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3918,7 +3906,7 @@
     "node_modules/hasown": {
       "version": "2.0.2",
       "integrity": "sha1-AD6vkb563DcuhOxZ3DclLO24AAM=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4682,7 +4670,7 @@
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "integrity": "sha1-oN10voHiqlwvJ+Zc4oNgXuTit/k=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4731,7 +4719,7 @@
     "node_modules/mime-db": {
       "version": "1.52.0",
       "integrity": "sha1-u6vNwChZ9JhzAchW4zh85exDv3A=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4740,7 +4728,7 @@
     "node_modules/mime-types": {
       "version": "2.1.35",
       "integrity": "sha1-OBqHG2KnNEUGYK497uRIE/cNlZo=",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -5056,25 +5044,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "integrity": "sha1-0PD6bj4twdJ+/NitmdVQvalNGH0=",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
     },
     "node_modules/node-sarif-builder": {
       "version": "3.2.0",
@@ -6668,11 +6637,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "integrity": "sha1-WV9wlORu7TZME/0j51+VE9Kbr5E=",
@@ -6962,11 +6926,6 @@
       "integrity": "sha1-MnNnbwzy6rQLP0TQhay7fwijnYo=",
       "license": "MIT"
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "integrity": "sha1-0PTvdpkF1CbhaI8+NDgambYLduU=",
@@ -6986,15 +6945,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@vscode/vsce": "^3.6.0",
-        "esbuild": "^0.25.6"
+        "esbuild": "^0.25.8"
       },
       "engines": {
         "vscode": "^1.101.0"
@@ -26,7 +26,7 @@
       "optionalDependencies": {
         "@eslint/js": "^9.26.0",
         "@types/mock-fs": "^4.13.4",
-        "@types/node": "^22.15.1",
+        "@types/node": "^22.16.5",
         "@types/semver": "^7.7.0",
         "@types/sinon": "^17.0.4",
         "@types/ungap__structured-clone": "^1.2.0",
@@ -37,14 +37,14 @@
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.5.2",
         "esbuild-register": "^3.6.0",
-        "eslint": "^9.30.1",
-        "eslint-config-prettier": "^10.1.5",
+        "eslint": "^9.31.0",
+        "eslint-config-prettier": "^10.1.8",
         "mock-fs": "^5.5.0",
         "prettier": "^3.6.2",
-        "prettier-plugin-organize-imports": "^4.1.0",
+        "prettier-plugin-organize-imports": "^4.2.0",
         "sinon": "^19.0.5",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.36.0"
+        "typescript-eslint": "^8.38.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -75,8 +75,8 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.9.0",
-      "integrity": "sha1-rHJbA/q+PIkjcQZe6eIEG+4P0aw=",
+      "version": "1.10.0",
+      "integrity": "sha1-aNunA2CA4dnVaZxOSCFKt5b6c60=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -85,12 +85,12 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.9.4",
-      "integrity": "sha1-u5u4Xtx4D8ZWMLbY/6Fyw2M8qP4=",
+      "version": "1.10.0",
+      "integrity": "sha1-n07JyJpjUWknhArmIMYOgRoLVKM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -103,12 +103,12 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.21.0",
-      "integrity": "sha1-ZaNgDanztjXlmq3Ap1ISt4Fbx7U=",
+      "version": "1.22.0",
+      "integrity": "sha1-duRKdQk6L0d/xUuE9GBJ3CzmWAA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -117,37 +117,37 @@
         "@azure/core-tracing": "^1.0.1",
         "@azure/core-util": "^1.11.0",
         "@azure/logger": "^1.0.0",
-        "@typespec/ts-http-runtime": "^0.2.3",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.2.0",
-      "integrity": "sha1-e+XVPDUi1jnPGQQsvNsZ9xvDWrI=",
+      "version": "1.3.0",
+      "integrity": "sha1-NBFT9bKSdTnriYV3ZR7kjOmN2iU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.12.0",
-      "integrity": "sha1-C4woN+bWfD+66uIN80zwf2azSA0=",
+      "version": "1.13.0",
+      "integrity": "sha1-/Cg0/FHh4rt0twwoS0D4JNhnQio=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
-        "@typespec/ts-http-runtime": "^0.2.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -173,33 +173,33 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.2.0",
-      "integrity": "sha1-p5rvzdV9KpZgP6tZyaZuDZAipWQ=",
+      "version": "1.3.0",
+      "integrity": "sha1-VQHPhdT1JjBgKozHXfdlaMlpqCc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typespec/ts-http-runtime": "^0.2.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.15.0",
-      "integrity": "sha1-BZ0nASdVDCUCoNBgkKvADCx4Iu8=",
+      "version": "4.16.0",
+      "integrity": "sha1-FbFWf2hz9ksNQ2ti8QaM4B/H8JA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.8.1"
+        "@azure/msal-common": "15.9.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.8.1",
-      "integrity": "sha1-JxDw/55LE0fITaHCaFchPHUw12w=",
+      "version": "15.9.0",
+      "integrity": "sha1-SbYqeY3RtHtBDm5UD9NgCfHU0Y4=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -207,12 +207,12 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.6.3",
-      "integrity": "sha1-0HzuQE0HGFCkZX6G4HtDwXNPl/g=",
+      "version": "3.6.4",
+      "integrity": "sha1-k38ON+c9SN+2irjzpQOgzyGmUoU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.8.1",
+        "@azure/msal-common": "15.9.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -259,8 +259,8 @@
       "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.6",
-      "integrity": "sha1-FksZEi4u1U+FRp353qmN2wHV554=",
+      "version": "0.25.8",
+      "integrity": "sha1-oUFJA7s4AnOC+F8D3aYGUFZ1dyc=",
       "cpu": [
         "ppc64"
       ],
@@ -274,8 +274,8 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.6",
-      "integrity": "sha1-TOsPQBE+mGEWm+g+KmcMJg3SNP8=",
+      "version": "0.25.8",
+      "integrity": "sha1-lqjyypHGzSnqkLGvedg3Yci6AFk=",
       "cpu": [
         "arm"
       ],
@@ -289,8 +289,8 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-j1Oefe+Ej3ZPZDJZjlHMOCD946U=",
+      "version": "0.25.8",
+      "integrity": "sha1-yFmZQInpdnIkJpiEBh+J2ub7UcY=",
       "cpu": [
         "arm64"
       ],
@@ -304,8 +304,8 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-rU8oAFdiLCX+mFwImZRDoZXcY6g=",
+      "version": "0.25.8",
+      "integrity": "sha1-o6YmxP7EoCSp+ox2ecOZlukpFvA=",
       "cpu": [
         "x64"
       ],
@@ -319,8 +319,8 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-0fBAJzlrPWr8lrrNDRMWff2fAfc=",
+      "version": "0.25.8",
+      "integrity": "sha1-peElLKKYPVZq8cDqOa3tZXNvxm0=",
       "cpu": [
         "arm64"
       ],
@@ -334,8 +334,8 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-K0ps7beZ9jV1jXgy11sjdyyO9o8=",
+      "version": "0.25.8",
+      "integrity": "sha1-UnGw3yuxLOjfiGcEv90cfMAThdI=",
       "cpu": [
         "x64"
       ],
@@ -349,8 +349,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-omJmzJfdeNw8Pz1niLG4NpexBV0=",
+      "version": "0.25.8",
+      "integrity": "sha1-0KDn/fGXM7i7FWa4HfGqC7fkato=",
       "cpu": [
         "arm64"
       ],
@@ -364,8 +364,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-n+uOgmc1xWjr/ZSFmyKj+7apvdI=",
+      "version": "0.25.8",
+      "integrity": "sha1-Leiy4ImdCPHLHvMSjhWWFufoU0M=",
       "cpu": [
         "x64"
       ],
@@ -379,8 +379,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.6",
-      "integrity": "sha1-1uLNjvMZZGgGXUHxP6KmGqpyZEo=",
+      "version": "0.25.8",
+      "integrity": "sha1-zNnikcJM2NkULYGdRj4ucgDSWxk=",
       "cpu": [
         "arm"
       ],
@@ -394,8 +394,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-wHy+2OJJ9MKOfzJ4HTb8RpUpPSg=",
+      "version": "0.25.8",
+      "integrity": "sha1-pCCe+twMKXVxZFhISk6QwjfEiuk=",
       "cpu": [
         "arm64"
       ],
@@ -409,8 +409,8 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.6",
-      "integrity": "sha1-Pmgr1HxO3cxLjxOT38giJILxeZc=",
+      "version": "0.25.8",
+      "integrity": "sha1-AGrRU20MKyj7OhzwtTvLhar5LE0=",
       "cpu": [
         "ia32"
       ],
@@ -424,8 +424,8 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.6",
-      "integrity": "sha1-Rz9eouUjmcCK1M1rEubbzd1jDwU=",
+      "version": "0.25.8",
+      "integrity": "sha1-Ens/v7LC4IsTl+mFky9xjwmo9cQ=",
       "cpu": [
         "loong64"
       ],
@@ -439,8 +439,8 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.6",
-      "integrity": "sha1-mWBjHJ/WFgWwk5wZBDrPTvK1Fxg=",
+      "version": "0.25.8",
+      "integrity": "sha1-g30USVF3keP6fYJnWi0G2fVss0A=",
       "cpu": [
         "mips64el"
       ],
@@ -454,8 +454,8 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.6",
-      "integrity": "sha1-R3y/i7BKoDS5TzYsMshrXDHbjT4=",
+      "version": "0.25.8",
+      "integrity": "sha1-qi472Tq43whCEvGJXKSwPELZ4P4=",
       "cpu": [
         "ppc64"
       ],
@@ -469,8 +469,8 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.6",
-      "integrity": "sha1-vNtGyPuOk6p3npoKYs1KwA3KxiY=",
+      "version": "0.25.8",
+      "integrity": "sha1-o0BiDjEJP+9ydn3SirBCFLNEIIM=",
       "cpu": [
         "riscv64"
       ],
@@ -484,8 +484,8 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.6",
-      "integrity": "sha1-9BLPX98K6oSf9Rxz/YF8bAI01G0=",
+      "version": "0.25.8",
+      "integrity": "sha1-3f7SZsjBP177MQWgzUf23NDnnnE=",
       "cpu": [
         "s390x"
       ],
@@ -499,8 +499,8 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-2CM8CbXrwMhVcS3F7rg1o6M0EQg=",
+      "version": "0.25.8",
+      "integrity": "sha1-mk94x1wFHowGAYPrs5omm6k2oqw=",
       "cpu": [
         "x64"
       ],
@@ -514,8 +514,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-9Rro3RR0Fy5zz5y6+KONHHLdjxo=",
+      "version": "0.25.8",
+      "integrity": "sha1-kCyA4dZ4BHkmOHIwvAN+Y+AGl9A=",
       "cpu": [
         "arm64"
       ],
@@ -529,8 +529,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-omdThgLA5QqFjPQdz+XYA2+NqOc=",
+      "version": "0.25.8",
+      "integrity": "sha1-LZ60aSrdJoH/BaFM6Z3lT77XB5w=",
       "cpu": [
         "x64"
       ],
@@ -544,8 +544,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-pRvmDEJbhcIWR5uMNErQURY18tI=",
+      "version": "0.25.8",
+      "integrity": "sha1-icO5mMbec52zirf7cainaz+oSkU=",
       "cpu": [
         "arm64"
       ],
@@ -559,8 +559,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-fkp0PHP3VWLikiO6adC+bJyQCNo=",
+      "version": "0.25.8",
+      "integrity": "sha1-LwFhXPRysOSMB3BFz9lrXBSTZcw=",
       "cpu": [
         "x64"
       ],
@@ -574,8 +574,8 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-IIelAo84eHkVTr9Eve36+hdoLls=",
+      "version": "0.25.8",
+      "integrity": "sha1-ogH3IM0sPr+aYDP8w/6waaVLUJo=",
       "cpu": [
         "arm64"
       ],
@@ -589,8 +589,8 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-VlMfhhcj6g3GKDoruINzBCI8tzY=",
+      "version": "0.25.8",
+      "integrity": "sha1-BwRsl3mFozNGZ/GearOgGoCGKvs=",
       "cpu": [
         "x64"
       ],
@@ -604,8 +604,8 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.6",
-      "integrity": "sha1-9JifAz3qxvrjI6z/WHZPqLwBQ24=",
+      "version": "0.25.8",
+      "integrity": "sha1-SlRwyvDRYSfAXUgz1JNCE8aTktE=",
       "cpu": [
         "arm64"
       ],
@@ -619,8 +619,8 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.6",
-      "integrity": "sha1-smDp33Hjk56zOSUHbTn2POx9FSU=",
+      "version": "0.25.8",
+      "integrity": "sha1-PePoRwt7Mo2Z28Pp7B6s4gflu8Q=",
       "cpu": [
         "ia32"
       ],
@@ -634,8 +634,8 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.6",
-      "integrity": "sha1-Qnbt1cEFvCixHGofdvudKdG9JcE=",
+      "version": "0.25.8",
+      "integrity": "sha1-YQ1+pTnS/Nvjkje1zBdessRFH5w=",
       "cpu": [
         "x64"
       ],
@@ -733,8 +733,8 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "integrity": "sha1-MmKJOAlo6vfpbzZOHkz4863y0AM=",
+      "version": "0.15.1",
+      "integrity": "sha1-1TDUQgnL/i+C74bWugh2AZbdO2A=",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -830,8 +830,8 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.1",
-      "integrity": "sha1-6+ndUqODRXhMSGMAF1ooxgE8CI0=",
+      "version": "9.31.0",
+      "integrity": "sha1-rbHzmVPYxHXEOEtntnVBsNcgbtg=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -851,25 +851,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "integrity": "sha1-MpJrWb1AfVjYF5QeSLKnBJNZsf0=",
+      "version": "0.3.4",
+      "integrity": "sha1-xrnxZelL9Nn91JPxwCipSq9fwcw=",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "integrity": "sha1-1TDUQgnL/i+C74bWugh2AZbdO2A=",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1190,26 +1178,26 @@
       }
     },
     "node_modules/@secretlint/config-creator": {
-      "version": "10.2.0",
-      "integrity": "sha1-X98pVw5c8bqlQ2d7PCyKkJMQUkQ=",
+      "version": "10.2.1",
+      "integrity": "sha1-hnyIdB+MsimIcIkZ5IAzDl+makQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/types": "^10.2.0"
+        "@secretlint/types": "^10.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@secretlint/config-loader": {
-      "version": "10.2.0",
-      "integrity": "sha1-dr/WmQthMiH5z+w+pWZl98hXUzs=",
+      "version": "10.2.1",
+      "integrity": "sha1-is/xW09SqVaeQDzvmf7ijTMAQao=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/profiler": "^10.2.0",
-        "@secretlint/resolver": "^10.2.0",
-        "@secretlint/types": "^10.2.0",
+        "@secretlint/profiler": "^10.2.1",
+        "@secretlint/resolver": "^10.2.1",
+        "@secretlint/types": "^10.2.1",
         "ajv": "^8.17.1",
         "debug": "^4.4.1",
         "rc-config-loader": "^4.1.3"
@@ -1219,13 +1207,13 @@
       }
     },
     "node_modules/@secretlint/core": {
-      "version": "10.2.0",
-      "integrity": "sha1-3byBlaKY/As0iGDwRxHsmCgemgs=",
+      "version": "10.2.1",
+      "integrity": "sha1-pycXT7/Xt/XY9jtGRwwUBbvoXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/profiler": "^10.2.0",
-        "@secretlint/types": "^10.2.0",
+        "@secretlint/profiler": "^10.2.1",
+        "@secretlint/types": "^10.2.1",
         "debug": "^4.4.1",
         "structured-source": "^4.0.0"
       },
@@ -1234,16 +1222,16 @@
       }
     },
     "node_modules/@secretlint/formatter": {
-      "version": "10.2.0",
-      "integrity": "sha1-NKTDYnpz8XjSPfbfwML4d4s2rIY=",
+      "version": "10.2.1",
+      "integrity": "sha1-oJ7QDbuRoXR23Dz4hTh3IrUiWIE=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/resolver": "^10.2.0",
-        "@secretlint/types": "^10.2.0",
-        "@textlint/linter-formatter": "^15.1.0",
-        "@textlint/module-interop": "^15.1.0",
-        "@textlint/types": "^15.1.0",
+        "@secretlint/resolver": "^10.2.1",
+        "@secretlint/types": "^10.2.1",
+        "@textlint/linter-formatter": "^15.2.0",
+        "@textlint/module-interop": "^15.2.0",
+        "@textlint/types": "^15.2.0",
         "chalk": "^5.4.1",
         "debug": "^4.4.1",
         "pluralize": "^8.0.0",
@@ -1268,17 +1256,17 @@
       }
     },
     "node_modules/@secretlint/node": {
-      "version": "10.2.0",
-      "integrity": "sha1-Rvv0eJwNQlmZcLSNS7hL+Xaq+xg=",
+      "version": "10.2.1",
+      "integrity": "sha1-T/CaJEUA7JxfnSpRK9BH67+py5c=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/config-loader": "^10.2.0",
-        "@secretlint/core": "^10.2.0",
-        "@secretlint/formatter": "^10.2.0",
-        "@secretlint/profiler": "^10.2.0",
-        "@secretlint/source-creator": "^10.2.0",
-        "@secretlint/types": "^10.2.0",
+        "@secretlint/config-loader": "^10.2.1",
+        "@secretlint/core": "^10.2.1",
+        "@secretlint/formatter": "^10.2.1",
+        "@secretlint/profiler": "^10.2.1",
+        "@secretlint/source-creator": "^10.2.1",
+        "@secretlint/types": "^10.2.1",
         "debug": "^4.4.1",
         "p-map": "^7.0.3"
       },
@@ -1287,20 +1275,20 @@
       }
     },
     "node_modules/@secretlint/profiler": {
-      "version": "10.2.0",
-      "integrity": "sha1-81+mpl61hC3XSZQXwFjwLoIY9H8=",
+      "version": "10.2.1",
+      "integrity": "sha1-61MsdUm2jGOd45l2DGVFKdgyflE=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@secretlint/resolver": {
-      "version": "10.2.0",
-      "integrity": "sha1-LDM1ekfb//nXvAj0KCgICqZDKxA=",
+      "version": "10.2.1",
+      "integrity": "sha1-UT4uSRbQn9lurY9wIICKU3N5TLg=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@secretlint/secretlint-formatter-sarif": {
-      "version": "10.2.0",
-      "integrity": "sha1-2QXAS2Xbz2IUbvDFguGqiw4WEPw=",
+      "version": "10.2.1",
+      "integrity": "sha1-Zed/UxORQEGzU60iFhM0GonVu4A=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1308,20 +1296,20 @@
       }
     },
     "node_modules/@secretlint/secretlint-rule-no-dotenv": {
-      "version": "10.2.0",
-      "integrity": "sha1-SkK4bvTsPmL7BEQktXIkHYtE5qk=",
+      "version": "10.2.1",
+      "integrity": "sha1-LCcr7s1sJittV0E8cv56rlfxs+s=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/types": "^10.2.0"
+        "@secretlint/types": "^10.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@secretlint/secretlint-rule-preset-recommend": {
-      "version": "10.2.0",
-      "integrity": "sha1-OYdEzJuCVrZBAIutkaDMhmnkBT4=",
+      "version": "10.2.1",
+      "integrity": "sha1-wA+9IlcyjskJ2kNDGCbN+3KaIYU=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1329,12 +1317,12 @@
       }
     },
     "node_modules/@secretlint/source-creator": {
-      "version": "10.2.0",
-      "integrity": "sha1-VCbLX9noEtNdlwccdauwAgmaGUs=",
+      "version": "10.2.1",
+      "integrity": "sha1-GxwcZNtncDTinBo9t43M1g2onTI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/types": "^10.2.0",
+        "@secretlint/types": "^10.2.1",
         "istextorbinary": "^9.5.0"
       },
       "engines": {
@@ -1342,8 +1330,8 @@
       }
     },
     "node_modules/@secretlint/types": {
-      "version": "10.2.0",
-      "integrity": "sha1-C81qd+QkhT1ISUYH5b5DIhUr1Rs=",
+      "version": "10.2.1",
+      "integrity": "sha1-AY8lKjdUqf8jcbPhMiJtKBvoUVs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1576,16 +1564,16 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.36.0",
-      "integrity": "sha1-iAzid/ijDM9TnsAnrKwVcIjxMa4=",
+      "version": "8.38.0",
+      "integrity": "sha1-blIg0W8mkattmDwXN91bNuF2Qbc=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.36.0",
-        "@typescript-eslint/type-utils": "8.36.0",
-        "@typescript-eslint/utils": "8.36.0",
-        "@typescript-eslint/visitor-keys": "8.36.0",
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/type-utils": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -1599,7 +1587,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.36.0",
+        "@typescript-eslint/parser": "^8.38.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -1614,15 +1602,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.36.0",
-      "integrity": "sha1-ADAH/iAwATk2tmNLnPUsRX027UI=",
+      "version": "8.38.0",
+      "integrity": "sha1-ZyOl6ogeF3eVaxBFy6ML5eqDgpM=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.36.0",
-        "@typescript-eslint/types": "8.36.0",
-        "@typescript-eslint/typescript-estree": "8.36.0",
-        "@typescript-eslint/visitor-keys": "8.36.0",
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1638,13 +1626,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.36.0",
-      "integrity": "sha1-DErNy+VkdqQ82rqsHwiBlCSjef0=",
+      "version": "8.38.0",
+      "integrity": "sha1-SQB3H5QxYwJ/19ICCgYokgVrXi8=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.36.0",
-        "@typescript-eslint/types": "^8.36.0",
+        "@typescript-eslint/tsconfig-utils": "^8.38.0",
+        "@typescript-eslint/types": "^8.38.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1659,13 +1647,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.36.0",
-      "integrity": "sha1-I+QZbtB9fqNzelhPvryaecODUWg=",
+      "version": "8.38.0",
+      "integrity": "sha1-Wg78tcnPbkEhtY+Hly9WfGlSkiY=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.36.0",
-        "@typescript-eslint/visitor-keys": "8.36.0"
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1676,8 +1664,8 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.36.0",
-      "integrity": "sha1-Y++KIK6bV1TGzqy+h7L+GqsSuhM=",
+      "version": "8.38.0",
+      "integrity": "sha1-beTOIkp3lgGo32Z9tWUnJVxCxNA=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1692,13 +1680,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.36.0",
-      "integrity": "sha1-FrCSwsu7VUn2pN8TgqSBWGhQUC8=",
+      "version": "8.38.0",
+      "integrity": "sha1-pWzYR2X6bsE1/iUrXbYeMEQDqFs=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.36.0",
-        "@typescript-eslint/utils": "8.36.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -1715,8 +1704,8 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.36.0",
-      "integrity": "sha1-09GErcKJnikSwTsXwVkEhu83x6w=",
+      "version": "8.38.0",
+      "integrity": "sha1-KXNRyZSXa5PIKsDw4gbIFDqoJSk=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1728,15 +1717,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.36.0",
-      "integrity": "sha1-NEhX+nn3FxU2lVSjy7a0/4aVp7w=",
+      "version": "8.38.0",
+      "integrity": "sha1-giYhmetneLuiijGeJa0FsRWJV98=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.36.0",
-        "@typescript-eslint/tsconfig-utils": "8.36.0",
-        "@typescript-eslint/types": "8.36.0",
-        "@typescript-eslint/visitor-keys": "8.36.0",
+        "@typescript-eslint/project-service": "8.38.0",
+        "@typescript-eslint/tsconfig-utils": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1756,15 +1745,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.36.0",
-      "integrity": "sha1-LJr1KS8U4KpLDpx6wEBq+vspms8=",
+      "version": "8.38.0",
+      "integrity": "sha1-XxAVmJnTDrkrpw5kLKb3VL3b8Vo=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.36.0",
-        "@typescript-eslint/types": "8.36.0",
-        "@typescript-eslint/typescript-estree": "8.36.0"
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1779,12 +1768,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.36.0",
-      "integrity": "sha1-fca6TdA3l56zo73SCTqjYEu3NnQ=",
+      "version": "8.38.0",
+      "integrity": "sha1-qXZaUnsILLj8YP2KFuR8etW2DqU=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.36.0",
+        "@typescript-eslint/types": "8.38.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -1796,8 +1785,8 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.2.3",
-      "integrity": "sha1-WleWWIugULV72liFJpfWFzN3tkc=",
+      "version": "0.3.0",
+      "integrity": "sha1-9Qb/IXDllKJX+OeKoZYIjzpGoi0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1806,7 +1795,7 @@
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2575,8 +2564,8 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.0",
-      "integrity": "sha1-h7m+xt02luQF6nnafSdJ2DCLCVM=",
+      "version": "1.1.2",
+      "integrity": "sha1-Jq936JM2yBxj6oMZf4aLTL01E2k=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2584,16 +2573,16 @@
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.0",
+        "encoding-sniffer": "^0.2.1",
         "htmlparser2": "^10.0.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.10.0",
+        "undici": "^7.12.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -3174,8 +3163,8 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.6",
-      "integrity": "sha1-m4Kj2y+hMa7AaasED9V+0KiAzc0=",
+      "version": "0.25.8",
+      "integrity": "sha1-SC1CGYtCfJwvOoG2PXZjrssd2gc=",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3186,32 +3175,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.6",
-        "@esbuild/android-arm": "0.25.6",
-        "@esbuild/android-arm64": "0.25.6",
-        "@esbuild/android-x64": "0.25.6",
-        "@esbuild/darwin-arm64": "0.25.6",
-        "@esbuild/darwin-x64": "0.25.6",
-        "@esbuild/freebsd-arm64": "0.25.6",
-        "@esbuild/freebsd-x64": "0.25.6",
-        "@esbuild/linux-arm": "0.25.6",
-        "@esbuild/linux-arm64": "0.25.6",
-        "@esbuild/linux-ia32": "0.25.6",
-        "@esbuild/linux-loong64": "0.25.6",
-        "@esbuild/linux-mips64el": "0.25.6",
-        "@esbuild/linux-ppc64": "0.25.6",
-        "@esbuild/linux-riscv64": "0.25.6",
-        "@esbuild/linux-s390x": "0.25.6",
-        "@esbuild/linux-x64": "0.25.6",
-        "@esbuild/netbsd-arm64": "0.25.6",
-        "@esbuild/netbsd-x64": "0.25.6",
-        "@esbuild/openbsd-arm64": "0.25.6",
-        "@esbuild/openbsd-x64": "0.25.6",
-        "@esbuild/openharmony-arm64": "0.25.6",
-        "@esbuild/sunos-x64": "0.25.6",
-        "@esbuild/win32-arm64": "0.25.6",
-        "@esbuild/win32-ia32": "0.25.6",
-        "@esbuild/win32-x64": "0.25.6"
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
       }
     },
     "node_modules/esbuild-register": {
@@ -3248,8 +3237,8 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.1",
-      "integrity": "sha1-1BB7OZZEEqzZtcB0Txxt9RT6EhE=",
+      "version": "9.31.0",
+      "integrity": "sha1-mkiObadbvgV4XNYuQ8XqmTVtIbo=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3257,9 +3246,9 @@
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.1",
+        "@eslint/js": "9.31.0",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3308,8 +3297,8 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.5",
-      "integrity": "sha1-AMGNciUEO2+85qZlaXN3mY1FN4I=",
+      "version": "10.1.8",
+      "integrity": "sha1-FXNM5K+MJ3jMMvCwGzewtc0ey5c=",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3642,7 +3631,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.4",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "integrity": "sha1-eEzczgZpqdaOlNEaxO6pgIjt0sQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5148,15 +5137,15 @@
       }
     },
     "node_modules/open": {
-      "version": "10.1.2",
-      "integrity": "sha1-1d9AmEdVyanDyT34FWoSRn6IKSU=",
+      "version": "10.2.0",
+      "integrity": "sha1-udhVvgB2IOgLb7BfrJgUH+Yttzw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.2.1",
         "define-lazy-prop": "^3.0.0",
         "is-inside-container": "^1.0.0",
-        "is-wsl": "^3.1.0"
+        "wsl-utils": "^0.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -5585,14 +5574,14 @@
       }
     },
     "node_modules/prettier-plugin-organize-imports": {
-      "version": "4.1.0",
-      "integrity": "sha1-89N2QEao57pkkUMRWLm+b/2DuQ8=",
+      "version": "4.2.0",
+      "integrity": "sha1-kqxI4j5kl7rk12HUPRet7RgFpG0=",
       "license": "MIT",
       "optional": true,
       "peerDependencies": {
         "prettier": ">=2.0",
         "typescript": ">=2.9",
-        "vue-tsc": "^2.1.0"
+        "vue-tsc": "^2.1.0 || 3"
       },
       "peerDependenciesMeta": {
         "vue-tsc": {
@@ -5932,15 +5921,15 @@
       "license": "ISC"
     },
     "node_modules/secretlint": {
-      "version": "10.2.0",
-      "integrity": "sha1-ZJ03QZCSps/7JSLgWc1WvsxATcw=",
+      "version": "10.2.1",
+      "integrity": "sha1-Ah6iW7d/I++6Is53jRoAGxXed7E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@secretlint/config-creator": "^10.2.0",
-        "@secretlint/formatter": "^10.2.0",
-        "@secretlint/node": "^10.2.0",
-        "@secretlint/profiler": "^10.2.0",
+        "@secretlint/config-creator": "^10.2.1",
+        "@secretlint/formatter": "^10.2.1",
+        "@secretlint/node": "^10.2.1",
+        "@secretlint/profiler": "^10.2.1",
         "debug": "^4.4.1",
         "globby": "^14.1.0",
         "read-pkg": "^9.0.1"
@@ -6734,14 +6723,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.36.0",
-      "integrity": "sha1-bIfVzPG9RahJwVniOHu2W2Bo7ZA=",
+      "version": "8.38.0",
+      "integrity": "sha1-5zr3YYE58HsW4vrnFe7aq7Qe6LA=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.36.0",
-        "@typescript-eslint/parser": "8.36.0",
-        "@typescript-eslint/utils": "8.36.0"
+        "@typescript-eslint/eslint-plugin": "8.38.0",
+        "@typescript-eslint/parser": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6768,8 +6758,8 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.11.0",
-      "integrity": "sha1-jhOlT2Kvp1ZmbAWQw4s4ZuKG0LM=",
+      "version": "7.12.0",
+      "integrity": "sha1-6TJE+kk4PooOGkKVBI/UVFQcfMs=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7073,6 +7063,21 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "integrity": "sha1-h4PU32cdTVA2W+LuTHGRegVXuqs=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/xml2js": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
   },
   "devDependencies": {
     "@vscode/vsce": "^3.6.0",
-    "esbuild": "^0.25.6"
+    "esbuild": "^0.25.8"
   },
   "optionalDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/mock-fs": "^4.13.4",
-    "@types/node": "^22.15.1",
+    "@types/node": "^22.16.5",
     "@types/semver": "^7.7.0",
     "@types/sinon": "^17.0.4",
     "@types/ungap__structured-clone": "^1.2.0",
@@ -85,14 +85,14 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.5.2",
     "esbuild-register": "^3.6.0",
-    "eslint": "^9.30.1",
-    "eslint-config-prettier": "^10.1.5",
+    "eslint": "^9.31.0",
+    "eslint-config-prettier": "^10.1.8",
     "mock-fs": "^5.5.0",
     "prettier": "^3.6.2",
-    "prettier-plugin-organize-imports": "^4.1.0",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "sinon": "^19.0.5",
     "typescript": "^5.8.3",
-    "typescript-eslint": "^8.36.0"
+    "typescript-eslint": "^8.38.0"
   },
   "extensionDependencies": [
     "vscode.powershell"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.101.0"
   },
   "author": "Microsoft Corporation",
   "license": "SEE LICENSE IN LICENSE.txt",
@@ -61,7 +61,6 @@
   ],
   "dependencies": {
     "@vscode/extension-telemetry": "^0.9.9",
-    "node-fetch": "^2.7.0",
     "semver": "^7.7.2",
     "untildify": "^4.0.0",
     "uuid": "^9.0.1",
@@ -75,13 +74,12 @@
   "optionalDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/mock-fs": "^4.13.4",
-    "@types/node": "^20.19.6",
-    "@types/node-fetch": "^2.6.12",
+    "@types/node": "^22.15.1",
     "@types/semver": "^7.7.0",
     "@types/sinon": "^17.0.4",
     "@types/ungap__structured-clone": "^1.2.0",
     "@types/uuid": "^9.0.8",
-    "@types/vscode": "~1.96.0",
+    "@types/vscode": "~1.101.0",
     "@ungap/structured-clone": "^1.3.0",
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/test-cli": "^0.0.10",

--- a/src/features/UpdatePowerShell.ts
+++ b/src/features/UpdatePowerShell.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import fetch from "node-fetch";
 import { SemVer } from "semver";
 import vscode = require("vscode");
 


### PR DESCRIPTION
Fixes #5213

## PR Summary

Bumps to Node 22.15.1 and removes node-fetch. Requires VSCode v1.101 or higher for future extension releases.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
