### PR TITLE
Add createTemporaryIntegratedConsole to attach opt

### DIFF
--- a/package.json
+++ b/package.json
@@ -610,6 +610,11 @@
                 "type": "string",
                 "description": "The custom pipe name of the PowerShell host process to attach to.",
                 "default": null
+              },
+              "createTemporaryIntegratedConsole": {
+                "type": "boolean",
+                "description": "Determines whether a temporary PowerShell Extension Terminal is created for each debugging session, useful for debugging PowerShell classes and binary modules.  Overrides the user setting 'powershell.debugging.createTemporaryIntegratedConsole'.",
+                "default": false
               }
             }
           }


### PR DESCRIPTION
## PR Summary
Adds the option `createTemporaryIntegratedConsole` to the attach configuration. No changes are needed in the code to enable this scenario as it work without any issues right now.

No changes are needed in PSES to enable this. The logic for spawning the temp console exists in the vscode plugin and not PSES.

## PR Checklist
- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
