### PR TITLE
Don't prompt to restart Extension Terminal on shutdown (#4101, #4145)

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -19,6 +19,11 @@ export class PowerShellProcess {
     private consoleTerminal?: vscode.Terminal;
     private consoleCloseSubscription?: vscode.Disposable;
 
+    // The reason the Extension Terminal closed, if it was closed by VS Code
+    // (as opposed to disposed by us). Used to suppress the restart prompt when
+    // the window is shutting down or reloading (see issue #4101).
+    public terminalExitReason?: vscode.TerminalExitReason;
+
     private pid?: number;
     private pidUpdateEmitter?: vscode.EventEmitter<number | undefined>;
 
@@ -342,6 +347,11 @@ export class PowerShellProcess {
         if (terminal !== this.consoleTerminal) {
             return;
         }
+
+        // Capture why the terminal closed before disposing fires `onExited`, so
+        // consumers can tell a window shutdown/reload apart from a user closing
+        // the terminal or the process crashing.
+        this.terminalExitReason = terminal.exitStatus?.reason;
 
         this.logger.writeWarning(
             `PowerShell process terminated or Extension Terminal was closed, PID: ${this.pid}`,

--- a/src/session.ts
+++ b/src/session.ts
@@ -121,6 +121,14 @@ export class SessionManager implements Middleware {
     private versionDetails: IPowerShellVersionDetails | undefined;
     private traceLogLevelHandler?: vscode.Disposable;
 
+    // Set when the session manager is being disposed (e.g. the extension is
+    // deactivating because VS Code is shutting down or reloading). Used to
+    // suppress the "Extension Terminal has stopped" prompt (see issue #4101).
+    private isDisposing = false;
+    // Guards against showing the restart prompt more than once concurrently
+    // (see issue #4145).
+    private isPromptingForRestart = false;
+
     // Promise-based gate resolved when the session reaches Running status.
     // Used by waitUntilStarted() and the didOpen()/didChange() notifications.
     private started = Promise.withResolvers<undefined>();
@@ -170,6 +178,7 @@ export class SessionManager implements Middleware {
     }
 
     public async dispose(): Promise<void> {
+        this.isDisposing = true;
         await this.stop(); // A whole lot of disposals.
 
         this.languageStatusItem.dispose();
@@ -759,7 +768,9 @@ export class SessionManager implements Middleware {
                 this.sessionStatus === SessionStatus.Busy
             ) {
                 this.setSessionStatus("Session Exited!", SessionStatus.Failed);
-                void this.promptForRestart();
+                void this.promptForRestart(
+                    languageServerProcess.terminalExitReason,
+                );
             }
         });
 
@@ -1090,7 +1101,25 @@ Type 'help' to get help.
         return versionDetails;
     }
 
-    private async promptForRestart(): Promise<void> {
+    private async promptForRestart(
+        terminalExitReason?: vscode.TerminalExitReason,
+    ): Promise<void> {
+        // Don't prompt when VS Code itself is shutting down or reloading the
+        // window, nor when the session manager is being disposed (#4101). The
+        // terminal exit reason tells us the window closed even if it happens
+        // before the extension's `deactivate()` runs.
+        if (
+            this.isDisposing ||
+            terminalExitReason === vscode.TerminalExitReason.Shutdown
+        ) {
+            return;
+        }
+
+        // Don't show a second prompt while one is already open (#4145).
+        if (this.isPromptingForRestart) {
+            return;
+        }
+
         const suppressTerminalStoppedNotification = vscode.workspace
             .getConfiguration("powershell.integratedConsole")
             .get<boolean>("suppressTerminalStoppedNotification");
@@ -1098,32 +1127,37 @@ Type 'help' to get help.
             return;
         }
 
-        await this.logger.writeAndShowErrorWithActions(
-            "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
-            [
-                {
-                    prompt: "Yes",
-                    action: async (): Promise<void> => {
-                        await this.restartSession();
+        this.isPromptingForRestart = true;
+        try {
+            await this.logger.writeAndShowErrorWithActions(
+                "The PowerShell Extension Terminal has stopped, would you like to restart it? IntelliSense and other features will not work without it!",
+                [
+                    {
+                        prompt: "Yes",
+                        action: async (): Promise<void> => {
+                            await this.restartSession();
+                        },
                     },
-                },
-                {
-                    prompt: "No",
-                    action: undefined,
-                },
-                {
-                    prompt: "Don't Show Again",
-                    action: async (): Promise<void> => {
-                        await changeSetting(
-                            "integratedConsole.suppressTerminalStoppedNotification",
-                            true,
-                            true,
-                            this.logger,
-                        );
+                    {
+                        prompt: "No",
+                        action: undefined,
                     },
-                },
-            ],
-        );
+                    {
+                        prompt: "Don't Show Again",
+                        action: async (): Promise<void> => {
+                            await changeSetting(
+                                "integratedConsole.suppressTerminalStoppedNotification",
+                                true,
+                                true,
+                                this.logger,
+                            );
+                        },
+                    },
+                ],
+            );
+        } finally {
+            this.isPromptingForRestart = false;
+        }
     }
 
     private sendTelemetryEvent(

--- a/test/core/session.test.ts
+++ b/test/core/session.test.ts
@@ -6,8 +6,9 @@ import * as assert from "assert";
 import Sinon from "sinon";
 import * as vscode from "vscode";
 import type { DocumentSelector } from "vscode-languageclient";
+import type { ILogger } from "../../src/logging";
 import { SessionManager } from "../../src/session";
-import { stubInterface, testLogger } from "../utils";
+import { stubInterface, TestLogger, testLogger } from "../utils";
 
 describe("SessionManager middleware", () => {
     afterEach(() => {
@@ -159,6 +160,163 @@ describe("SessionManager middleware", () => {
             nextCalled,
             true,
             "didChange should run after initialization",
+        );
+    });
+});
+
+describe("SessionManager restart prompt", () => {
+    afterEach(() => {
+        Sinon.restore();
+    });
+
+    function createSessionManager(logger: ILogger): SessionManager {
+        Sinon.stub(vscode.commands, "registerCommand").returns(
+            disposableStub(),
+        );
+        Sinon.stub(vscode.workspace, "onDidChangeConfiguration").returns(
+            disposableStub(),
+        );
+        Sinon.stub(vscode.languages, "createLanguageStatusItem").returns(
+            stubInterface<vscode.LanguageStatusItem>({
+                text: "",
+                detail: "",
+                busy: false,
+                severity: vscode.LanguageStatusSeverity.Information,
+                dispose: () => {
+                    return;
+                },
+            }),
+        );
+
+        return new SessionManager(
+            stubInterface<vscode.ExtensionContext>({
+                globalStorageUri: vscode.Uri.file("C:/tmp"),
+                extensionMode: vscode.ExtensionMode.Test,
+                subscriptions: [],
+                logUri: vscode.Uri.file("C:/tmp"),
+            }),
+            logger,
+            ["powershell"] as DocumentSelector,
+            "Visual Studio Code",
+            "PowerShell",
+            "2026.5.0",
+            "ms-vscode",
+            stubInterface<TelemetryReporter>(),
+        );
+    }
+
+    // Invokes the private `promptForRestart` method for testing.
+    function promptForRestart(
+        manager: SessionManager,
+        reason?: vscode.TerminalExitReason,
+    ): Promise<void> {
+        return (
+            manager as unknown as {
+                promptForRestart: (
+                    reason?: vscode.TerminalExitReason,
+                ) => Promise<void>;
+            }
+        ).promptForRestart(reason);
+    }
+
+    it("prompts to restart when the user closes the terminal", async () => {
+        const logger = new TestLogger();
+        const prompt = Sinon.stub(
+            logger,
+            "writeAndShowErrorWithActions",
+        ).resolves();
+        const manager = createSessionManager(logger);
+
+        await promptForRestart(manager, vscode.TerminalExitReason.User);
+
+        assert.ok(
+            prompt.calledOnce,
+            "should prompt when the terminal is closed by the user",
+        );
+    });
+
+    it("does not prompt to restart while disposing (#4101)", async () => {
+        const logger = new TestLogger();
+        const prompt = Sinon.stub(
+            logger,
+            "writeAndShowErrorWithActions",
+        ).resolves();
+        const manager = createSessionManager(logger);
+        (manager as unknown as { isDisposing: boolean }).isDisposing = true;
+
+        await promptForRestart(manager, vscode.TerminalExitReason.User);
+
+        assert.ok(
+            prompt.notCalled,
+            "should not prompt while the session manager is disposing",
+        );
+    });
+
+    it("does not prompt to restart when the window is shutting down (#4101)", async () => {
+        const logger = new TestLogger();
+        const prompt = Sinon.stub(
+            logger,
+            "writeAndShowErrorWithActions",
+        ).resolves();
+        const manager = createSessionManager(logger);
+
+        await promptForRestart(manager, vscode.TerminalExitReason.Shutdown);
+
+        assert.ok(
+            prompt.notCalled,
+            "should not prompt when VS Code is shutting down or reloading",
+        );
+    });
+
+    it("does not show a second prompt while one is open (#4145)", async () => {
+        const logger = new TestLogger();
+        let resolvePrompt: (() => void) | undefined;
+        const prompt = Sinon.stub(
+            logger,
+            "writeAndShowErrorWithActions",
+        ).callsFake(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolvePrompt = resolve;
+                }),
+        );
+        const manager = createSessionManager(logger);
+
+        const first = promptForRestart(manager, vscode.TerminalExitReason.User);
+        const second = promptForRestart(
+            manager,
+            vscode.TerminalExitReason.User,
+        );
+
+        // Let any microtasks settle so a (buggy) second prompt would have fired.
+        await Promise.resolve();
+        assert.ok(
+            prompt.calledOnce,
+            "should not show a second prompt while one is already open",
+        );
+
+        resolvePrompt?.();
+        await Promise.all([first, second]);
+    });
+
+    it("does not prompt to restart when notifications are suppressed", async () => {
+        const logger = new TestLogger();
+        const prompt = Sinon.stub(
+            logger,
+            "writeAndShowErrorWithActions",
+        ).resolves();
+        const manager = createSessionManager(logger);
+        Sinon.stub(vscode.workspace, "getConfiguration").returns(
+            stubInterface<vscode.WorkspaceConfiguration>({
+                get: () => true,
+            }),
+        );
+
+        await promptForRestart(manager, vscode.TerminalExitReason.User);
+
+        assert.ok(
+            prompt.notCalled,
+            "should respect suppressTerminalStoppedNotification",
         );
     });
 });


### PR DESCRIPTION
## Summary

Fixes #4101 and #4145, two related bugs with the "The PowerShell Extension Terminal has stopped, would you like to restart it?" prompt.

- **#4101 — prompt during VS Code shutdown:** When VS Code closes or reloads the window it disposes our Extension Terminal, firing `onDidCloseTerminal` → `PowerShellProcess.dispose()` → `onExited` → `promptForRestart()`. Since that can happen *before* the extension's `deactivate()` runs, a status/disposal check alone misses it. We now capture the terminal's `TerminalExitReason` (finalized in VS Code 1.71) and bail out of the prompt when the reason is `Shutdown`, plus set an `isDisposing` flag in `dispose()` as a belt-and-suspenders guard.
- **#4145 — double prompt:** Nothing prevented the prompt from being shown more than once concurrently. Added an `isPromptingForRestart` guard (try/finally) so at most one is open at a time.

We still prompt on a genuine user-close (`User`) or process crash (`Process`), and the existing `powershell.integratedConsole.suppressTerminalStoppedNotification` behavior is preserved.

## Changes

- `src/process.ts`: capture `terminal.exitStatus?.reason` on close, exposed as `terminalExitReason`.
- `src/session.ts`: pass the exit reason into `promptForRestart()`; early-return on `isDisposing` or `Shutdown` (#4101) and dedupe with `isPromptingForRestart` (#4145).
- `test/core/session.test.ts`: 5 new tests (user-close prompts; suppressed while disposing; suppressed on shutdown; deduped concurrent prompts; respects the suppress setting).

## Verification

- `npm run compile`, `npm run lint`, `npm run format` — clean.
- Full `vscode-test` suite: **109 passing, 4 pending**, including the 5 new tests.
