### PR TITLE
Default `useLegacyCodeLens` to `false` for Pester 5 CodeLens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1008,8 +1008,8 @@
         "properties": {
           "powershell.pester.useLegacyCodeLens": {
             "type": "boolean",
-            "default": true,
-            "markdownDescription": "Use a CodeLens that is compatible with Pester 4. Disabling this will show `Run Tests` on all `It`, `Describe` and `Context` blocks, and will correctly work only with Pester 5 and newer."
+            "default": false,
+            "markdownDescription": "Use the legacy CodeLens compatible with Pester 4 (only shows `Run Tests` on `Describe` blocks). When disabled (the default), `Run Tests` is shown on all `It`, `Describe` and `Context` blocks for Pester 5 and newer."
           },
           "powershell.pester.codeLens": {
             "type": "boolean",

--- a/src/features/PesterTests.ts
+++ b/src/features/PesterTests.ts
@@ -149,7 +149,7 @@ export class PesterTestsFeature implements vscode.Disposable {
 
         const useLegacyCodeLens = pesterConfig.get<boolean>(
             "useLegacyCodeLens",
-            true,
+            false,
         );
         if (!useLegacyCodeLens) {
             launchConfig.args.push("-MinimumVersion5");


### PR DESCRIPTION
Pester 4 has been EOL since 2020 and Pester 5 is the current stable. Default the CodeLens to the Pester 5 layout (`Run Tests` on `It`, `Describe` and `Context`) instead of the Pester 4 one (`Run Tests` on `Describe` only).

- `package.json`: flip `powershell.pester.useLegacyCodeLens.default` from `true` to `false`, update description.
- `src/features/PesterTests.ts`: flip the matching fallback in `pesterConfig.get<boolean>("useLegacyCodeLens", …)` to keep runner and CodeLens in sync.

Impact: users who have not explicitly set the value get CodeLens on `It` and `Context` too, and clicking it runs `InvokePesterStub.ps1` with `-MinimumVersion5`. On systems with only Pester 4 the stub falls back to v4 and warns; tests still run but the line-level filter is a v5 feature. Workaround: set `powershell.pester.useLegacyCodeLens` to `true` in user or workspace settings.

Verified: `npm run compile`, `npm run lint`, `npm run format` clean. No tests in this repo reference the setting. PSES already handles both modes in `PesterCodeLensProvider.cs`.
