### PR TITLE
Add Mocha Types as a optional dependency for Intellisense

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
-        "@types/mocha": "^10.0.10",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.0"
       },
@@ -27,6 +26,7 @@
       },
       "optionalDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/mocha": "^10.0.10",
         "@types/mock-fs": "^4.13.4",
         "@types/node": "^22.19.17",
         "@types/semver": "^7.7.1",
@@ -1398,8 +1398,8 @@
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
+        "@types/mocha": "^10.0.10",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.28.0"
       },
@@ -1397,8 +1398,8 @@
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "integrity": "sha1-kfYpBejSPL1mIlMS8jlFSiO+v6A=",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/mock-fs": {
       "version": "4.13.4",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vscode-languageserver-protocol": "^3.17.5"
   },
   "devDependencies": {
+    "@types/mocha": "^10.0.10",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.0"
   },

--- a/package.json
+++ b/package.json
@@ -69,12 +69,12 @@
     "vscode-languageserver-protocol": "^3.17.5"
   },
   "devDependencies": {
-    "@types/mocha": "^10.0.10",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.28.0"
   },
   "optionalDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/mocha": "^10.0.10",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^22.19.17",
     "@types/semver": "^7.7.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "verbatimModuleSyntax": true,
     "strict": true,
     "noEmit": true,
-    "module": "Preserve"
+    "module": "Preserve",
+    "types": ["mocha"]
   },
   "include": ["**/*.ts", "eslint.config.mjs", ".vscode-test.mjs"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Add Mocha as a devdependency to restore Intellisense functionality. Update TypeScript configuration to include Mocha types.

Fixes regression from cb773b1afd2e1701bdfc5c00cfadf9bff30302d4

