### PR TITLE
Update build process to avoid prompting for admin rights unnecessarily

### DIFF
--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -51,7 +51,7 @@ task RestoreEditorServices -If (Get-EditorServicesPath) {
             if ((Get-Item ./modules -ErrorAction SilentlyContinue).LinkType -ne $linkType) {
                 Write-Build DarkMagenta "Creating $linkType to PSES"
                 Remove-BuildLinks $linkType $psesModuleDir
-                New-Item -ItemType $linkType -Path ./modules -Value "$(Split-Path (Get-EditorServicesPath))/module"
+                New-Item -ItemType $linkType -Path ./modules -Target "$(Split-Path (Get-EditorServicesPath))/module"
             }
 
             Write-Build DarkGreen "Building PSES"


### PR DESCRIPTION
## PR Summary
- Use Junctions instead of SymbolicLinks on Windows to avoid prompting for admin rights unnecessarily.

## PR Checklist
Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
