### PR TITLE
Reduce scope of regex in PowerShellExeFinder

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -78,7 +78,7 @@ export function getPlatformDetails(): IPlatformDetails {
  */
 export class PowerShellExeFinder {
     // This is required, since parseInt("7-preview") will return 7.
-    private static IntRegex = /^\d+$/;
+    private static IntRegex = /^\d$/;
     private static PwshMsixRegex = /^Microsoft.PowerShell_.*/;
     private static PwshPreviewMsixRegex = /^Microsoft.PowerShellPreview_.*/;
     private winPS: IPossiblePowerShellExe | undefined;


### PR DESCRIPTION
## PR Summary
- Update integer checking regex to match implied expectations from related comments.
  - While reading through the comments associated with the IntRegex value it is implied that we're only looking for single digit integer folders. This update formally matches that implied expectation.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
