### PR TITLE
Restore editor focus after `forceClearScrollbackBuffer` clears terminal

### DIFF
--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -328,7 +328,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
 
     private async clearTerminal(): Promise<void> {
         // We check to see if they have TrueClear on. If not, no-op because the
-        // overriden Clear-Host already calls [System.Console]::Clear()
+        // overridden Clear-Host already calls [System.Console]::Clear()
         const forceClearScrollbackBuffer = vscode.workspace
             .getConfiguration("powershell.integratedConsole")
             .get<boolean>("forceClearScrollbackBuffer");

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -309,16 +309,7 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
             ),
 
             languageClient.onNotification(ClearTerminalNotificationType, () => {
-                // We check to see if they have TrueClear on. If not, no-op because the
-                // overriden Clear-Host already calls [System.Console]::Clear()
-                const forceClearScrollbackBuffer = vscode.workspace
-                    .getConfiguration("powershell.integratedConsole")
-                    .get<boolean>("forceClearScrollbackBuffer");
-                if (forceClearScrollbackBuffer) {
-                    void vscode.commands.executeCommand(
-                        "workbench.action.terminal.clear",
-                    );
-                }
+                void this.clearTerminal();
             }),
         ];
     }
@@ -332,6 +323,30 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
         }
         for (const statusBarMessage of this.statusBarMessages) {
             statusBarMessage.dispose();
+        }
+    }
+
+    private async clearTerminal(): Promise<void> {
+        // We check to see if they have TrueClear on. If not, no-op because the
+        // overriden Clear-Host already calls [System.Console]::Clear()
+        const forceClearScrollbackBuffer = vscode.workspace
+            .getConfiguration("powershell.integratedConsole")
+            .get<boolean>("forceClearScrollbackBuffer");
+        if (!forceClearScrollbackBuffer) {
+            return;
+        }
+
+        await vscode.commands.executeCommand("workbench.action.terminal.clear");
+
+        // Clearing the terminal focuses it, but if the user has asked us not to
+        // focus the console on execute, then we restore focus to the editor.
+        const focusConsoleOnExecute = vscode.workspace
+            .getConfiguration("powershell.integratedConsole")
+            .get<boolean>("focusConsoleOnExecute", true);
+        if (!focusConsoleOnExecute) {
+            await vscode.commands.executeCommand(
+                "workbench.action.focusActiveEditorGroup",
+            );
         }
     }
 

--- a/src/features/ExtensionCommands.ts
+++ b/src/features/ExtensionCommands.ts
@@ -338,8 +338,13 @@ export class ExtensionCommandsFeature extends LanguageClientConsumer {
 
         await vscode.commands.executeCommand("workbench.action.terminal.clear");
 
-        // Clearing the terminal focuses it, but if the user has asked us not to
-        // focus the console on execute, then we restore focus to the editor.
+        // Clearing the terminal also focuses it, and VS Code exposes no way to
+        // learn what was focused beforehand (there's no terminal focus state,
+        // and `activeTextEditor` doesn't go undefined when the terminal is
+        // focused). So when the user has opted out of focusing the console on
+        // execute, we best-effort restore focus to the editor. The caveat is
+        // that running `Clear-Host` directly in the console also moves focus to
+        // the editor under this setting.
         const focusConsoleOnExecute = vscode.workspace
             .getConfiguration("powershell.integratedConsole")
             .get<boolean>("focusConsoleOnExecute", true);


### PR DESCRIPTION
Fixes PowerShell/PowerShellEditorServices#2313

When `powershell.integratedConsole.forceClearScrollbackBuffer` is `true`, clearing the Extension Terminal runs `workbench.action.terminal.clear`, which focuses the terminal. That stole focus from the editor on every `Clear-Host` even when `powershell.integratedConsole.focusConsoleOnExecute` was `false`, violating that setting.

## ⚠️ Draft — superseded approach, see "Real fix" below

The commit on this branch moves the `ClearTerminalNotificationType` handler into a `clearTerminal()` method and, after `workbench.action.terminal.clear`, re-focuses the editor when `focusConsoleOnExecute` is `false`. **This is a stopgap with a real regression** and should not merge as-is.

The focus is only *stolen* when `workbench.action.terminal.clear` grabs it from elsewhere (the editor). When the user typed `Clear-Host` directly in the terminal, focus was already there and the correct action is to do nothing — but this approach unconditionally re-focuses the editor, so interactive `Clear-Host`/`cls` now bounces focus out of the terminal. That's arguably worse than the original bug.

A client-side conditional restore isn't possible: the stable VS Code API can't tell us whether the terminal or the editor was focused when the clear arrived.

- `TerminalState` only carries `isInteractedWith` / `shell` — no focus flag.
- `window.activeTerminal` is the *active* terminal, not the *focused* one.
- `window.activeTextEditor` does **not** go `undefined` when the terminal is focused.
- `terminalFocus` exists only as a `when`-clause context key; it isn't readable from extension code (microsoft/vscode#72647).

## Real fix — erase scrollback from PSES with `CSI 3 J`

The root cause is the **mechanism**, not the focus handling. `forceClearScrollbackBuffer` only exists because PSES's `Clear-Host` (`module/PowerShellEditorServices/Commands/Public/Clear-Host.ps1`) calls `[Console]::Clear()`, which clears the viewport but not xterm.js's scrollback — so it round-trips `editor/clearTerminal` to the extension, which runs the focus-stealing `workbench.action.terminal.clear`.

VS Code's integrated terminal is **always xterm.js**, which supports `CSI 3 J` (`ESC [ 3 J`, "Erase Saved Lines"). If PSES writes that sequence to its own output stream as part of `Clear-Host`, xterm clears the scrollback with **no focus change at all** — in both the execute-from-editor and the interactive case. No workbench command, no focus steal, no regression.

The settings plumbing for this already exists: the extension syncs the whole `powershell` config section to PSES via `didChangeConfiguration`, so PSES can gate the erase on `integratedConsole.forceClearScrollbackBuffer` by mapping one new field onto `LanguageServerSettings`.

**Proposed plan (spans two repos):**
1. **PSES:** map `integratedConsole.forceClearScrollbackBuffer` into `LanguageServerSettings`, and have `Clear-Host` write `ESC [ 3 J` (gated on that setting) instead of calling `$psEditor.Window.Terminal.Clear()`.
2. **vscode-powershell:** once PSES lands, remove the `editor/clearTerminal` handler and this `clearTerminal()` focus hack; keep the `forceClearScrollbackBuffer` setting (now consumed server-side).

Because the client must keep clearing scrollback until PSES does it, the PSES change lands first (or together); this PR stays a draft until then.

## Verification (of the current stopgap commit)

`npm run lint`, `npm run format`, and `npm run compile` all pass.