### PR TITLE
[REGRESSION] Fix didOpen handler binding

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -490,21 +490,21 @@ export class SessionManager implements Middleware {
     // is fully initialized. This prevents stale parser diagnostics (e.g.
     // unresolved custom attribute types) that would otherwise appear because
     // textDocument/didOpen is sent before the server's type resolution is ready.
-    public async didOpen(
+    public didOpen = async (
         document: vscode.TextDocument,
         next: (document: vscode.TextDocument) => Promise<void>,
-    ): Promise<void> {
+    ): Promise<void> => {
         await this.started.promise;
         return next(document);
-    }
+    };
 
-    public async didChange(
+    public didChange = async (
         event: vscode.TextDocumentChangeEvent,
         next: (event: vscode.TextDocumentChangeEvent) => Promise<void>,
-    ): Promise<void> {
+    ): Promise<void> => {
         await this.started.promise;
         return next(event);
-    }
+    };
 
     // TODO: Is this used by the magic of "Middleware" in the client library?
     public resolveCodeLens(

--- a/test/core/session.test.ts
+++ b/test/core/session.test.ts
@@ -1,0 +1,170 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { type TelemetryReporter } from "@vscode/extension-telemetry";
+import * as assert from "assert";
+import Sinon from "sinon";
+import * as vscode from "vscode";
+import type { DocumentSelector } from "vscode-languageclient";
+import { SessionManager } from "../../src/session";
+import { stubInterface, testLogger } from "../utils";
+
+describe("SessionManager middleware", () => {
+    afterEach(() => {
+        Sinon.restore();
+    });
+
+    it("delays didOpen until session initialization completes", async () => {
+        const registerCommandStub = Sinon.stub(
+            vscode.commands,
+            "registerCommand",
+        ).returns(disposableStub());
+        const onDidChangeConfigurationStub = Sinon.stub(
+            vscode.workspace,
+            "onDidChangeConfiguration",
+        ).returns(disposableStub());
+
+        Sinon.stub(vscode.languages, "createLanguageStatusItem").returns(
+            stubInterface<vscode.LanguageStatusItem>({
+                text: "",
+                detail: "",
+                busy: false,
+                severity: vscode.LanguageStatusSeverity.Information,
+                dispose: () => {
+                    return;
+                },
+            }),
+        );
+
+        const manager = new SessionManager(
+            stubInterface<vscode.ExtensionContext>({
+                globalStorageUri: vscode.Uri.file("C:/tmp"),
+                extensionMode: vscode.ExtensionMode.Test,
+                subscriptions: [],
+                logUri: vscode.Uri.file("C:/tmp"),
+            }),
+            testLogger,
+            ["powershell"] as DocumentSelector,
+            "Visual Studio Code",
+            "PowerShell",
+            "2026.5.0",
+            "ms-vscode",
+            stubInterface<TelemetryReporter>(),
+        );
+
+        const document = stubInterface<vscode.TextDocument>();
+        let nextCalled = false;
+        const next = Sinon.spy(
+            (_document: vscode.TextDocument): Promise<void> => {
+                nextCalled = true;
+                return Promise.resolve();
+            },
+        );
+
+        const didOpenPromise = manager.didOpen(document, next);
+
+        await Promise.resolve();
+        assert.equal(
+            nextCalled,
+            false,
+            "didOpen should wait for initialization",
+        );
+
+        (
+            manager as unknown as {
+                started: PromiseWithResolvers<undefined>;
+            }
+        ).started.resolve(undefined);
+
+        await didOpenPromise;
+        assert.equal(
+            nextCalled,
+            true,
+            "didOpen should run after initialization",
+        );
+        assert.ok(
+            registerCommandStub.calledThrice,
+            "SessionManager should register its commands in constructor",
+        );
+        assert.ok(
+            onDidChangeConfigurationStub.calledOnce,
+            "SessionManager should register configuration listener in constructor",
+        );
+    });
+
+    it("delays didChange until session initialization completes", async () => {
+        Sinon.stub(vscode.commands, "registerCommand").returns(
+            disposableStub(),
+        );
+        Sinon.stub(vscode.workspace, "onDidChangeConfiguration").returns(
+            disposableStub(),
+        );
+
+        Sinon.stub(vscode.languages, "createLanguageStatusItem").returns(
+            stubInterface<vscode.LanguageStatusItem>({
+                text: "",
+                detail: "",
+                busy: false,
+                severity: vscode.LanguageStatusSeverity.Information,
+                dispose: () => {
+                    return;
+                },
+            }),
+        );
+
+        const manager = new SessionManager(
+            stubInterface<vscode.ExtensionContext>({
+                globalStorageUri: vscode.Uri.file("C:/tmp"),
+                extensionMode: vscode.ExtensionMode.Test,
+                subscriptions: [],
+                logUri: vscode.Uri.file("C:/tmp"),
+            }),
+            testLogger,
+            ["powershell"] as DocumentSelector,
+            "Visual Studio Code",
+            "PowerShell",
+            "2026.5.0",
+            "ms-vscode",
+            stubInterface<TelemetryReporter>(),
+        );
+
+        const changeEvent = stubInterface<vscode.TextDocumentChangeEvent>();
+        let nextCalled = false;
+        const next = Sinon.spy(
+            (_event: vscode.TextDocumentChangeEvent): Promise<void> => {
+                nextCalled = true;
+                return Promise.resolve();
+            },
+        );
+
+        const didChangePromise = manager.didChange(changeEvent, next);
+
+        await Promise.resolve();
+        assert.equal(
+            nextCalled,
+            false,
+            "didChange should wait for initialization",
+        );
+
+        (
+            manager as unknown as {
+                started: PromiseWithResolvers<undefined>;
+            }
+        ).started.resolve(undefined);
+
+        await didChangePromise;
+        assert.equal(
+            nextCalled,
+            true,
+            "didChange should run after initialization",
+        );
+    });
+});
+
+function disposableStub(): vscode.Disposable {
+    return {
+        dispose: (): void => {
+            return;
+        },
+    };
+}

--- a/test/core/session.test.ts
+++ b/test/core/session.test.ts
@@ -61,7 +61,8 @@ describe("SessionManager middleware", () => {
             },
         );
 
-        const didOpenPromise = manager.didOpen(document, next);
+        const didOpen = manager.didOpen;
+        const didOpenPromise = didOpen(document, next);
 
         await Promise.resolve();
         assert.equal(
@@ -137,7 +138,8 @@ describe("SessionManager middleware", () => {
             },
         );
 
-        const didChangePromise = manager.didChange(changeEvent, next);
+        const didChange = manager.didChange;
+        const didChangePromise = didChange(changeEvent, next);
 
         await Promise.resolve();
         assert.equal(


### PR DESCRIPTION
Improve the `didOpen` method to ensure it does not get stuck due to an undefined context. Add tests to verify the behavior of `didOpen` and `didChange` methods, confirming they wait for session initialization before proceeding.

Fixes regression in bd33d21621bad6adc663f9f88af31cafbf76f70c

## PR Summary

Improve the `didOpen` method to ensure it does not get stuck due to an undefined context. Add tests to verify the behavior of `didOpen` and `didChange` methods, confirming they wait for session initialization before proceeding.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready

