### PR TITLE
Add notifyOnAttach option

### DIFF
--- a/package.json
+++ b/package.json
@@ -610,6 +610,11 @@
                 "type": "string",
                 "description": "The custom pipe name of the PowerShell host process to attach to.",
                 "default": null
+              },
+              "notifyOnAttach": {
+                "type": "boolean",
+                "description": "Creates the event 'PSES.Attached' when the debugger attaches to the PowerShell host process. This is useful when creating a script that waits for the debugger to attach.",
+                "default": false
               }
             }
           }


### PR DESCRIPTION
## PR Summary
Adds the new `notifyOnAttach` option for an attach request. This option will have PSES create a new event with the source identifier `PSES.Attached` that allows the attached script to wait for the attach event.

Should wait until https://github.com/PowerShell/PowerShellEditorServices/pull/2250 is merged (or rejected).

## PR Checklist
- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
