### PR TITLE
Add temporaryConsoleWindowActionOnDebugEnd option

### DIFF
--- a/package.json
+++ b/package.json
@@ -581,6 +581,21 @@
                 "type": "string",
                 "description": "If you would like to use a custom coreclr attach debug launch configuration for the debug session, specify the name here. Otherwise a default basic config will be used. The config must be a coreclr attach config. Launch configs are not supported.",
                 "default": false
+              },
+              "temporaryConsoleWindowActionOnDebugEnd": {
+                "type": "string",
+                "description": "Determines whether the temporary PowerShell Extension Terminal is closed when the debugging session ends.",
+                "default": "keep",
+                "enum": [
+                  "close",
+                  "hide",
+                  "keep"
+                ],
+                "enumDescriptions": [
+                  "Closes the temporary PowerShell Extension Terminal when the debugging session ends.",
+                  "Hides the temporary PowerShell Extension Terminal when the debugging session ends and restores the previous window before the debug session had started. This does nothing if the previous window was closed during the debug session.",
+                  "Keeps the temporary PowerShell Extension Terminal open after the debugging session ends."
+                ]
               }
             }
           },
@@ -615,6 +630,21 @@
                 "type": "boolean",
                 "description": "Determines whether a temporary PowerShell Extension Terminal is created for each debugging session, useful for debugging PowerShell classes and binary modules.  Overrides the user setting 'powershell.debugging.createTemporaryIntegratedConsole'.",
                 "default": false
+              },
+              "temporaryConsoleWindowActionOnDebugEnd": {
+                "type": "string",
+                "description": "Determines whether the temporary PowerShell Extension Terminal is closed when the debugging session ends.",
+                "default": "keep",
+                "enum": [
+                  "close",
+                  "hide",
+                  "keep"
+                ],
+                "enumDescriptions": [
+                  "Closes the temporary PowerShell Extension Terminal when the debugging session ends.",
+                  "Hides the temporary PowerShell Extension Terminal when the debugging session ends and restores the previous window before the debug session had started. This does nothing if the previous window was closed during the debug session.",
+                  "Keeps the temporary PowerShell Extension Terminal open after the debugging session ends."
+                ]
               }
             }
           }

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -604,22 +604,35 @@ export class DebugSessionFeature
             );
         }
 
-        const closeDebugEvent = debug.onDidTerminateDebugSession(
-            (terminatedSession) => {
-                closeDebugEvent.dispose();
+        if (
+            session.configuration.temporaryConsoleWindowActionOnDebugEnd !==
+            "keep"
+        ) {
+            const closeDebugEvent = debug.onDidTerminateDebugSession(
+                (terminatedSession) => {
+                    closeDebugEvent.dispose();
 
-                if (terminatedSession.id !== session.id) {
-                    return;
-                }
+                    if (terminatedSession.id !== session.id) {
+                        return;
+                    }
 
-                if (terminatedSession.configuration.temporaryConsoleWindowActionOnDebugEnd === "close") {
-                    this.tempDebugProcess?.dispose();
-                } else if (terminatedSession.configuration.temporaryConsoleWindowActionOnDebugEnd === "hide" &&
-                    window.terminals.includes(previousActiveTerminal)) {
-                    previousActiveTerminal.show();
-                }
-            },
-        );
+                    if (
+                        terminatedSession.configuration
+                            .temporaryConsoleWindowActionOnDebugEnd === "close"
+                    ) {
+                        this.tempDebugProcess?.dispose();
+                    } else if (
+                        terminatedSession.configuration
+                            .temporaryConsoleWindowActionOnDebugEnd ===
+                            "hide" &&
+                        previousActiveTerminal &&
+                        window.terminals.includes(previousActiveTerminal)
+                    ) {
+                        previousActiveTerminal.show();
+                    }
+                },
+            );
+        }
 
         return this.tempSessionDetails;
     }


### PR DESCRIPTION
## PR Summary
Adds a new option `temporaryConsoleWindowActionOnDebugEnd` to both the attach and launch configurations which can be used to specify what happens with the temporary integrated console when a debug session ends. The option can be set to `keep`, current behaviour and default, that will keep the active terminal as the temporary console. It can be set to `close` which closes the terminal and removes it from the selection pane or `hide` which keeps the terminal window alive but changes the active terminal to the previous one before the debug session started.

Issue for this feature was opened under https://github.com/PowerShell/PowerShellEditorServices/issues/2247 but the actual implementation needs to be done here.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests - not sure if I can test this out?
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
