### PR TITLE
Fix new suppress terminal setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1047,7 +1047,7 @@
             "default": false,
             "markdownDescription": "Do not show the startup banner in the PowerShell Extension Terminal."
           },
-          "powershell.suppressTerminalStoppedNotification": {
+          "powershell.integratedConsole.suppressTerminalStoppedNotification": {
             "type": "boolean",
             "default": false,
             "markdownDescription": "Do not show a notification when the PowerShell Extension Terminal has stopped."

--- a/src/session.ts
+++ b/src/session.ts
@@ -1159,13 +1159,9 @@ Type 'help' to get help.
     }
 
     private async promptForRestart(): Promise<void> {
-        // Check user configuration before showing notification
-        const suppressNotification =
-            vscode.workspace
-                .getConfiguration("powershell")
-                .get<boolean>("suppressTerminalStoppedNotification") ?? false;
-
-        if (suppressNotification) {
+        if (
+            getSettings().integratedConsole.suppressTerminalStoppedNotification
+        ) {
             return;
         }
 
@@ -1186,7 +1182,7 @@ Type 'help' to get help.
                     prompt: "Don't Show Again",
                     action: async (): Promise<void> => {
                         await changeSetting(
-                            "suppressTerminalStoppedNotification",
+                            "integratedConsole.suppressTerminalStoppedNotification",
                             true,
                             true,
                             this.logger,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -133,6 +133,7 @@ class IntegratedConsoleSettings extends PartialSettings {
     useLegacyReadLine = false;
     forceClearScrollbackBuffer = false;
     suppressStartupBanner = false;
+    suppressTerminalStoppedNotification = false;
     startLocation = StartLocation.Panel;
 }
 


### PR DESCRIPTION
Behaviorally it was working, but it wasn't showing up in the settings. We also hadn't mapped it into our (pointless IMHO) `Settings` class, or put it under the "correct" section of `integratedConsole`.

To be honest, it's open work to migrate away from `getSettings()` and to just using the VS Code APIs directly, but we shouldn't do it now.