### PR TITLE
Update NPM packages and override transitive vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,25 @@
 {
   "name": "powershell",
-  "version": "2026.1.0",
+  "version": "2026.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "powershell",
-      "version": "2026.1.0",
+      "version": "2026.1.1",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.5.2",
-        "semver": "^7.8.0",
+        "semver": "^7.8.4",
         "untildify": "^4.0.0",
         "uuid": "^14.0.0",
         "vscode-languageclient": "^9.0.1",
-        "vscode-languageserver-protocol": "^3.17.5"
+        "vscode-languageserver-protocol": "^3.18.0"
       },
       "devDependencies": {
-        "@vscode/vsce": "^3.9.1",
-        "esbuild": "^0.28.0"
+        "@vscode/vsce": "^3.9.2",
+        "esbuild": "^0.28.1"
       },
       "engines": {
         "vscode": "^1.114.0"
@@ -28,7 +28,7 @@
         "@eslint/js": "^10.0.1",
         "@types/mocha": "^10.0.10",
         "@types/mock-fs": "^4.13.4",
-        "@types/node": "^22.19.19",
+        "@types/node": "^22.19.21",
         "@types/semver": "^7.7.1",
         "@types/sinon": "^21.0.1",
         "@types/ungap__structured-clone": "^1.2.0",
@@ -38,14 +38,14 @@
         "@vscode/test-cli": "^0.0.12",
         "@vscode/test-electron": "^2.5.2",
         "esbuild-register": "^3.6.0",
-        "eslint": "^10.3.0",
+        "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",
         "mock-fs": "^5.5.0",
-        "prettier": "^3.8.3",
+        "prettier": "^3.8.4",
         "prettier-plugin-organize-imports": "^4.3.0",
         "sinon": "^22.0.0",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.59.3"
+        "typescript-eslint": "^8.61.1"
       }
     },
     "node_modules/@azu/format-text": {
@@ -253,8 +253,8 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "integrity": "sha1-eiicFY4py/WeoK/IPMgPBtHIlAI=",
+      "version": "0.28.1",
+      "integrity": "sha1-egGo0uwvuy2seK2tCbD6eB5Agr4=",
       "cpu": [
         "ppc64"
       ],
@@ -268,8 +268,8 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "integrity": "sha1-XsGEdgXgW12+XfkNuf9+PkxY3Kc=",
+      "version": "0.28.1",
+      "integrity": "sha1-cEvSl95tdi3lTqu+r79V9nVqvi8=",
       "cpu": [
         "arm"
       ],
@@ -283,8 +283,8 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-uIKNnt+jqSZgZE643m5PPCA9exc=",
+      "version": "0.28.1",
+      "integrity": "sha1-tUCifRTkr9BYSWpNvsTT9BTbEQo=",
       "cpu": [
         "arm64"
       ],
@@ -298,8 +298,8 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-OQZCF1uI74K61MzgP4qxP+mxkS4=",
+      "version": "0.28.1",
+      "integrity": "sha1-0csWbTSw+/D+irRgpVlPJKN4cB4=",
       "cpu": [
         "x64"
       ],
@@ -313,8 +313,8 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-rkUyWWDVlQzWlR5PlzlvTh/32NM=",
+      "version": "0.28.1",
+      "integrity": "sha1-EDSyZFf8iGNo/mG70J9lP2r6jlQ=",
       "cpu": [
         "arm64"
       ],
@@ -328,8 +328,8 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-wHkkfViba5lEllnZTwaVG4S/8uQ=",
+      "version": "0.28.1",
+      "integrity": "sha1-ZVVqQyoeTXIDLYIYwZMvzKGkl3I=",
       "cpu": [
         "x64"
       ],
@@ -343,8 +343,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-RcRWIVpIZZPJSQApcgLcEciAo3o=",
+      "version": "0.28.1",
+      "integrity": "sha1-LmHgWS+QMNfj2uGO4l68U1kYrvY=",
       "cpu": [
         "arm64"
       ],
@@ -358,8 +358,8 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-A5lJTByF5DiOm3BAvWDUjypbDSw=",
+      "version": "0.28.1",
+      "integrity": "sha1-yV7CiZWe+AecTcqBeh4sS+Zrm9M=",
       "cpu": [
         "x64"
       ],
@@ -373,8 +373,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "integrity": "sha1-e0L/qEwoiulP3EMcGyionjw7kng=",
+      "version": "0.28.1",
+      "integrity": "sha1-wJoPZ5F1kqwN6JKpvk04FN69Kmw=",
       "cpu": [
         "arm"
       ],
@@ -388,8 +388,8 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-1tnwnvDeVBFr9Fmk1TysfglS/jk=",
+      "version": "0.28.1",
+      "integrity": "sha1-QLIhdd2gYYLz7oFBGGxf8wTEpxc=",
       "cpu": [
         "arm64"
       ],
@@ -403,8 +403,8 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "integrity": "sha1-3rFdES7Y3WBTRra5U9I6If+BJT8=",
+      "version": "0.28.1",
+      "integrity": "sha1-pYD5xnZ5eDOJHlGfx6EzfIr9jbM=",
       "cpu": [
         "ia32"
       ],
@@ -418,8 +418,8 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "integrity": "sha1-gfuJ0H7sx5sVfephAzdXcm/ODKQ=",
+      "version": "0.28.1",
+      "integrity": "sha1-RkUs8yHcf56Rwvp4Cla7Vuec1os=",
       "cpu": [
         "loong64"
       ],
@@ -433,8 +433,8 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "integrity": "sha1-0OQmkbP/evn7Ihe3D8AfNDvbYrs=",
+      "version": "0.28.1",
+      "integrity": "sha1-QhGzGE3WYI9T3LIuOfXTTuCIUsg=",
       "cpu": [
         "mips64el"
       ],
@@ -448,8 +448,8 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "integrity": "sha1-OJ8+XpjxfUd8RnzIcTbhoHburYc=",
+      "version": "0.28.1",
+      "integrity": "sha1-aXhXwqYcubC2u2ZS5AwdxeHKjl0=",
       "cpu": [
         "ppc64"
       ],
@@ -463,8 +463,8 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "integrity": "sha1-djvWDVmyQr4S2h5n1XKfMCTGBfo=",
+      "version": "0.28.1",
+      "integrity": "sha1-0ZKUPrFGpArExkl9DPe+NbmGvwg=",
       "cpu": [
         "riscv64"
       ],
@@ -478,8 +478,8 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "integrity": "sha1-qsYGFjSHLkZ33mk7zoAw1zsf0FU=",
+      "version": "0.28.1",
+      "integrity": "sha1-rOoDVtoODrwI+Xz3ucLkAeHmSNw=",
       "cpu": [
         "s390x"
       ],
@@ -493,8 +493,8 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-TykXdHGI/ndjK87GWy2EtCJBl3k=",
+      "version": "0.28.1",
+      "integrity": "sha1-bww84MtkxTS3DExF7LLBbTTjXf0=",
       "cpu": [
         "x64"
       ],
@@ -508,8 +508,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-gU3wrlegw4aBRJG4OX7rqCCUqUc=",
+      "version": "0.28.1",
+      "integrity": "sha1-i813B3oNzjN4tXT+2ybSolO3PTY=",
       "cpu": [
         "arm64"
       ],
@@ -523,8 +523,8 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-4BvffmD6GgjkbUbZYLDZu4rCEK8=",
+      "version": "0.28.1",
+      "integrity": "sha1-5/sqAemcgwyU5mI82f77TI+1g0c=",
       "cpu": [
         "x64"
       ],
@@ -538,8 +538,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-ShXDaqzKaNLVpMkLcQwGdZ9MH/o=",
+      "version": "0.28.1",
+      "integrity": "sha1-xSkJNy24uG4sVeBaiUADO1Zgo7I=",
       "cpu": [
         "arm64"
       ],
@@ -553,8 +553,8 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-R15hAUmKjszjAI18OIER16J8F70=",
+      "version": "0.28.1",
+      "integrity": "sha1-xCe5vlpkwmL/mn63C1+7qt9EbGw=",
       "cpu": [
         "x64"
       ],
@@ -568,8 +568,8 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-z9w5V/C3pp8b3hKarRf8wvb6Az4=",
+      "version": "0.28.1",
+      "integrity": "sha1-3JsUe6yi5sSzyFVxdB70hgpIkJc=",
       "cpu": [
         "arm64"
       ],
@@ -583,8 +583,8 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-oBPIVv7KzRw67Jhciv4dHLAXSX0=",
+      "version": "0.28.1",
+      "integrity": "sha1-zoZtEt8TwV5MmfBzo9Rm9uBkmzo=",
       "cpu": [
         "x64"
       ],
@@ -598,8 +598,8 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "integrity": "sha1-6uBeDzUnHK04mLQxaNPpo7uvR+U=",
+      "version": "0.28.1",
+      "integrity": "sha1-dGjjaS0B1inVlB5dg4F7uA+eObQ=",
       "cpu": [
         "arm64"
       ],
@@ -613,8 +613,8 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "integrity": "sha1-BhYevFv3XAjWn+s8ayJWBRWROZg=",
+      "version": "0.28.1",
+      "integrity": "sha1-pbwAY/sryrbQ7WPyoVN5WLwmnsY=",
       "cpu": [
         "ia32"
       ],
@@ -628,8 +628,8 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "integrity": "sha1-BNkNV1K0zmXStqwl66CP92JP4Hw=",
+      "version": "0.28.1",
+      "integrity": "sha1-EAZO5E9DR7kMmgK0Rrv4CpFjKxI=",
       "cpu": [
         "x64"
       ],
@@ -732,8 +732,8 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.5",
-      "integrity": "sha1-rhYTTkeSrF+9xTNUiiSsHqn3864=",
+      "version": "0.6.0",
+      "integrity": "sha1-75o2iB0539Xb6sIrDamX+r+wiwM=",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -785,8 +785,8 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "integrity": "sha1-xBJf0BXs7rCbeTEJ/bzU3QoC00Y=",
+      "version": "0.7.2",
+      "integrity": "sha1-Swli8/LHzovJiz7P40UlwJ0styk=",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -1040,8 +1040,18 @@
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.13.0",
-      "integrity": "sha1-CxaZWX9zbRYiIcGSIXKSSzjO9Uw=",
+      "version": "0.15.0",
+      "integrity": "sha1-GJnfBddSG2r8rh3VPzXMBMZjSPQ=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nevware21"
+        },
+        {
+          "type": "other",
+          "url": "https://buymeacoffee.com/nevware21"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1414,8 +1424,8 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "integrity": "sha1-MSS/Jt7VQWi3aBODIf75m0IMYRI=",
+      "version": "22.19.21",
+      "integrity": "sha1-XJ2EPqOFsx7pN6n3Q0Q4MGIKMt4=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1468,16 +1478,16 @@
       "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "integrity": "sha1-XW2n57I2tGRS+gDTkEu29ZYVv94=",
+      "version": "8.61.1",
+      "integrity": "sha1-bkt/7iHxmDMI6em2NOy69wLIYAY=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/type-utils": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1490,7 +1500,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.3",
+        "@typescript-eslint/parser": "^8.61.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1505,15 +1515,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "integrity": "sha1-9Gy8cK4KJRGe+U6sns1GcUeI4aE=",
+      "version": "8.61.1",
+      "integrity": "sha1-iB+6YLUGNiSc3uouVHv3VxUlTHI=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1529,13 +1539,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "integrity": "sha1-G+WuFSqtmHoVbJoam0JW51z7vgw=",
+      "version": "8.61.1",
+      "integrity": "sha1-/NlzmWSkCGfu1V8awxjTkJ8ktK8=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.3",
-        "@typescript-eslint/types": "^8.59.3",
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1550,13 +1560,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "integrity": "sha1-kaYPZoA/6drgaW+6skUfVyPxGdI=",
+      "version": "8.61.1",
+      "integrity": "sha1-JHmSGkD9sK+hj1g4+uYWcmS0F7I=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1567,8 +1577,8 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "integrity": "sha1-iMqQNrQszdHmMM/a/S4ELCymqDU=",
+      "version": "8.61.1",
+      "integrity": "sha1-yogIDgzxkdSVFtfzALZ6oJDSJU8=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1583,14 +1593,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "integrity": "sha1-Qh+yRIvf6zAdE0oBzQJQP2f9gZI=",
+      "version": "8.61.1",
+      "integrity": "sha1-j6GPRT7hQIk7R9M50aa2TKybCKE=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1607,8 +1617,8 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "integrity": "sha1-t8pTnF4wL93pp8rbc8rtEH748s0=",
+      "version": "8.61.1",
+      "integrity": "sha1-DFH1GOTmhINxocmI6FnVnrdSLVo=",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1620,15 +1630,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "integrity": "sha1-5rsUCOALR+QxQnpAJo206GyxIas=",
+      "version": "8.61.1",
+      "integrity": "sha1-/rvnA2WsC/dhEmK2GzOPyHl5Zcc=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.3",
-        "@typescript-eslint/tsconfig-utils": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/visitor-keys": "8.59.3",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1683,15 +1693,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "integrity": "sha1-9pP5ed603DmU3gP/iyOXbWJcNsU=",
+      "version": "8.61.1",
+      "integrity": "sha1-/9EFTefdM7eHPNbGcT7GsDZjFtM=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.3",
-        "@typescript-eslint/types": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1706,12 +1716,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "integrity": "sha1-gghDsbXKQpAAnPGJOCq89v4A36Y=",
+      "version": "8.61.1",
+      "integrity": "sha1-VGzxArTv23KpoI5jobDX10XrZus=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/types": "8.61.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1803,8 +1813,8 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.9.1",
-      "integrity": "sha1-zyc/4IlaFP6KXn/YhjC7Wlh2rWo=",
+      "version": "3.9.2",
+      "integrity": "sha1-kmLRc326bGHZHcVq4pAa8+HgKUo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1820,13 +1830,13 @@
         "cockatiel": "^3.1.2",
         "commander": "^12.1.0",
         "form-data": "^4.0.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.6",
         "hosted-git-info": "^4.0.2",
         "jsonc-parser": "^3.2.0",
         "leven": "^3.1.0",
         "markdown-it": "^14.1.0",
         "mime": "^1.3.4",
-        "minimatch": "^3.0.3",
+        "minimatch": "^10.2.2",
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "secretlint": "^10.1.2",
@@ -1983,49 +1993,7 @@
         "win32"
       ]
     },
-    "node_modules/@vscode/vsce/node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "integrity": "sha1-TQo/EnBYBDvy5+4Wnq8w7ZATAvM=",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "integrity": "sha1-2d5gI3DZE0fNndrRIk1P1wHrNIs=",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/glob": {
-      "version": "11.1.0",
-      "integrity": "sha1-T4JlduTrmcfa04N5PS+fCPZ+UKY=",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/glob/node_modules/balanced-match": {
+    "node_modules/@vscode/vsce/node_modules/balanced-match": {
       "version": "4.0.4",
       "integrity": "sha1-v7EGYv7tgZaixi58aOF3IMJ0F5o=",
       "dev": true,
@@ -2034,7 +2002,7 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/glob/node_modules/brace-expansion": {
+    "node_modules/@vscode/vsce/node_modules/brace-expansion": {
       "version": "5.0.6",
       "integrity": "sha1-7Gj+CmQaKdhxFXnK9kHQW64fIoU=",
       "dev": true,
@@ -2046,7 +2014,33 @@
         "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
+    "node_modules/@vscode/vsce/node_modules/glob": {
+      "version": "13.0.6",
+      "integrity": "sha1-B4ZmVmpCUUfMrPvS4zLetmor5x0=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "integrity": "sha1-89qjVAhHuXN+vAJJnds2dl5U20o=",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/minimatch": {
       "version": "10.2.5",
       "integrity": "sha1-vUhoegvjjtKWE5kQVgD4MglYYdE=",
       "dev": true,
@@ -2059,42 +2053,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/jackspeak": {
-      "version": "4.2.3",
-      "integrity": "sha1-J++A8zuTQSA3w76k+O3fgOGTFIM=",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/lru-cache": {
-      "version": "11.3.6",
-      "integrity": "sha1-8DBq1unwpdwlsWrrpOj1e37C31U=",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@vscode/vsce/node_modules/minimatch": {
-      "version": "3.1.5",
-      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@vscode/vsce/node_modules/path-scurry": {
@@ -2720,12 +2678,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "integrity": "sha1-S1YPZJ/E6RjdCrdc9JYei8iC2Co=",
@@ -2741,8 +2693,8 @@
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "integrity": "sha1-ilj+ePANzXDDcEUXWd+/rwPo7p8=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2898,15 +2850,6 @@
       "optional": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "8.0.4",
-      "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/dom-serializer": {
@@ -3121,8 +3064,8 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "integrity": "sha1-Xe40f/s+OHQhKjWmmDawd7HObZY=",
+      "version": "0.28.1",
+      "integrity": "sha1-70W0Y0ycnZeilq6kEUpfmED5VXg=",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3133,32 +3076,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/esbuild-register": {
@@ -3195,17 +3138,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.3.0",
-      "integrity": "sha1-7VuBDrjgGRvyS93PnNtFuXTgoW0=",
+      "version": "10.5.0",
+      "integrity": "sha1-X8pp1rQf5+ALoi1BALLkTv5DmtU=",
       "license": "MIT",
       "optional": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
         "@eslint/config-array": "^0.23.5",
-        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/config-helpers": "^0.6.0",
         "@eslint/core": "^1.2.1",
-        "@eslint/plugin-kit": "^0.7.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -3563,8 +3509,8 @@
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "integrity": "sha1-Mujp7Rtoo0l777msK2rfkqY4V28=",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -3577,16 +3523,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "integrity": "sha1-tJ5IhYBF/0y/awPhgFzrytNnkFM=",
+      "version": "4.0.6",
+      "integrity": "sha1-KOhk4beG2+u2jbH0UvljUnhmWCc=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3815,8 +3761,8 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "integrity": "sha1-XlwrFbYDcKTHkww4Pft2vxe8QDw=",
+      "version": "2.0.4",
+      "integrity": "sha1-jGLYy5C+sqrV0KW2dYGtmFTD8AM=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4142,8 +4088,8 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -4232,9 +4178,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "integrity": "sha1-hUwpJGdwW2mUduGi3swMijRYgGs=",
+      "version": "4.2.0",
+      "integrity": "sha1-K9noVoLdkb1GmvuAnYFgQ7PUlSQ=",
       "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4399,9 +4355,19 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "integrity": "sha1-nvI4v6bccL2Of5VytS02mvVptCE=",
+      "version": "5.0.1",
+      "integrity": "sha1-EMTOy7XGgo6r+B08gBrcSlQt+1U=",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -4520,14 +4486,24 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.1",
-      "integrity": "sha1-hW+Qtm/DmucK/9JcGxi1gdfe7h8=",
+      "version": "14.2.0",
+      "integrity": "sha1-BtSNkDXnfVscha2zFUgvyCQCie8=",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.1",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -4721,6 +4697,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/mocha/node_modules/diff": {
+      "version": "8.0.4",
+      "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/mocha/node_modules/readdirp": {
@@ -5086,8 +5071,8 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "integrity": "sha1-TxRxoBCCeob5TP2bByfjbSZ95QU=",
-      "devOptional": true,
-      "license": "BlueOak-1.0.0"
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -5191,8 +5176,8 @@
     "node_modules/path-key": {
       "version": "3.1.1",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5301,8 +5286,8 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "integrity": "sha1-Vg8t5VvwG0wFA7xinV35m5odCbA=",
+      "version": "3.8.4",
+      "integrity": "sha1-8zTwE6wEqWZ28k2rwjwcSuG65BE=",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -5367,8 +5352,8 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "integrity": "sha1-vbVa7Qa/rCV6kMRKRGpz+6VXXI8=",
+      "version": "6.15.2",
+      "integrity": "sha1-/VVCbXEEA93MxF4PnqsW23cn7Ok=",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5651,8 +5636,8 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "integrity": "sha1-7QZhA5/LzaLOcfAfpq2++qdwQN8=",
+      "version": "7.8.4",
+      "integrity": "sha1-xz7O664GFpNL6N/yin/XB1fI5pY=",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5662,8 +5647,8 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "integrity": "sha1-x5jMBVL/uwiYGRSkKodW4znQ1bE=",
+      "version": "7.0.6",
+      "integrity": "sha1-8vIMivB1fk2PoynQIQY22gaC3e8=",
       "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
@@ -5679,8 +5664,8 @@
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -5691,8 +5676,8 @@
     "node_modules/shebang-regex": {
       "version": "3.0.0",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5772,8 +5757,8 @@
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "integrity": "sha1-lSGIwcvVRgcOLdIND0HArgUwywQ=",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=14"
       },
@@ -5842,6 +5827,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/diff": {
+      "version": "8.0.4",
+      "integrity": "sha1-T1uvMYi5skMRF7li6yC6Mw+t9pY=",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/slash": {
@@ -6284,8 +6278,8 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "integrity": "sha1-HDt+uVP85Csia8Wh7gZCgoGv89Y=",
+      "version": "0.2.17",
+      "integrity": "sha1-ViqabJ6ys7Ej05cZ+a9btE/NdjE=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6329,8 +6323,8 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "integrity": "sha1-sGvNI/DzyDV7QmiRcm0WAVq/2Pg=",
+      "version": "0.2.7",
+      "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6446,15 +6440,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.3",
-      "integrity": "sha1-SkHZAH+qU5pmKSGJ4nle6wufyik=",
+      "version": "8.61.1",
+      "integrity": "sha1-fCJKmmQ7f0LSlcZ6dcHjD+6MPqo=",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.3",
-        "@typescript-eslint/parser": "8.59.3",
-        "@typescript-eslint/typescript-estree": "8.59.3",
-        "@typescript-eslint/utils": "8.59.3"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6481,8 +6475,8 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "integrity": "sha1-fXL8QpoEIXacopZv0Hysh1yFt4E=",
+      "version": "7.28.0",
+      "integrity": "sha1-l9ZFZBmLKFvCgfDo4pWX49Ef5+w=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6594,8 +6588,8 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "integrity": "sha1-9D36NftR52PRfNlNzKDJRY81q/k=",
+      "version": "9.0.0",
+      "integrity": "sha1-m6YAyQvuOTP//fAOpa9XRH+sNsU=",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6625,7 +6619,15 @@
         "node": ">=10"
       }
     },
-    "node_modules/vscode-languageserver-protocol": {
+    "node_modules/vscode-languageclient/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "integrity": "sha1-9D36NftR52PRfNlNzKDJRY81q/k=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-protocol": {
       "version": "3.17.5",
       "integrity": "sha1-hkqLjzkINVcvThO9n4MT0OOsS+o=",
       "license": "MIT",
@@ -6634,9 +6636,23 @@
         "vscode-languageserver-types": "3.17.5"
       }
     },
-    "node_modules/vscode-languageserver-types": {
+    "node_modules/vscode-languageclient/node_modules/vscode-languageserver-types": {
       "version": "3.17.5",
       "integrity": "sha1-MnNnbwzy6rQLP0TQhay7fwijnYo=",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.0",
+      "integrity": "sha1-/EFcONZ6QPWKCBgvWXLahJfFj3s=",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "integrity": "sha1-EyMhIpYEg2urcQyXSH5s2vub17s=",
       "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
@@ -6663,8 +6679,8 @@
     "node_modules/which": {
       "version": "2.0.2",
       "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -62,21 +62,21 @@
   "dependencies": {
     "@microsoft/applicationinsights-common": "^3.4.1",
     "@vscode/extension-telemetry": "^1.5.2",
-    "semver": "^7.8.0",
+    "semver": "^7.8.4",
     "untildify": "^4.0.0",
     "uuid": "^14.0.0",
     "vscode-languageclient": "^9.0.1",
-    "vscode-languageserver-protocol": "^3.17.5"
+    "vscode-languageserver-protocol": "^3.18.0"
   },
   "devDependencies": {
-    "@vscode/vsce": "^3.9.1",
-    "esbuild": "^0.28.0"
+    "@vscode/vsce": "^3.9.2",
+    "esbuild": "^0.28.1"
   },
   "optionalDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/mocha": "^10.0.10",
     "@types/mock-fs": "^4.13.4",
-    "@types/node": "^22.19.19",
+    "@types/node": "^22.19.21",
     "@types/semver": "^7.7.1",
     "@types/sinon": "^21.0.1",
     "@types/ungap__structured-clone": "^1.2.0",
@@ -86,18 +86,25 @@
     "@vscode/test-cli": "^0.0.12",
     "@vscode/test-electron": "^2.5.2",
     "esbuild-register": "^3.6.0",
-    "eslint": "^10.3.0",
+    "eslint": "^10.5.0",
     "eslint-config-prettier": "^10.1.8",
     "mock-fs": "^5.5.0",
-    "prettier": "^3.8.3",
+    "prettier": "^3.8.4",
     "prettier-plugin-organize-imports": "^4.3.0",
     "sinon": "^22.0.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.3"
+    "typescript-eslint": "^8.61.1"
   },
   "overrides": {
-    "serialize-javascript": "^7.0.5",
-    "diff": "^8.0.3"
+    "@nevware21/ts-utils": "^0.15.0",
+    "diff": "^8.0.3",
+    "form-data": "^4.0.6",
+    "js-yaml": "^4.2.0",
+    "markdown-it": "^14.2.0",
+    "qs": "^6.15.2",
+    "serialize-javascript": "^7.0.6",
+    "tmp": "^0.2.7",
+    "undici": "^7.28.0"
   },
   "extensionDependencies": [
     "vscode.powershell"


### PR DESCRIPTION
## PR Summary

Routine dependency refresh to stay current and clear `npm audit` (was 8 vulnerabilities, now 0). All updates stay within each package's existing semver range, so this is a "safe" bump with no major-version jumps.

Direct bumps: `semver`, `vscode-languageserver-protocol`, `@vscode/vsce`, `esbuild` (also clears a dev-server advisory), `@types/node` (stays on the Node 22 major), `prettier`, and the ESLint group (`eslint` + `typescript-eslint`) bumped together with no new lint warnings.

The eight audited vulnerabilities are all transitive (mostly under `@vscode/vsce`). Per our convention I fixed them with `overrides` rather than `npm audit fix --force`, so our own packages don't get downgraded: added `@nevware21/ts-utils`, `form-data`, `js-yaml`, `markdown-it`, `qs`, `tmp`, and `undici`, and bumped the existing `serialize-javascript` override. The `undici` pin is `^7.28.0`, the minimum fix that still satisfies `cheerio`'s `^7.19.0` range.

I verified the two pre-existing overrides are still needed by removing them and re-auditing: dropping them lets `mocha` pull a vulnerable `diff` (jsdiff DoS) and `serialize-javascript` (RCE), so both stay.

Held back deliberately as not simple/safe bumps: `vscode-languageclient` 9 -> 10 (coupled to PSES), `@vscode/test-electron` 2 -> 3 (test harness; integration tests can't run in this environment), `untildify` 4 -> 6 (ESM-only), and the `@types/vscode` / `engines.vscode` pair (bumping the VS Code engine is its own change per `docs/development.md`).

`npm run compile`, `npm run lint`, `npm run format`, and `npm audit` all pass.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests `NA` (dependency-only update; existing test suite covers behavior)
- [x] This PR is ready to merge and is not work in progress