### PR TITLE
Update npm packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2025.4.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@vscode/extension-telemetry": "^1.2.0",
-        "semver": "^7.7.3",
+        "@vscode/extension-telemetry": "^1.5.0",
+        "semver": "^7.7.4",
         "untildify": "^4.0.0",
         "uuid": "^13.0.0",
         "vscode-languageclient": "^9.0.1",
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@vscode/vsce": "^3.7.1",
-        "esbuild": "^0.27.0"
+        "esbuild": "^0.27.3"
       },
       "engines": {
         "vscode": "^1.106.0"
@@ -26,7 +26,7 @@
       "optionalDependencies": {
         "@eslint/js": "^9.39.1",
         "@types/mock-fs": "^4.13.4",
-        "@types/node": "^22.19.1",
+        "@types/node": "^22.19.11",
         "@types/semver": "^7.7.1",
         "@types/sinon": "^17.0.4",
         "@types/ungap__structured-clone": "^1.2.0",
@@ -36,14 +36,14 @@
         "@vscode/test-cli": "^0.0.10",
         "@vscode/test-electron": "^2.5.2",
         "esbuild-register": "^3.6.0",
-        "eslint": "^9.39.1",
+        "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
         "mock-fs": "^5.5.0",
-        "prettier": "^3.6.2",
+        "prettier": "^3.8.1",
         "prettier-plugin-organize-imports": "^4.3.0",
         "sinon": "^19.0.5",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.48.0"
+        "typescript-eslint": "^8.56.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -185,20 +185,20 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.26.2",
-      "integrity": "sha1-HUFrerakCU+gmOTaUFjdPSEjF4M=",
+      "version": "4.28.2",
+      "integrity": "sha1-0oikf/yiUDYahvOnpPHfSnmlWeA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.2"
+        "@azure/msal-common": "15.14.2"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.13.2",
-      "integrity": "sha1-eYbfEiu2z5auFgu6cHWP1ctmZpU=",
+      "version": "15.14.2",
+      "integrity": "sha1-IFXqU0Chy3FOUUsWLESRG2NO4OY=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -206,12 +206,12 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "3.8.3",
-      "integrity": "sha1-v58g11nrXRvgDnajLDfym/4SLLU=",
+      "version": "3.8.7",
+      "integrity": "sha1-4Ry2bmb5MmUWDuX0YPV1Z1KkH2E=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.13.2",
+        "@azure/msal-common": "15.14.2",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -229,12 +229,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "integrity": "sha1-IA9xXmbVKiOyIalDVTSpHME61b4=",
+      "version": "7.29.0",
+      "integrity": "sha1-fNelnxWzzA3NgDA493knEqfQsVw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -258,8 +258,8 @@
       "optional": true
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.0",
-      "integrity": "sha1-HYvkNImpYWFdSeA38b+g9Sp3Nzc=",
+      "version": "0.27.3",
+      "integrity": "sha1-gVs5Jn+b/9NAfqbDdqwylG4k+NI=",
       "cpu": [
         "ppc64"
       ],
@@ -273,8 +273,8 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.0",
-      "integrity": "sha1-ace1fwLTs2GKW6T4LRJ7V2Zdw5c=",
+      "version": "0.27.3",
+      "integrity": "sha1-kL5Y3ieRXvont2f8vbN6RHBifXs=",
       "cpu": [
         "arm"
       ],
@@ -288,8 +288,8 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-vRdjGUqtYHU/ozOLG6m9qXS1hyQ=",
+      "version": "0.27.3",
+      "integrity": "sha1-GbiCQIgprY4SsQr/KEBxGy2jYeg=",
       "cpu": [
         "arm64"
       ],
@@ -303,8 +303,8 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-bqIrWEOssjJD0BJsBS19O2oRypA=",
+      "version": "0.27.3",
+      "integrity": "sha1-19zJdvFuAamqovm5OPvsc4n4law=",
       "cpu": [
         "x64"
       ],
@@ -318,8 +318,8 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-WtfAK8GxqTekIPkZr+QGZboUrR4=",
+      "version": "0.27.3",
+      "integrity": "sha1-n2yscrOoUyKYpqRJPtY5qJiOir0=",
       "cpu": [
         "arm64"
       ],
@@ -333,8 +333,8 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-SEcMg8X9bR/HyCPCxgOu7pbhAck=",
+      "version": "0.27.3",
+      "integrity": "sha1-rGHWRfqjf9ZQNA8YZrCBLh+xTWo=",
       "cpu": [
         "x64"
       ],
@@ -348,8 +348,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-1ajv/YsL575hPNEAnaNNYp1MJFc=",
+      "version": "0.27.3",
+      "integrity": "sha1-uGJWidc88YMP5Yw5BRrNwSR06hs=",
       "cpu": [
         "arm64"
       ],
@@ -363,8 +363,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-m95ji9oxqiRNbWTbr6+0Hm55m8w=",
+      "version": "0.27.3",
+      "integrity": "sha1-B75908nUL+DszSq5+d7XgLxTvq0=",
       "cpu": [
         "x64"
       ],
@@ -378,8 +378,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.0",
-      "integrity": "sha1-m0fLDyIuVnrzFul4x/NTB9uXvA4=",
+      "version": "0.27.3",
+      "integrity": "sha1-KEk+5Gq+wdw/UAIjzZ+NLfCPnRE=",
       "cpu": [
         "arm"
       ],
@@ -393,8 +393,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-lgCMOiB9jKSVcI23FMR16lv34q8=",
+      "version": "0.27.3",
+      "integrity": "sha1-vzGRj+XHmFhkYNKz1sRu0sAcoLY=",
       "cpu": [
         "arm64"
       ],
@@ -408,8 +408,8 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.0",
-      "integrity": "sha1-0eHjjUBsvfuKSfTsoMJbvDROGMw=",
+      "version": "0.27.3",
+      "integrity": "sha1-dQdSqLMLQ2R0AlYe6nZNCkHQ7ik=",
       "cpu": [
         "ia32"
       ],
@@ -423,8 +423,8 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.0",
-      "integrity": "sha1-wTvGpT47abdvJIBlvr7oQVtE384=",
+      "version": "0.27.3",
+      "integrity": "sha1-pakoE6BOcRmMUPBa368Y/B6Vue0=",
       "cpu": [
         "loong64"
       ],
@@ -438,8 +438,8 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.0",
-      "integrity": "sha1-BfgyLrCpbOG/vFlpGr54j3Hi0hc=",
+      "version": "0.27.3",
+      "integrity": "sha1-3rRdf9LSFh6t8fvFk2N+12bVC7E=",
       "cpu": [
         "mips64el"
       ],
@@ -453,8 +453,8 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.0",
-      "integrity": "sha1-b8Xnr5i0+wxqfwtzuoN85E3FSYA=",
+      "version": "0.27.3",
+      "integrity": "sha1-bzmuC4xNPS1hplsm33n24SocPXg=",
       "cpu": [
         "ppc64"
       ],
@@ -468,8 +468,8 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.0",
-      "integrity": "sha1-UIr6n2mj+XNowL8H3YlKBK852G4=",
+      "version": "0.27.3",
+      "integrity": "sha1-TFwZw5FmEuyOORUYcDC53wuVXB0=",
       "cpu": [
         "riscv64"
       ],
@@ -483,8 +483,8 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.0",
-      "integrity": "sha1-If2mVhEO4kL8ZPh6ngsCdtTk7Fs=",
+      "version": "0.27.3",
+      "integrity": "sha1-ntF7MZj6CK1cyqnnT2wK/3rQFW0=",
       "cpu": [
         "s390x"
       ],
@@ -498,8 +498,8 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-F1ioXcwJs4f9V2IWQ+d7JeDMulk=",
+      "version": "0.27.3",
+      "integrity": "sha1-Ejg9y/cbfPZRPli0sI2VpxC/UqU=",
       "cpu": [
         "x64"
       ],
@@ -513,8 +513,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-oBMRWfTbbkkNo1zEu1HvDQO3hIo=",
+      "version": "0.27.3",
+      "integrity": "sha1-3Qyy+lQyBfzZMd9E9Hhr/M5t99c=",
       "cpu": [
         "arm64"
       ],
@@ -528,8 +528,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-b0h318K6QlorgOQzBZTgtDyqLX0=",
+      "version": "0.27.3",
+      "integrity": "sha1-AorRgHqOA+FVFTstAltQbDeHNUs=",
       "cpu": [
         "x64"
       ],
@@ -543,8 +543,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-y++9TC83XOvrT5ZZRb5s+BMxvQE=",
+      "version": "0.27.3",
+      "integrity": "sha1-48Fv80kMm1m5af/8qH81D/wOKvU=",
       "cpu": [
         "arm64"
       ],
@@ -558,8 +558,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-Mfqehkn8dQ18IwLIudDhVH9XvIQ=",
+      "version": "0.27.3",
+      "integrity": "sha1-xaRpP8sD0cvsv4tCJCJGjfwNKos=",
       "cpu": [
         "x64"
       ],
@@ -573,8 +573,8 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-A3J3gPH99gbntWGTaTpxXZ8e4AE=",
+      "version": "0.27.3",
+      "integrity": "sha1-CCCCRE8S21ZKB3WkHhmRwOElBV4=",
       "cpu": [
         "arm64"
       ],
@@ -588,8 +588,8 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-hmo184cjSoZ87TWviQbf/7Bzuf8=",
+      "version": "0.27.3",
+      "integrity": "sha1-WrA2xT+SnoQFxOluhlpCQWChtTc=",
       "cpu": [
         "x64"
       ],
@@ -603,8 +603,8 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.0",
-      "integrity": "sha1-U95DqWKbijRnjyjNVswQTbG2ers=",
+      "version": "0.27.3",
+      "integrity": "sha1-ON5wDvS5YKAEU3DBcXlFJuWJhi4=",
       "cpu": [
         "arm64"
       ],
@@ -618,8 +618,8 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.0",
-      "integrity": "sha1-kk0q7YaS/qXSe/tlAPm4ucGjSvQ=",
+      "version": "0.27.3",
+      "integrity": "sha1-RRuT3APsXU84YZ5s1k2fnv8G9Vw=",
       "cpu": [
         "ia32"
       ],
@@ -633,8 +633,8 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.0",
-      "integrity": "sha1-ZJlSlSJ+AB8pQCWGF8ZnTvs6xI0=",
+      "version": "0.27.3",
+      "integrity": "sha1-Dq9wXJQaIYpD26jgnx3x1s0vHxc=",
       "cpu": [
         "x64"
       ],
@@ -648,8 +648,8 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "integrity": "sha1-cwjfFY4GTw3YuP21iqFPoqf5E7M=",
+      "version": "4.9.1",
+      "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -747,8 +747,8 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "integrity": "sha1-5V9/HdQAYA3QZtu6NJxMC6yRaWQ=",
+      "version": "3.3.3",
+      "integrity": "sha1-Jjk6CAZQG14rakOqWIpNjfZ4gKw=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -758,7 +758,7 @@
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.1.1",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
@@ -785,12 +785,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "license": "Python-2.0",
-      "optional": true
-    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
       "version": "1.1.12",
       "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
@@ -799,18 +793,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
@@ -832,8 +814,8 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "integrity": "sha1-DdWcOp9A4/GIKXXDIUcJaSQ+AWQ=",
+      "version": "9.39.2",
+      "integrity": "sha1-LUuOxMPqE8GzdI4Ml+zXZr3YBZk=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -913,32 +895,11 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "integrity": "sha1-MIHa28NGBmG3UedZHX+upd853Sk=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "integrity": "sha1-Sz2rq32OdaQpQUqWvWe/TB0T4PM=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "integrity": "sha1-s3Znt7wYHBaHgiWbq0JHT79StVA=",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -954,14 +915,14 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1009,11 +970,11 @@
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "4.3.10",
-      "integrity": "sha1-2K7M0Upqg2EG28SH7peLIPYZPwA=",
+      "version": "4.3.11",
+      "integrity": "sha1-UjxgDSXgBDecWUBLDXXuAAQ2Jc0=",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.11",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
@@ -1021,11 +982,11 @@
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "4.3.10",
-      "integrity": "sha1-c3cwQhpaoVeMZrJTIlWCuu/IfNM=",
+      "version": "4.3.11",
+      "integrity": "sha1-iOwI5LSrWWmwAiglT1MD1gO/8J4=",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "4.3.10",
+        "@microsoft/1ds-core-js": "4.3.11",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
@@ -1033,12 +994,12 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.10",
-      "integrity": "sha1-moE3HyFDtTful36XSIKdhVMtV4A=",
+      "version": "3.3.11",
+      "integrity": "sha1-eZGzFbKVIZpD6FyWqwTrBwpeE/Y=",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.10",
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-common": "3.3.11",
+        "@microsoft/applicationinsights-core-js": "3.3.11",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
@@ -1049,11 +1010,11 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.3.10",
-      "integrity": "sha1-geOljyU801CKZV6tdCh/fxRFzO0=",
+      "version": "3.3.11",
+      "integrity": "sha1-Gtdkowgz+A+soacq9Lj6K3w7KLo=",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-core-js": "3.3.11",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
@@ -1063,8 +1024,8 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.3.10",
-      "integrity": "sha1-owq2HBszyCImR5ua37rzvEyFz/k=",
+      "version": "3.3.11",
+      "integrity": "sha1-ks6WCSSxYSH4aBSpteo11canuOA=",
       "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "3.0.1",
@@ -1085,13 +1046,13 @@
       }
     },
     "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.10",
-      "integrity": "sha1-mj7LfhJLb7Oeb5XwoWikf5Q8MbY=",
+      "version": "3.3.11",
+      "integrity": "sha1-NT0VkSfCtWuC3Vd396NVYmQR+O8=",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.3.10",
-        "@microsoft/applicationinsights-common": "3.3.10",
-        "@microsoft/applicationinsights-core-js": "3.3.10",
+        "@microsoft/applicationinsights-channel-js": "3.3.11",
+        "@microsoft/applicationinsights-common": "3.3.11",
+        "@microsoft/applicationinsights-core-js": "3.3.11",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
@@ -1110,16 +1071,16 @@
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.4",
-      "integrity": "sha1-UvhEndCzsWqjF6GLRmL2+xOhNfE=",
+      "version": "0.5.5",
+      "integrity": "sha1-UJZI48PDqpq2E8AMce7k/pvYo8M=",
       "license": "MIT",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.12.5",
-      "integrity": "sha1-/jPBDRGui3JMyqox0tAQnRhgHaY=",
+      "version": "0.12.6",
+      "integrity": "sha1-bWT6nnS6BNJwvjK3WCpxI0GtV0Q=",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1383,25 +1344,25 @@
       "optional": true
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.4.0",
-      "integrity": "sha1-0I/mINOoL+ImXG//9mrGsMAwlp8=",
+      "version": "15.5.1",
+      "integrity": "sha1-TD0ohO/e5Y1EDf6fGKZpp4PS9F4=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.4.0",
-      "integrity": "sha1-MmJ6nDCuxDsv2ho/cauqk7zm07g=",
+      "version": "15.5.1",
+      "integrity": "sha1-oe0OXIOR8xfo5mphFNV2lEnKNdc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.4.0",
-        "@textlint/resolver": "15.4.0",
-        "@textlint/types": "15.4.0",
+        "@textlint/module-interop": "15.5.1",
+        "@textlint/resolver": "15.5.1",
+        "@textlint/types": "15.5.1",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
-        "js-yaml": "^3.14.1",
+        "js-yaml": "^4.1.1",
         "lodash": "^4.17.21",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
@@ -1438,24 +1399,24 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.4.0",
-      "integrity": "sha1-KA5LFN5MT9wUQxLDnr76s33ZIkM=",
+      "version": "15.5.1",
+      "integrity": "sha1-9vdffptUrSqVcdPVXmXT1NXmrNo=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.4.0",
-      "integrity": "sha1-SkE7xbTWbuFdAVSacU+yIq6Ibhk=",
+      "version": "15.5.1",
+      "integrity": "sha1-//bIaxXsuu8WqaiO5BYn3t8aBEs=",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/types": {
-      "version": "15.4.0",
-      "integrity": "sha1-H2t3jxYigSgjgmh2QO5/GGOgXqA=",
+      "version": "15.5.1",
+      "integrity": "sha1-w94pRdv5ZBhVvkN8zGbJcsvr9U4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.4.0"
+        "@textlint/ast-node-types": "15.5.1"
       }
     },
     "node_modules/@types/estree": {
@@ -1492,8 +1453,8 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.1",
-      "integrity": "sha1-EYjx3cn0a0zDrsdnSQULTh9Fm3s=",
+      "version": "22.19.11",
+      "integrity": "sha1-fh/qrSTk42xS+lVY1YZLtLJyYD4=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1546,20 +1507,19 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.48.0",
-      "integrity": "sha1-zcm9vpR3E/ZY62EJ7u6l10aCTPQ=",
+      "version": "8.56.0",
+      "integrity": "sha1-Wuw9uAemuEN+pdXr970WtBGauo0=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/type-utils": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1569,8 +1529,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.48.0",
-        "eslint": "^8.57.0 || ^9.0.0",
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -1584,16 +1544,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.48.0",
-      "integrity": "sha1-/DnqmxyLJBTB9LYlJ3Yp4SqUDms=",
+      "version": "8.56.0",
+      "integrity": "sha1-js/xZ4uLGnQtKcRGzPXu6n+XHXI=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1603,19 +1563,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.48.0",
-      "integrity": "sha1-wh9viX+8TmHHseIJBuodWVlMzC0=",
+      "version": "8.56.0",
+      "integrity": "sha1-u4Vi/s2PeSLmdvxqEYnCDdeZHXM=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.48.0",
-        "@typescript-eslint/types": "^8.48.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1629,13 +1589,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.48.0",
-      "integrity": "sha1-gwav30CTZNTkNIE/DfmoVX3f91E=",
+      "version": "8.56.0",
+      "integrity": "sha1-YEAwpMZDPfNyjv/dRB1H9FqG7bQ=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1646,8 +1606,8 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.48.0",
-      "integrity": "sha1-Bc8JHNnySo4Ed4P/l5E232zxvgQ=",
+      "version": "8.56.0",
+      "integrity": "sha1-JTjOg8vDduaFSHlgy7JLZf4qvE4=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1662,16 +1622,16 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.48.0",
-      "integrity": "sha1-604OYOVFtEgRLykbZlLu3bFtuD8=",
+      "version": "8.56.0",
+      "integrity": "sha1-crTtwfxzmImY8WMrPsmcKmbqrG4=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1681,13 +1641,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.48.0",
-      "integrity": "sha1-8Nxc8nIXNG6bDZBVaRHgHZDQ8qU=",
+      "version": "8.56.0",
+      "integrity": "sha1-okRAEbmpjKE9cEEdLL/tVEOzUmo=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1699,20 +1659,20 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.48.0",
-      "integrity": "sha1-OLNAUkzjTODkbKVBqGz2ytiHLls=",
+      "version": "8.56.0",
+      "integrity": "sha1-+tvHTBTFuslH2wSYD/WLsXhwHC4=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.48.0",
-        "@typescript-eslint/tsconfig-utils": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/visitor-keys": "8.48.0",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.4.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1726,15 +1686,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.48.0",
-      "integrity": "sha1-wRlr77Zk9QvhBpLHgcf8diTBpfk=",
+      "version": "8.56.0",
+      "integrity": "sha1-Bjzm9wLsYD3huD7nle1eh31veEE=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.48.0",
-        "@typescript-eslint/types": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1744,18 +1704,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.48.0",
-      "integrity": "sha1-awfvVmGoXQiwH75LgxCnMRpkca8=",
+      "version": "8.56.0",
+      "integrity": "sha1-fWWSqwAYJ9POBSFV7ffsrRlojX0=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.48.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1765,9 +1725,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "integrity": "sha1-uaoadKpIxEs65GwVl85xcSRqlKk=",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.2",
-      "integrity": "sha1-EEjfYYKwK+yJYqnP/Rxe4aEpVB8=",
+      "version": "0.3.3",
+      "integrity": "sha1-YnZ7iN87p/xTv9ZqlMiN/h3sVbw=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1792,8 +1764,8 @@
       "optional": true
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "1.2.0",
-      "integrity": "sha1-A37FLMEooPEfaIkmTZR4zZVT8jQ=",
+      "version": "1.5.0",
+      "integrity": "sha1-LWnb19JAZjZZyi7xoMLTpib8rp4=",
       "license": "MIT",
       "dependencies": {
         "@microsoft/1ds-core-js": "^4.3.10",
@@ -2024,6 +1996,15 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/vsce/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "integrity": "sha1-TQo/EnBYBDvy5+4Wnq8w7ZATAvM=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@vscode/vsce/node_modules/brace-expansion": {
       "version": "1.1.12",
       "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
@@ -2057,13 +2038,37 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.2",
+      "integrity": "sha1-JBWR6mNHAr75xIJpbyRpQG4W0jM=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jackspeak": "^4.2.3"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "integrity": "sha1-tsFtB5EIevbCvEY/UqgUIEbAa28=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-      "version": "10.1.1",
-      "integrity": "sha1-5uYbmwwdyrEWtafRRY6LaunnOlU=",
+      "version": "10.2.1",
+      "integrity": "sha1-nYKDWDTNyF1QhN0FXppGhfpW5fA=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": "20 || >=22"
@@ -2073,12 +2078,12 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/jackspeak": {
-      "version": "4.1.1",
-      "integrity": "sha1-lodgMPRQUCBH/H6Mf8+M6BJOQ64=",
+      "version": "4.2.3",
+      "integrity": "sha1-J++A8zuTQSA3w76k+O3fgOGTFIM=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
+        "@isaacs/cliui": "^9.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -2088,10 +2093,10 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "integrity": "sha1-QP037f/PrkspQDecByLcbuqnXyQ=",
+      "version": "11.2.6",
+      "integrity": "sha1-NWv4op6Ip6KUVQezH2QpploZLFg=",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
       }
@@ -2155,8 +2160,8 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "integrity": "sha1-N9mlx3ava8ktf0+VEOukwKYNEaY=",
+      "version": "8.18.0",
+      "integrity": "sha1-iGQYa2c40APrOpMxcrs4M+EM77w=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2180,8 +2185,8 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "7.2.0",
-      "integrity": "sha1-MbJa+j7dPvwJ2Ywv7oMdRg/wa0k=",
+      "version": "7.3.0",
+      "integrity": "sha1-U5W7dLIVCkodbjwlZfSuynjShic=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2235,13 +2240,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
+      "devOptional": true,
+      "license": "Python-2.0"
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -2545,8 +2547,8 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "integrity": "sha1-Jq936JM2yBxj6oMZf4aLTL01E2k=",
+      "version": "1.2.0",
+      "integrity": "sha1-8jt3fEkCHq10ddzzOQ01Naf4ltY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2555,11 +2557,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -2866,8 +2868,8 @@
       "optional": true
     },
     "node_modules/default-browser": {
-      "version": "5.4.0",
-      "integrity": "sha1-tVzzNbsLRl3XyWGgLNJCRqpDQoc=",
+      "version": "5.5.0",
+      "integrity": "sha1-J5LohvJCKJRUWUfMgOGkRElsWXY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2925,8 +2927,8 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "integrity": "sha1-Jt7QR80RebeLlTfV73JVA84a5TE=",
+      "version": "5.2.2",
+      "integrity": "sha1-CkdCeXKB0Jz6aZt56jLSdyNiO60=",
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -3005,8 +3007,8 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "integrity": "sha1-aWzi7Aqg5uqTo5f/zySqeEDIJ8s=",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -3063,13 +3065,13 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "integrity": "sha1-m19MXAdrh4fHj+VAOSznaoiFW0Q=",
+      "version": "5.19.0",
+      "integrity": "sha1-ZodEahXpaeqmPC+iaUUQ4Xrm2Xw=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -3145,8 +3147,8 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.0",
-      "integrity": "sha1-25g77W92mBNhyS9Qz2oExm97Ph0=",
+      "version": "0.27.3",
+      "integrity": "sha1-WFnKjnCjr5VrJolc5JVNfnO9J6g=",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3157,32 +3159,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.0",
-        "@esbuild/android-arm": "0.27.0",
-        "@esbuild/android-arm64": "0.27.0",
-        "@esbuild/android-x64": "0.27.0",
-        "@esbuild/darwin-arm64": "0.27.0",
-        "@esbuild/darwin-x64": "0.27.0",
-        "@esbuild/freebsd-arm64": "0.27.0",
-        "@esbuild/freebsd-x64": "0.27.0",
-        "@esbuild/linux-arm": "0.27.0",
-        "@esbuild/linux-arm64": "0.27.0",
-        "@esbuild/linux-ia32": "0.27.0",
-        "@esbuild/linux-loong64": "0.27.0",
-        "@esbuild/linux-mips64el": "0.27.0",
-        "@esbuild/linux-ppc64": "0.27.0",
-        "@esbuild/linux-riscv64": "0.27.0",
-        "@esbuild/linux-s390x": "0.27.0",
-        "@esbuild/linux-x64": "0.27.0",
-        "@esbuild/netbsd-arm64": "0.27.0",
-        "@esbuild/netbsd-x64": "0.27.0",
-        "@esbuild/openbsd-arm64": "0.27.0",
-        "@esbuild/openbsd-x64": "0.27.0",
-        "@esbuild/openharmony-arm64": "0.27.0",
-        "@esbuild/sunos-x64": "0.27.0",
-        "@esbuild/win32-arm64": "0.27.0",
-        "@esbuild/win32-ia32": "0.27.0",
-        "@esbuild/win32-x64": "0.27.0"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/esbuild-register": {
@@ -3219,8 +3221,8 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.1",
-      "integrity": "sha1-vov3xt533MQlK1qNyzHC7/90puU=",
+      "version": "9.39.2",
+      "integrity": "sha1-y2Dm0WqyNMD4Npo/58yHln+vS2w=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3230,7 +3232,7 @@
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
+        "@eslint/js": "9.39.2",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3393,22 +3395,9 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "integrity": "sha1-kUGSNPgE2FKoLc7sPhbNwiz52uc=",
+      "version": "1.7.0",
+      "integrity": "sha1-CNBI8mHw3e21uulfRoCUY9nJSW0=",
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -3509,8 +3498,8 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "integrity": "sha1-1Q6rqAPIhGqIPBZJKCHrzSzaVfU=",
+      "version": "1.20.1",
+      "integrity": "sha1-ynUKENySW8ixiDn9ID4+9LPO1nU=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3634,8 +3623,8 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "integrity": "sha1-yDiu3cb0qMdN0V+F4R/lURv+AqQ=",
+      "version": "11.3.3",
+      "integrity": "sha1-on2iO3JSToGsbDgVzAF5uMdMWe4=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3830,12 +3819,6 @@
       "devOptional": true,
       "license": "ISC"
     },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "integrity": "sha1-+y8dVeDjoYSa7/yQxPoN1ToOZsY=",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
@@ -3912,8 +3895,8 @@
       "optional": true
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "integrity": "sha1-d60kkDe2a/jMmcbihu9zuDrrYh0=",
+      "version": "10.1.0",
+      "integrity": "sha1-/j8uEsc7bkYtThA5XbnBEZ5NauQ=",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -3926,13 +3909,13 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "integrity": "sha1-wow0pDN5yn9h0HQTCy9fcCCjBpQ=",
+      "version": "7.0.1",
+      "integrity": "sha1-JuioiInbY0F9y5oeeaPxvJK1l2s=",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -4194,8 +4177,8 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "3.1.0",
-      "integrity": "sha1-4cZX45wQCQr8vt7GFyD2uSTDy9I=",
+      "version": "3.1.1",
+      "integrity": "sha1-MniXsmgyo+sRfabCdJLQTKEyWU8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4307,13 +4290,12 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "integrity": "sha1-d0hc4d1/M8Bh/RsW7OojtV/LBLA=",
-      "dev": true,
+      "version": "4.1.1",
+      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -4368,12 +4350,12 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "integrity": "sha1-Zf+R9KvvF4RpfUCVK7GZjFBMqvM=",
+      "version": "9.0.3",
+      "integrity": "sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jws": "^3.2.2",
+        "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
         "lodash.isboolean": "^3.0.3",
         "lodash.isinteger": "^4.0.4",
@@ -4408,8 +4390,8 @@
       "optional": true
     },
     "node_modules/jwa": {
-      "version": "1.4.2",
-      "integrity": "sha1-FgEaxttI3nsQJ3fleJeQFSDux7k=",
+      "version": "2.0.1",
+      "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4419,12 +4401,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "integrity": "sha1-ABCZ82OUaMlBQADpmZX6UvtHgwQ=",
+      "version": "4.0.1",
+      "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -4505,8 +4487,8 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
+      "version": "4.17.23",
+      "integrity": "sha1-8ROwN4OGEDvk9okziMc9C95/LFo=",
       "dev": true,
       "license": "MIT"
     },
@@ -4608,8 +4590,8 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "integrity": "sha1-PDxZkog8Yz20cUzLTXtZNdmLfUU=",
+      "version": "14.1.1",
+      "integrity": "sha1-hW+Qtm/DmucK/9JcGxi1gdfe7h8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4623,12 +4605,6 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4810,12 +4786,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/mocha/node_modules/argparse": {
-      "version": "2.0.1",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "license": "Python-2.0",
-      "optional": true
-    },
     "node_modules/mocha/node_modules/cliui": {
       "version": "7.0.4",
       "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
@@ -4844,18 +4814,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
@@ -4989,8 +4947,8 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.85.0",
-      "integrity": "sha1-sRXVdeUrJJXvCDcrBY4T0gKHWn0=",
+      "version": "3.87.0",
+      "integrity": "sha1-Qj4o/qXC8ZX93Zis3tmTjAAa5t0=",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5009,8 +4967,8 @@
       "optional": true
     },
     "node_modules/node-sarif-builder": {
-      "version": "3.3.1",
-      "integrity": "sha1-oyYOjVC/78i1Sa6N2T7AqboAejo=",
+      "version": "3.4.0",
+      "integrity": "sha1-nBrAJpGfWXfhAU8OJtT2nw9Fvs0=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5534,8 +5492,8 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "integrity": "sha1-zNoCoQA+u7K/2m+DoHSXj2CLk5M=",
+      "version": "3.8.1",
+      "integrity": "sha1-7fSJd8+ZFVj0/L2KO6YBW6KjoXM=",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5600,8 +5558,8 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
+      "version": "6.15.0",
+      "integrity": "sha1-24/V0bHS1rWzOtr4dCmAXxkJ57M=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5669,24 +5627,6 @@
         "js-yaml": "^4.1.0",
         "json5": "^2.2.2",
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/rc-config-loader/node_modules/argparse": {
-      "version": "2.0.1",
-      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg=",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/rc-config-loader/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/rc/node_modules/strip-json-comments": {
@@ -5890,10 +5830,13 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.4.3",
-      "integrity": "sha1-/OuuO3Vs3IQoMhgF9LcPFuwKtds=",
+      "version": "1.4.4",
+      "integrity": "sha1-8pwruoDOW4b0NDtMK+nyuWYnz4s=",
       "dev": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/secretlint": {
       "version": "10.2.2",
@@ -5917,8 +5860,8 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "integrity": "sha1-S19BQ9AHYzqNxnHNCm75FHuLuUY=",
+      "version": "7.7.4",
+      "integrity": "sha1-KEZONgYOmR+noR0CedLT87V6foo=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6194,12 +6137,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
       "integrity": "sha1-OQA39ExK4aGuU1xf443Dq6jZl74=",
@@ -6245,8 +6182,8 @@
       "name": "string-width",
       "version": "4.2.3",
       "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6259,8 +6196,8 @@
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6268,8 +6205,8 @@
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6317,8 +6254,8 @@
       "name": "strip-ansi",
       "version": "6.0.1",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -6329,8 +6266,8 @@
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6651,8 +6588,8 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "integrity": "sha1-WV9wlORu7TZME/0j51+VE9Kbr5E=",
+      "version": "2.4.0",
+      "integrity": "sha1-JpBXn5bSeQJTvc8co11WmtePmtg=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -6747,15 +6684,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.48.0",
-      "integrity": "sha1-Hwz7MzUfV0DVoom/OJtMystkvkI=",
+      "version": "8.56.0",
+      "integrity": "sha1-9Ghsyq8vuG2vATOCDaQMpZYaIjY=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.48.0",
-        "@typescript-eslint/parser": "8.48.0",
-        "@typescript-eslint/typescript-estree": "8.48.0",
-        "@typescript-eslint/utils": "8.48.0"
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6765,7 +6702,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
@@ -6782,8 +6719,8 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.16.0",
-      "integrity": "sha1-yyoelXcm1Fi1NuPwdr9R8GaQHBo=",
+      "version": "7.22.0",
+      "integrity": "sha1-eoJZClkI5QSkfYXGCw+JyhQkDmA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6994,8 +6931,8 @@
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "integrity": "sha1-VtwiNo7lcPrOG0mBmXXZuaXq0hQ=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -7012,8 +6949,8 @@
       "name": "wrap-ansi",
       "version": "7.0.0",
       "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -7029,8 +6966,8 @@
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7038,8 +6975,8 @@
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7050,8 +6987,8 @@
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.3",
       "integrity": "sha1-wETV3MUhoHZBNHJZehrLHxA8QEE=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -7062,14 +6999,14 @@
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
       "integrity": "sha1-hAyIA7DYBH9P8M+WMXazLU7z7XI=",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
       "integrity": "sha1-FPja7G2B5yIdKjV+Zoyrc728p5Q=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
     "onCommand:PowerShell.SpecifyScriptArgs"
   ],
   "dependencies": {
-    "@vscode/extension-telemetry": "^1.2.0",
-    "semver": "^7.7.3",
+    "@vscode/extension-telemetry": "^1.5.0",
+    "semver": "^7.7.4",
     "untildify": "^4.0.0",
     "uuid": "^13.0.0",
     "vscode-languageclient": "^9.0.1",
@@ -69,12 +69,12 @@
   },
   "devDependencies": {
     "@vscode/vsce": "^3.7.1",
-    "esbuild": "^0.27.0"
+    "esbuild": "^0.27.3"
   },
   "optionalDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/mock-fs": "^4.13.4",
-    "@types/node": "^22.19.1",
+    "@types/node": "^22.19.11",
     "@types/semver": "^7.7.1",
     "@types/sinon": "^17.0.4",
     "@types/ungap__structured-clone": "^1.2.0",
@@ -84,14 +84,14 @@
     "@vscode/test-cli": "^0.0.10",
     "@vscode/test-electron": "^2.5.2",
     "esbuild-register": "^3.6.0",
-    "eslint": "^9.39.1",
+    "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "mock-fs": "^5.5.0",
-    "prettier": "^3.6.2",
+    "prettier": "^3.8.1",
     "prettier-plugin-organize-imports": "^4.3.0",
     "sinon": "^19.0.5",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.48.0"
+    "typescript-eslint": "^8.56.0"
   },
   "extensionDependencies": [
     "vscode.powershell"


### PR DESCRIPTION
Updates npm packages to their latest versions within current semver ranges.

## Changes

- `@eslint/js`: 9.39.1 → 9.39.2
- `@types/node`: 22.19.1 → 22.19.11
- `@vscode/extension-telemetry`: 1.2.0 → 1.5.0
- `esbuild`: 0.27.0 → 0.27.3
- `eslint`: 9.39.1 → 9.39.2
- `prettier`: 3.6.2 → 3.8.1
- `semver`: 7.7.3 → 7.7.4
- `typescript-eslint`: 8.48.0 → 8.56.0

Skipped (major version bumps that require evaluation):
- `@eslint/js`/`eslint`: v10 (breaking changes)
- `@types/sinon`/`sinon`: v21
- `@types/vscode`: v1.109 (tied to engine version)
- `untildify`: v6