### PR TITLE
Add in settings to control Enum member Alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -885,6 +885,11 @@
             "default": true,
             "markdownDescription": "Align assignment statements in a hashtable or a DSC Configuration."
           },
+          "powershell.codeFormatting.alignEnumMemberValues": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Align member value assignments in an Enum Type Definition."
+          },
           "powershell.codeFormatting.useConstantStrings": {
             "type": "boolean",
             "default": false,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -92,6 +92,7 @@ class CodeFormattingSettings extends PartialSettings {
     trimWhitespaceAroundPipe = false;
     ignoreOneLineBlock = true;
     alignPropertyValuePairs = true;
+    alignEnumMemberValues = true;
     useConstantStrings = false;
     useCorrectCasing = false;
 }


### PR DESCRIPTION
## PR Summary

This PR exposes the new PSSA setting for controlling whether Enum formatting is enabled or disabled.

<img width="307" height="49" alt="image" src="https://github.com/user-attachments/assets/462d11b9-ce11-4bb8-b76e-10030ae4ea40" />

[PSScriptAnalyzer 1.25.0](https://github.com/PowerShell/PSScriptAnalyzer/releases/tag/1.25.0) has been released (🎉) and contains https://github.com/PowerShell/PSScriptAnalyzer/pull/2132 which added support for Enum formatting.

There is a corresponding PR in the PowerShellEditorServices which exposes the setting from the language server. https://github.com/PowerShell/PowerShellEditorServices/pull/2271

Fixes #5138 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
