### PR TITLE
Clean up dead code and other low-hanging tech debt

### DIFF
--- a/src/features/CodeActions.ts
+++ b/src/features/CodeActions.ts
@@ -27,7 +27,7 @@ export class CodeActionsFeature implements vscode.Disposable {
 
     private async showRuleDocumentation(ruleId: string): Promise<void> {
         const pssaDocBaseURL =
-            "https://docs.microsoft.com/powershell/utility-modules/psscriptanalyzer/rules/";
+            "https://learn.microsoft.com/powershell/utility-modules/psscriptanalyzer/rules/";
 
         if (!ruleId) {
             this.log.writeWarning(

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -755,21 +755,6 @@ export class PowerShellExeFinder {
     }
 }
 
-export function getWindowsSystemPowerShellPath(
-    systemFolderName: string,
-): string | undefined {
-    if (process.env.windir === undefined) {
-        return undefined;
-    } else
-        return path.join(
-            process.env.windir,
-            systemFolderName,
-            "WindowsPowerShell",
-            "v1.0",
-            "powershell.exe",
-        );
-}
-
 interface IPossiblePowerShellExe extends IPowerShellExeDetails {
     exists(): Promise<boolean>;
     readonly suppressWarning: boolean;

--- a/src/session.ts
+++ b/src/session.ts
@@ -4,9 +4,10 @@
 import net = require("net");
 import path = require("path");
 import vscode = require("vscode");
-import TelemetryReporter, {
+import {
     type TelemetryEventMeasurements,
     type TelemetryEventProperties,
+    TelemetryReporter,
 } from "@vscode/extension-telemetry";
 import { Message } from "vscode-jsonrpc";
 import {

--- a/src/session.ts
+++ b/src/session.ts
@@ -387,8 +387,14 @@ export class SessionManager implements Middleware {
         await fs.writeFile(pidFilePath, Buffer.from(pid));
         const deletePidOnExit = pwshProcess.onExited(async () => {
             deletePidOnExit.dispose();
-            await fs.delete(pidFilePath, { useTrash: false });
-            this.logger.writeDebug(`Deleted PID file: ${pidFilePath}`);
+            try {
+                await fs.delete(pidFilePath, { useTrash: false });
+                this.logger.writeDebug(`Deleted PID file: ${pidFilePath}`);
+            } catch (err) {
+                this.logger.writeError(
+                    `Error occurred while deleting PID file:\n${err}`,
+                );
+            }
         });
         this.registeredCommands.push(deletePidOnExit);
         this.extensionContext.subscriptions.push(deletePidOnExit);

--- a/src/session.ts
+++ b/src/session.ts
@@ -385,10 +385,10 @@ export class SessionManager implements Middleware {
         const fs = vscode.workspace.fs;
         const pid = (await pwshProcess.getPid())!.toString();
         await fs.writeFile(pidFilePath, Buffer.from(pid));
-        const deletePidOnExit = pwshProcess.onExited(() => {
+        const deletePidOnExit = pwshProcess.onExited(async () => {
             deletePidOnExit.dispose();
-            fs.delete(pidFilePath, { useTrash: false });
-            console.log(`Deleted PID file: ${pidFilePath}`);
+            await fs.delete(pidFilePath, { useTrash: false });
+            this.logger.writeDebug(`Deleted PID file: ${pidFilePath}`);
         });
         this.registeredCommands.push(deletePidOnExit);
         this.extensionContext.subscriptions.push(deletePidOnExit);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,11 +96,6 @@ export async function readDirectory(
     return items.map(([name, _type]) => name);
 }
 
-export function getTimestampString(): string {
-    const time = new Date();
-    return `[${time.getHours()}:${time.getMinutes()}:${time.getSeconds()}]`;
-}
-
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
## PR Summary

A few low-risk cleanups found while combing through the extension:

- **Remove unused `getTimestampString()`** (`src/utils.ts`) — dead since 2017 (`1b424000`), when "Add timestamps and log levels to all extension-side log messages" moved timestamping into the `Logger` and deleted its three call sites. It also had a latent bug: no zero-padding, so it rendered times like `[9:5:3]`.
- **Remove unused `getWindowsSystemPowerShellPath()`** (`src/platform.ts`) — dead since #2238 (2019), which introduced `PowerShellExeFinder` and deleted the `System32PowerShellPath` / `SysnativePowerShellPath` / `SysWow64PowerShellPath` constants that called it. The same path is now built inline in `findWinPS()`, with proper bitness handling in `getSystem32Path()`.
- **Use `ILogger` instead of `console.log`** in `writePidIfInDevMode` (`src/session.ts`), per our convention. While here, `await` the adjacent `fs.delete` so the "Deleted PID file" message is actually true — previously it was a floating promise and the log ran before the delete resolved.
- **Update the PSScriptAnalyzer rule docs link** to `learn.microsoft.com` from `docs.microsoft.com` (`src/features/CodeActions.ts`); the old URL just 301s there anyway.

I left the Command Explorer's dead code alone since #5508 already rewrites that file. `compile`, `lint`, and `format` all pass; the touched code has no test coverage so risk is low.

_Drafted by Copilot (Claude Opus 4.8)._

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [NA] PR has tests
- [x] This PR is ready to merge and is not work in progress