### PR TITLE
fix: Remove files.defaultLanguage from example settings

### DIFF
--- a/examples/.vscode/settings.json
+++ b/examples/.vscode/settings.json
@@ -2,5 +2,9 @@
   // Use a custom PowerShell Script Analyzer settings file for this workspace.
   // Relative paths for this setting are always relative to the workspace root dir.
   "powershell.scriptAnalysis.settingsPath": "./PSScriptAnalyzerSettings.psd1",
-  "files.defaultLanguage": "powershell"
+  // NOTE: "files.defaultLanguage" has been removed because it overrides user's
+  // global editor settings without explicit consent, which is unexpected behavior.
+  // Users who want PowerShell as the default language can add this setting
+  // to their user or workspace settings if desired.
+  // See: https://github.com/PowerShell/vscode-powershell/issues/5330
 }


### PR DESCRIPTION
## Description

Removes the `files.defaultLanguage: powershell` setting from the example settings file (`examples/.vscode/settings.json`).

## Problem

After installing the PowerShell extension, users observed that new untitled files defaulted to PowerShell language mode. This happened because the example settings file contained the `files.defaultLanguage` setting, which was being applied automatically and overriding users' global editor defaults without explicit consent.

## Solution

Removed the `files.defaultLanguage` setting from the example settings file and added a comment explaining that users who want PowerShell as the default language can add this setting to their user or workspace settings manually if desired.

## Changes

- Modified `examples/.vscode/settings.json`: Removed the `files.defaultLanguage: powershell` line and added explanatory comments

## Testing

- Verified the file parses correctly as JSON after the change
- The `powershell.scriptAnalysis.settingsPath` setting is preserved

## References

Fixes #5330

---

*This contribution was developed with AI assistance.*
