### PR TITLE
Fix marketplace publishing step

### DIFF
--- a/.pipelines/vscode-powershell-OneBranch.yml
+++ b/.pipelines/vscode-powershell-OneBranch.yml
@@ -54,7 +54,6 @@ extends:
       EnableCDPxPAT: false
       WindowsHostVersion:
         Version: 2022
-        Network: KS3
     release:
       category: NonAzure
     stages:
@@ -180,7 +179,7 @@ extends:
                 feed:
                   organization: msazure
                   project: One
-                  feedName: npmjs
+                  feedName: vsce
             steps:
               - pwsh: |
                   Write-Host Publishing: $(vsixVersion), pre-release: $(prerelease)

--- a/vscode-powershell.build.ps1
+++ b/vscode-powershell.build.ps1
@@ -71,12 +71,6 @@ task Build RestoreEditorServices, RestoreNode, {
     Write-Build DarkGreen "Building vscode-powershell"
     Assert-Build (Test-Path ./modules/PowerShellEditorServices/bin) "Extension requires PSES"
 
-    # TODO: When supported we should use `esbuild` for the tests too. Although
-    # we now use `esbuild` to transpile, bundle, and minify the extension, we
-    # still use `tsc` to transpile everything in `src` and `test` because the VS
-    # Code test runner expects individual files (and globs them at runtime).
-    # Unfortunately `esbuild` doesn't support emitting 1:1 files (yet).
-    # https://github.com/evanw/esbuild/issues/944
     switch ($Configuration) {
         "Debug" { Invoke-BuildExec { & npm run compile } }
         "Release" { Invoke-BuildExec { & npm run compile -- --minify } }


### PR DESCRIPTION
This custom task can't use an org-scoped feed, so I had to make a project-scoped one just for it. Which is only necessary because the package still isn't cached.

Also remove the `KS3` setting as it's no longer compliant, and an out-of-date TODO.