### PR TITLE
Feature/expose parameters outline #5153

### DIFF
--- a/package.json
+++ b/package.json
@@ -546,20 +546,6 @@
             }
           },
           {
-            "label": "PowerShell: Launch Current File w/Args Prompt",
-            "description": "Launch and debug the current file, prompting for command-line arguments",
-            "body": {
-              "name": "PowerShell Launch Current File w/Args Prompt",
-              "type": "PowerShell",
-              "request": "launch",
-              "script": "^\"\\${file}\"",
-              "args": [
-                "\\${command:SpecifyScriptArgs}"
-              ],
-              "cwd": "^\"\\${cwd}\""
-            }
-          },
-          {
             "label": "PowerShell: Launch Script",
             "description": "Launch and debug the specified file or command",
             "body": {
@@ -1052,6 +1038,11 @@
             "type": "boolean",
             "default": false,
             "markdownDescription": "Specifies to search for references only within open documents instead of all workspace files. An alternative to `#powershell.enableReferencesCodeLens#` that allows large workspaces to support some references without the performance impact."
+          },
+          "powershell.enableParameterOutline": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Specifies whether parameters are displayed in the Outline view."
           },
           "powershell.debugging.createTemporaryIntegratedConsole": {
             "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -546,6 +546,20 @@
             }
           },
           {
+            "label": "PowerShell: Launch Current File w/Args Prompt",
+            "description": "Launch and debug the current file, prompting for command-line arguments",
+            "body": {
+              "name": "PowerShell Launch Current File w/Args Prompt",
+              "type": "PowerShell",
+              "request": "launch",
+              "script": "^\"\\${file}\"",
+              "args": [
+                "\\${command:SpecifyScriptArgs}"
+              ],
+              "cwd": "^\"\\${cwd}\""
+            }
+          },
+          {
             "label": "PowerShell: Launch Script",
             "description": "Launch and debug the specified file or command",
             "body": {

--- a/src/features/DebugSession.ts
+++ b/src/features/DebugSession.ts
@@ -48,6 +48,7 @@ export const StopDebuggerNotificationType = new NotificationType<void>(
 
 export enum DebugConfig {
     LaunchCurrentFile,
+    LaunchCurrentFileWithArgsPrompt,
     LaunchScript,
     InteractiveSession,
     AttachHostProcess,
@@ -78,6 +79,13 @@ export const DebugConfigurations: Record<DebugConfig, DebugConfiguration> = {
         request: "launch",
         script: "${file}",
         args: [],
+    },
+    [DebugConfig.LaunchCurrentFileWithArgsPrompt]: {
+        name: "PowerShell: Launch Current File w/Args Prompt",
+        type: "PowerShell",
+        request: "launch",
+        script: "${file}",
+        args: ["${command:SpecifyScriptArgs}"],
     },
     [DebugConfig.LaunchScript]: {
         name: "PowerShell: Launch Script",
@@ -240,6 +248,12 @@ export class DebugSessionFeature
                 label: "Launch Current File",
                 description:
                     "Launch and debug the file in the currently active editor window",
+            },
+            {
+                id: DebugConfig.LaunchCurrentFileWithArgsPrompt,
+                label: "Launch Current File w/Args Prompt",
+                description:
+                    "Launch and debug the current file, prompting for command-line arguments",
             },
             {
                 id: DebugConfig.LaunchScript,


### PR DESCRIPTION
## PR Summary
Adds the `powershell.enableParameterOutline` setting to allow users to opt in to displaying PowerShell parameters in the Outline view.

The setting defaults to `false` to preserve the existing behavior.

The corresponding language-server implementation and regression tests are being added in the PowerShellEditorServices repository.

Fixes #5153

Related PowerShellEditorServices PR: #2340


## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets.
Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] PR has tests
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
