### PR TITLE
Add new code formatting preset "OTPS": OTBS with `else` on new line

### DIFF
--- a/package.json
+++ b/package.json
@@ -777,6 +777,7 @@
               "Custom",
               "Allman",
               "OTBS",
+              "OTPS",
               "Stroustrup"
             ],
             "markdownEnumDescriptions": [

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -46,6 +46,7 @@ export enum CodeFormattingPreset {
     Custom = "Custom",
     Allman = "Allman",
     OTBS = "OTBS",
+    OTPS = "OTPS",
     Stroustrup = "Stroustrup",
 }
 


### PR DESCRIPTION
Edit: Blocked, see <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045#issuecomment-4016377821>.

## PR Summary

Depends on:

* PSScriptAnalyzer: <https://github.com/PowerShell/PSScriptAnalyzer/pull/2158>
* PowerShellEditorServices: <https://github.com/PowerShell/PowerShellEditorServices/pull/2269>

This PR adds a new code formatting preset, "OTPS" (**O**ne **T**rue **P**owerShell **S**tyle): OTBS with `else` on new line.

Thoughts behind the name:

* To mock the idea of one true formatting style, even though there are none.
* We do ONE change from OTBS (`else` on new line), also in the name (change B with P).

Feature request:

* <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045>

Also related:

<https://github.com/PowerShell/vscode-powershell/issues/5109>

Context:

* "There is no One True Brace Style": <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177>
  * About OTBS with `else` on a new line:
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518163>
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518179>

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
