### PR TITLE
Pass --user-data-dir to keep mac CI IPC socket path under 103 chars

### DIFF
--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,7 @@
 import { defineConfig } from "@vscode/test-cli";
 import { existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 export default defineConfig({
     files: "test/**/*.test.ts",
@@ -10,6 +12,11 @@ export default defineConfig({
         "--disable-extensions",
         // Undocumented but valid option to use a temporary profile for testing
         "--profile-temp",
+        // Keep the user-data-dir short. The default lives under .vscode-test/
+        // which, combined with the nested checkout paths CI uses, can push the
+        // main IPC socket path over the macOS 103-char AF_UNIX limit and fail
+        // with EINVAL. See microsoft/vscode#196543.
+        `--user-data-dir=${join(tmpdir(), "vscp")}`,
     ],
     workspaceFolder: `test/${existsSync("C:\\powershell-7\\pwsh.exe") ? "OneBranch" : "TestEnvironment"}.code-workspace`,
     mocha: {


### PR DESCRIPTION
The mac CI job has been failing on every push since the latest VS Code Insiders bump. Same symptom in every log:

```
WARNING: IPC handle ".../.vscode-test/user-data/1.12-main.sock" is longer than 103 chars, try a shorter --user-data-dir
[main] Error: listen EINVAL: invalid argument .../1.12-main.sock
```

That path is 110 chars. The triple nesting (`work/repo/repo/repo/`) comes from `actions/checkout@v6 path: vscode-powershell` plus the sibling PSES clone — unavoidable. The default `--user-data-dir` sits inside that, and any `<version>-main.sock` filename pushes the IPC socket over the macOS 103-char `AF_UNIX` limit.

Pointing `--user-data-dir` at `os.tmpdir()` shortens the path well under the limit on every platform. Windows uses named pipes so it's unaffected either way; Linux's limit is roomier but the shorter path doesn't hurt.

Same class of bug as microsoft/vscode#196543 (2023, then with `1.84-main.sock`).