### PR TITLE
Enable new PSScriptAnalyzer option `removeTrailingWhitespace`

### DIFF
--- a/package.json
+++ b/package.json
@@ -898,6 +898,11 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Use correct casing for cmdlets."
+          },
+          "powershell.codeFormatting.removeTrailingWhitespace": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Removes trailing whitespace from the end of a line."
           }
         }
       },

--- a/pwsh-extension-dev.code-workspace
+++ b/pwsh-extension-dev.code-workspace
@@ -45,6 +45,7 @@
     "powershell.codeFormatting.autoCorrectAliases": true,
     "powershell.codeFormatting.avoidSemicolonsAsLineTerminators": true,
     "powershell.codeFormatting.newLineAfterCloseBrace": false,
+    "powershell.codeFormatting.removeTrailingWhitespace": true,
     "powershell.codeFormatting.trimWhitespaceAroundPipe": true,
     "powershell.codeFormatting.useCorrectCasing": true,
     "powershell.codeFormatting.whitespaceBeforeOpenBrace": false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -94,6 +94,7 @@ class CodeFormattingSettings extends PartialSettings {
     alignPropertyValuePairs = true;
     useConstantStrings = false;
     useCorrectCasing = false;
+    removeTrailingWhitespace = false;
 }
 
 class ScriptAnalysisSettings extends PartialSettings {


### PR DESCRIPTION
## PR Summary

Expose a setting `removeTrailingWhitespace` (defaults to `false`) related to the PSSA rule `AvoidTrailingWhitespace` - which since the release of 1.24 can correctly fix trailing whitespace through `Invoke-Formatter`.

Requires PSES PR first: https://github.com/PowerShell/PowerShellEditorServices/pull/2258

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
