### PR TITLE
v2026.1.2-preview: Add language model tools, redesign the Command Explorer, and render Show Help in an editor pane.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # PowerShell Extension Release History
 
+## v2026.1.2-preview
+### Thursday, June 25, 2026
+
+With PowerShell Editor Services [v4.7.0](https://github.com/PowerShell/PowerShellEditorServices/releases/tag/v4.7.0)!
+
+Add language model tools, redesign the Command Explorer, and render Show Help in an editor pane.
+
+See more details at the GitHub Release for [v2026.1.2-preview](https://github.com/PowerShell/vscode-powershell/releases/tag/v2026.1.2-preview).
+
 ## v2026.1.1-preview
 ### Friday, May 15, 2026
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "powershell",
   "displayName": "PowerShell",
-  "version": "2026.1.1",
+  "version": "2026.1.2",
   "preview": false,
   "publisher": "ms-vscode",
   "description": "Develop PowerShell modules, commands and scripts in Visual Studio Code!",


### PR DESCRIPTION
Release PR bumping the PowerShell extension to `v2026.1.2-preview`, with PowerShell Editor Services [v4.7.0](https://github.com/PowerShell/PowerShellEditorServices/releases/tag/v4.7.0). See `CHANGELOG.md` for details.

Depends on PowerShell/PowerShellEditorServices#2329 (PSES v4.7.0).