### PR TITLE
Improve PowerShell Extension termination experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1043,10 +1043,10 @@
             "default": false,
             "markdownDescription": "Do not show the startup banner in the PowerShell Extension Terminal."
           },
-          "powershell.showTerminalStoppedNotification": {
+          "powershell.suppressTerminalStoppedNotification": {
             "type": "boolean",
-            "default": true,
-            "markdownDescription": "Show a notification when the PowerShell Extension terminal has stopped."
+            "default": false,
+            "markdownDescription": "Do not show a notification when the PowerShell Extension Terminal has stopped."
           },
           "powershell.integratedConsole.showOnStartup": {
             "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -1043,6 +1043,11 @@
             "default": false,
             "markdownDescription": "Do not show the startup banner in the PowerShell Extension Terminal."
           },
+          "powershell.showTerminalStoppedNotification": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Show a notification when the PowerShell Extension terminal has stopped."
+          },
           "powershell.integratedConsole.showOnStartup": {
             "type": "boolean",
             "default": true,

--- a/src/session.ts
+++ b/src/session.ts
@@ -1158,6 +1158,15 @@ Type 'help' to get help.
     }
 
     private async promptForRestart(): Promise<void> {
+        // Check user configuration before showing notification
+        const showNotifications = vscode.workspace
+            .getConfiguration("powershell")
+            .get<boolean>("showTerminalStoppedNotification", true);
+
+        if (!showNotifications) {
+            // User opted out — silently skip the notification
+            return;
+        }
         await this.logger.writeAndShowErrorWithActions(
             "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
             [

--- a/src/session.ts
+++ b/src/session.ts
@@ -980,7 +980,8 @@ export class SessionManager implements Middleware {
                     return {
                         action: CloseAction.DoNotRestart,
                         message:
-                            "Connection to PowerShell Editor Services (the Extension Terminal) was closed. See below prompt to restart!",
+                            "Connection to PowerShell Editor Services (the Extension Terminal) was closed.",
+                        handled: true,
                     };
                 },
             },
@@ -1159,14 +1160,15 @@ Type 'help' to get help.
 
     private async promptForRestart(): Promise<void> {
         // Check user configuration before showing notification
-        const showNotifications = vscode.workspace
-            .getConfiguration("powershell")
-            .get<boolean>("showTerminalStoppedNotification", true);
+        const suppressNotification =
+            vscode.workspace
+                .getConfiguration("powershell")
+                .get<boolean>("suppressTerminalStoppedNotification") ?? false;
 
-        if (!showNotifications) {
-            // User opted out — silently skip the notification
+        if (suppressNotification) {
             return;
         }
+
         await this.logger.writeAndShowErrorWithActions(
             "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
             [
@@ -1179,6 +1181,17 @@ Type 'help' to get help.
                 {
                     prompt: "No",
                     action: undefined,
+                },
+                {
+                    prompt: "Don't Show Again",
+                    action: async (): Promise<void> => {
+                        await changeSetting(
+                            "suppressTerminalStoppedNotification",
+                            true,
+                            true,
+                            this.logger,
+                        );
+                    },
                 },
             ],
         );


### PR DESCRIPTION
PR Summary

This PR adds a configuration option to suppress PowerShell Extension terminal crash/restart notifications.

Reference issue: Allow disabling the "The PowerShell Extension terminal has stopped" notifications #5336

Currently, when the PowerShell Extension terminal is stopped (intentionally or otherwise), VS Code repeatedly shows notifications warning that IntelliSense will not work. While useful for new users, these notifications can become noisy for experienced users who intentionally close the terminal or are already aware of the consequences—especially now that the terminal is spawned more frequently (for example, when Copilot references PowerShell code).

This change introduces a user-configurable setting that allows disabling these notifications, keeping the notification area clean without affecting functionality.

Key points

Adds a new setting to opt out of PowerShell Extension terminal stopped/restart notifications

Default behavior remains unchanged (notifications are still shown unless disabled)

Improves user experience for advanced users without impacting discoverability for new users

PR Checklist

 PR has a meaningful title

 Summarized changes

[NA] PR has tests

 This PR is ready to merge and is not work in progress