### PR TITLE
Correct Windows log path in troubleshooting guide

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -269,7 +269,7 @@ your logs for any sensitive information you would not like to share online!**
 
 * Logs are located at:
   * Unix: `~/.config/Code/User/globalStorage/ms-vscode.powershell/logs`.
-  * Windows: `%APPDATA%\Code\User\globalStorage\ms-vscode.powershell\logs`
+  * Windows: `%APPDATA%\Code\User\globalStorage\ms-vscode.powershell\sessions`
 
 * In VS Code you can open and read the logs directly from the [Command Palette][]
   (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>) with `PowerShell: Open PowerShell Extension Logs Folder`.


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
Updated Windows log path to reflect `sessions` instead of `logs`.
<img width="1138" height="308" alt="The old path throws an exeption `not exist`" src="https://github.com/user-attachments/assets/d20f0ba3-e1c8-48f9-87f0-64cc3b67df2b" />
<img width="2278" height="1200" alt="The logs are stored in `sessions`" src="https://github.com/user-attachments/assets/b4471d61-87ef-4b43-ae55-23c4d7d91a32" />

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready