### PR TITLE
Use official OneBranch template by default for CodeQL

### DIFF
--- a/.pipelines/vscode-powershell-OneBranch.yml
+++ b/.pipelines/vscode-powershell-OneBranch.yml
@@ -34,6 +34,10 @@ parameters:
   - name: OfficialBuild
     displayName: Use Official OneBranch template
     type: boolean
+    default: true
+  - name: Release
+    displayName: Generate a release
+    type: boolean
     default: false
 
 variables:
@@ -127,7 +131,7 @@ extends:
                   files_to_sign: "*.signature.p7s"
       - stage: release
         dependsOn: build
-        condition: and(succeeded(), ${{ eq(parameters.OfficialBuild, true) }})
+        condition: and(succeeded(), ${{ eq(parameters.Release, true) }})
         variables:
           ob_release_environment: ${{ iif(parameters.OfficialBuild, 'Production', 'Test') }}
           version: $[ stageDependencies.build.main.outputs['package.version'] ]


### PR DESCRIPTION
The weekly CodeQL task requires being run as an official build, hence CodeQL was not yet running.
The easiest fix is to set the parameter controlling that to default to true, which means introducing another parameter controlling whether to release (which defaults to false).