### PR TITLE
Ignore `.config/tsaoptions.json` for Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 modules/
 out/
+.config/


### PR DESCRIPTION
It seems to get modified during the OneBranch build and then fails.