### PR TITLE
Shell integration script moved back

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,15 +4,11 @@
 import os = require("os");
 import path = require("path");
 import vscode = require("vscode");
-import { satisfies } from "semver";
 
 export const PowerShellLanguageId = "powershell";
 
-// Path to the shell integration script in the VS Code installation
-// See https://github.com/microsoft/vscode/pull/251303
-const shellIntegrationMoved = satisfies(vscode.version, ">=1.102", {
-    includePrerelease: true,
-});
+// Path to the shell integration script in the VS Code installation.
+// See commit 21114288b if it moves again.
 export const ShellIntegrationScript = path.join(
     vscode.env.appRoot,
     "out",
@@ -22,7 +18,7 @@ export const ShellIntegrationScript = path.join(
     "terminal",
     "common",
     "scripts",
-    shellIntegrationMoved ? "shellIntegration.psm1" : "shellIntegration.ps1",
+    "shellIntegration.ps1",
 );
 
 export function escapeSingleQuotes(p: string): string {


### PR DESCRIPTION
Undoes #5217 (except it's not a revert since we don't need the original logic any more). Since the change only appeared in Insiders, the check doesn't have to stick around (literally added and removed without a version bump).